### PR TITLE
feat: deploy image on merge

### DIFF
--- a/.github/workflows/deploy-image-to-registry.yml
+++ b/.github/workflows/deploy-image-to-registry.yml
@@ -1,0 +1,49 @@
+name: Deploy Image to Registry
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Convert repository name to lowercase
+        id: repo_name
+        run: |
+          echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TDW_PRIVATE_KEY }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO_LC }}:latest
+            ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
+          ssh: |
+            trades-warehouse=${{ env.SSH_AUTH_SOCK }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pytest.ini
 
 storage
 logs
+.env
+loop


### PR DESCRIPTION
## Summary

-  Adds a new GitHub Actions workflow deploy-image-to-registry.yml to automatically build and push Docker images to GitHub Container Registry (ghcr.io) upon pushes to main or master branches.
-  Configures the workflow to properly handle SSH-based git clone operations within the Docker build process, leveraging the TDW_PRIVATE_KEY secret.
- Ensures no pruning or deletion of Docker images/containers occurs, safeguarding critical data.