### PR TITLE
fix: Update CLICKHOUSE_HOST

### DIFF
--- a/tdw_control_plane/utils/get_clickhouse_client.py
+++ b/tdw_control_plane/utils/get_clickhouse_client.py
@@ -5,7 +5,7 @@ def get_clickhouse_client():
 
     '''Returns a ClickHouse client.'''
 
-    CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', 'localhost')
+    CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', 'clickhouse')
     CLICKHOUSE_PORT = int(os.environ.get('CLICKHOUSE_PORT', 8123))
     CLICKHOUSE_USER = os.environ.get('CLICKHOUSE_USER', 'default')
     CLICKHOUSE_PASSWORD = os.environ.get('CLICKHOUSE_PASSWORD', 'password123')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default server address for ClickHouse connections to use 'clickhouse' instead of 'localhost'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->