### PR TITLE
ci: Add ci for creating image on merge

### DIFF
--- a/.github/workflows/pr-merge-to-image.yml
+++ b/.github/workflows/pr-merge-to-image.yml
@@ -1,0 +1,33 @@
+name: Build & Publish Docker Image
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/tdw-control-plane:latest
+            ghcr.io/${{ github.repository_owner }}/tdw-control-plane:${{ github.sha }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated workflow to build and publish Docker images when changes are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->