### PR TITLE
[codex] add binance daily overlay pipeline

### DIFF
--- a/tdw_control_plane/assets/cleanup_binance_daily_trades.py
+++ b/tdw_control_plane/assets/cleanup_binance_daily_trades.py
@@ -10,8 +10,17 @@ from tdw_control_plane.assets.monthly_trades_to_tdw import (
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+def _get_clickhouse_password():
+    if not CLICKHOUSE_PASSWORD:
+        raise RuntimeError(
+            "CLICKHOUSE_PASSWORD environment variable must be set before creating the ClickHouse client."
+        )
+
+    return CLICKHOUSE_PASSWORD
 
 
 @asset(
@@ -32,7 +41,7 @@ def cleanup_binance_daily_trades_for_finalized_month(context: AssetExecutionCont
             host=CLICKHOUSE_HOST,
             port=CLICKHOUSE_PORT,
             user=CLICKHOUSE_USER,
-            password=CLICKHOUSE_PASSWORD,
+            password=_get_clickhouse_password(),
             database=CLICKHOUSE_DATABASE,
             compression=True,
             send_receive_timeout=900,
@@ -93,8 +102,8 @@ def cleanup_binance_daily_trades_for_finalized_month(context: AssetExecutionCont
             "status": "cleanup_queued",
         }
 
-    except Exception as e:
-        raise e
+    except Exception:
+        raise
     finally:
         if client:
             try:

--- a/tdw_control_plane/assets/cleanup_binance_daily_trades.py
+++ b/tdw_control_plane/assets/cleanup_binance_daily_trades.py
@@ -1,0 +1,103 @@
+import os
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import asset, AssetExecutionContext
+
+from tdw_control_plane.assets.monthly_trades_to_tdw import (
+    insert_monthly_binance_trades_to_tdw,
+    monthly_partitions,
+)
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+@asset(
+    partitions_def=monthly_partitions,
+    deps=[insert_monthly_binance_trades_to_tdw],
+    group_name="binance_data",
+    description="Deletes finalized months from tdw.binance_daily_trades once the monthly archive has landed in tdw.binance_trades",
+)
+def cleanup_binance_daily_trades_for_finalized_month(context: AssetExecutionContext):
+    partition_date_str = context.asset_partition_key_for_output()
+    date_parts = partition_date_str.split("-")
+    year, month = date_parts[0], date_parts[1]
+    month_start = f"{year}-{month}-01"
+
+    client = None
+    try:
+        client = ClickhouseClient(
+            host=CLICKHOUSE_HOST,
+            port=CLICKHOUSE_PORT,
+            user=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+            database=CLICKHOUSE_DATABASE,
+            compression=True,
+            send_receive_timeout=900,
+        )
+
+        monthly_count = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.binance_trades
+            WHERE datetime >= toDate('{month_start}')
+              AND datetime < addMonths(toDate('{month_start}'), 1)
+        """
+        )[0][0]
+
+        if monthly_count == 0:
+            context.log.info(
+                f"No finalized monthly data found for {month_start}. Skipping daily cleanup."
+            )
+            return {
+                "month_start": month_start,
+                "rows_deleted": 0,
+                "status": "skipped",
+            }
+
+        daily_count = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.binance_daily_trades
+            WHERE datetime >= toDate('{month_start}')
+              AND datetime < addMonths(toDate('{month_start}'), 1)
+        """
+        )[0][0]
+
+        if daily_count == 0:
+            context.log.info(
+                f"No overlay rows found for {month_start}. Nothing to delete from binance_daily_trades."
+            )
+            return {
+                "month_start": month_start,
+                "rows_deleted": 0,
+                "status": "no_overlay_rows",
+            }
+
+        client.execute(
+            f"""
+            ALTER TABLE {CLICKHOUSE_DATABASE}.binance_daily_trades
+            DELETE WHERE datetime >= toDate('{month_start}')
+              AND datetime < addMonths(toDate('{month_start}'), 1)
+        """
+        )
+        context.log.info(
+            f"Queued deletion of {daily_count} overlay rows for finalized month {month_start}."
+        )
+
+        return {
+            "month_start": month_start,
+            "rows_deleted": daily_count,
+            "status": "cleanup_queued",
+        }
+
+    except Exception as e:
+        raise e
+    finally:
+        if client:
+            try:
+                client.disconnect()
+            except Exception:
+                pass

--- a/tdw_control_plane/assets/create_binance_daily_trades_table.py
+++ b/tdw_control_plane/assets/create_binance_daily_trades_table.py
@@ -5,8 +5,17 @@ from dagster import asset, AssetExecutionContext
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+def _get_clickhouse_password():
+    if not CLICKHOUSE_PASSWORD:
+        raise RuntimeError(
+            "CLICKHOUSE_PASSWORD environment variable must be set before creating the ClickHouse client."
+        )
+
+    return CLICKHOUSE_PASSWORD
 
 
 @asset(
@@ -23,7 +32,7 @@ def create_binance_daily_trades_table(context: AssetExecutionContext):
             host=CLICKHOUSE_HOST,
             port=CLICKHOUSE_PORT,
             user=CLICKHOUSE_USER,
-            password=CLICKHOUSE_PASSWORD,
+            password=_get_clickhouse_password(),
             database=CLICKHOUSE_DATABASE,
         )
 

--- a/tdw_control_plane/assets/create_binance_daily_trades_table.py
+++ b/tdw_control_plane/assets/create_binance_daily_trades_table.py
@@ -1,0 +1,105 @@
+import os
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import asset, AssetExecutionContext
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+@asset(
+    group_name="tdw_setup",
+    description="Creates the binance_daily_trades table for rolling daily Binance trade data",
+)
+def create_binance_daily_trades_table(context: AssetExecutionContext):
+    """
+    Creates a ClickHouse table for daily Binance trade overlays on top of the monthly table.
+    """
+    client = None
+    try:
+        client = ClickhouseClient(
+            host=CLICKHOUSE_HOST,
+            port=CLICKHOUSE_PORT,
+            user=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+            database=CLICKHOUSE_DATABASE,
+        )
+
+        db_exists = client.execute(
+            f"SELECT count() FROM system.databases WHERE name = '{CLICKHOUSE_DATABASE}'"
+        )
+        if not db_exists[0][0]:
+            context.log.error(
+                f"Database {CLICKHOUSE_DATABASE} does not exist. Please create it first."
+            )
+            return {
+                "status": "error",
+                "message": f"Database {CLICKHOUSE_DATABASE} does not exist",
+            }
+
+        table_exists = client.execute(
+            f"SELECT count() FROM system.tables WHERE database = '{CLICKHOUSE_DATABASE}' "
+            "AND name = 'binance_daily_trades'"
+        )
+        was_dropped = False
+
+        if table_exists[0][0]:
+            context.log.info(
+                f"Table {CLICKHOUSE_DATABASE}.binance_daily_trades already exists. Dropping it..."
+            )
+            client.execute(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.binance_daily_trades")
+            context.log.info(
+                f"Table {CLICKHOUSE_DATABASE}.binance_daily_trades has been dropped."
+            )
+            was_dropped = True
+
+        context.log.info(f"Creating table {CLICKHOUSE_DATABASE}.binance_daily_trades...")
+        client.execute(
+            f"""
+            CREATE TABLE {CLICKHOUSE_DATABASE}.binance_daily_trades (
+                trade_id        UInt64  CODEC(Delta(8), ZSTD(3)),
+                price           Float64 CODEC(Delta, ZSTD(3)),
+                quantity        Float64 CODEC(ZSTD(3)),
+                quote_quantity  Float64 CODEC(ZSTD(3)),
+                timestamp       UInt64  CODEC(Delta, ZSTD(3)),
+                is_buyer_maker  UInt8   CODEC(ZSTD(1)),
+                is_best_match   UInt8   CODEC(ZSTD(1)),
+                datetime        DateTime CODEC(Delta, ZSTD(3))
+            )
+            ENGINE = MergeTree()
+            PARTITION BY toYYYYMM(datetime)
+            ORDER BY (toStartOfDay(datetime), trade_id)
+            SAMPLE BY trade_id
+            SETTINGS
+                index_granularity = 8192,
+                enable_mixed_granularity_parts = 1,
+                min_rows_for_wide_part = 1000000,
+                min_bytes_for_wide_part = 10000000,
+                min_rows_for_compact_part = 10000,
+                write_final_mark = 0,
+                optimize_on_insert = 1,
+                max_partitions_per_insert_block = 1000
+        """
+        )
+        context.log.info(
+            f"Table {CLICKHOUSE_DATABASE}.binance_daily_trades has been created successfully."
+        )
+
+        return {
+            "status": "success",
+            "table": f"{CLICKHOUSE_DATABASE}.binance_daily_trades",
+            "action": "recreated" if was_dropped else "created",
+        }
+
+    except Exception as e:
+        context.log.error(f"Error creating binance_daily_trades table: {str(e)}")
+        return {"status": "error", "message": str(e)}
+
+    finally:
+        if client:
+            try:
+                client.disconnect()
+            except Exception as e:
+                context.log.warning(f"Error disconnecting from ClickHouse: {str(e)}")

--- a/tdw_control_plane/assets/create_binance_trades_complete_view.py
+++ b/tdw_control_plane/assets/create_binance_trades_complete_view.py
@@ -5,8 +5,17 @@ from dagster import asset, AssetExecutionContext
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+def _get_clickhouse_password():
+    if not CLICKHOUSE_PASSWORD:
+        raise RuntimeError(
+            "CLICKHOUSE_PASSWORD environment variable must be set before creating the ClickHouse client."
+        )
+
+    return CLICKHOUSE_PASSWORD
 
 
 @asset(
@@ -23,7 +32,7 @@ def create_binance_trades_complete_view(context: AssetExecutionContext):
             host=CLICKHOUSE_HOST,
             port=CLICKHOUSE_PORT,
             user=CLICKHOUSE_USER,
-            password=CLICKHOUSE_PASSWORD,
+            password=_get_clickhouse_password(),
             database=CLICKHOUSE_DATABASE,
         )
 

--- a/tdw_control_plane/assets/create_binance_trades_complete_view.py
+++ b/tdw_control_plane/assets/create_binance_trades_complete_view.py
@@ -2,6 +2,13 @@ import os
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import asset, AssetExecutionContext
 
+from tdw_control_plane.assets.create_binance_daily_trades_table import (
+    create_binance_daily_trades_table,
+)
+from tdw_control_plane.assets.create_binance_trades_table import (
+    create_binance_trades_table,
+)
+
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
@@ -20,6 +27,7 @@ def _get_clickhouse_password():
 
 @asset(
     group_name="tdw_setup",
+    deps=[create_binance_daily_trades_table, create_binance_trades_table],
     description="Creates a view that combines final monthly Binance trades with open-period daily trades",
 )
 def create_binance_trades_complete_view(context: AssetExecutionContext):
@@ -96,7 +104,7 @@ def create_binance_trades_complete_view(context: AssetExecutionContext):
                     SELECT toStartOfMonth(max(datetime))
                     FROM {CLICKHOUSE_DATABASE}.binance_trades
                 ),
-                toDateTime('1969-12-01 00:00:00')
+                toDateTime('1970-01-01 00:00:00')
             )
         """
         )

--- a/tdw_control_plane/assets/create_binance_trades_complete_view.py
+++ b/tdw_control_plane/assets/create_binance_trades_complete_view.py
@@ -1,0 +1,113 @@
+import os
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import asset, AssetExecutionContext
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+
+
+@asset(
+    group_name="tdw_setup",
+    description="Creates a view that combines final monthly Binance trades with open-period daily trades",
+)
+def create_binance_trades_complete_view(context: AssetExecutionContext):
+    """
+    Creates a plain ClickHouse view over monthly final data and the still-open daily overlay.
+    """
+    client = None
+    try:
+        client = ClickhouseClient(
+            host=CLICKHOUSE_HOST,
+            port=CLICKHOUSE_PORT,
+            user=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+            database=CLICKHOUSE_DATABASE,
+        )
+
+        db_exists = client.execute(
+            f"SELECT count() FROM system.databases WHERE name = '{CLICKHOUSE_DATABASE}'"
+        )
+        if not db_exists[0][0]:
+            context.log.error(
+                f"Database {CLICKHOUSE_DATABASE} does not exist. Please create it first."
+            )
+            return {
+                "status": "error",
+                "message": f"Database {CLICKHOUSE_DATABASE} does not exist",
+            }
+
+        view_exists = client.execute(
+            f"SELECT count() FROM system.tables WHERE database = '{CLICKHOUSE_DATABASE}' "
+            "AND name = 'binance_trades_complete'"
+        )
+        was_dropped = False
+
+        if view_exists[0][0]:
+            context.log.info(
+                f"View {CLICKHOUSE_DATABASE}.binance_trades_complete already exists. Dropping it..."
+            )
+            client.execute(f"DROP VIEW IF EXISTS {CLICKHOUSE_DATABASE}.binance_trades_complete")
+            context.log.info(
+                f"View {CLICKHOUSE_DATABASE}.binance_trades_complete has been dropped."
+            )
+            was_dropped = True
+
+        context.log.info(f"Creating view {CLICKHOUSE_DATABASE}.binance_trades_complete...")
+        client.execute(
+            f"""
+            CREATE VIEW {CLICKHOUSE_DATABASE}.binance_trades_complete AS
+            SELECT
+                trade_id,
+                price,
+                quantity,
+                quote_quantity,
+                timestamp,
+                is_buyer_maker,
+                is_best_match,
+                datetime
+            FROM {CLICKHOUSE_DATABASE}.binance_trades
+
+            UNION ALL
+
+            SELECT
+                daily.trade_id,
+                daily.price,
+                daily.quantity,
+                daily.quote_quantity,
+                daily.timestamp,
+                daily.is_buyer_maker,
+                daily.is_best_match,
+                daily.datetime
+            FROM {CLICKHOUSE_DATABASE}.binance_daily_trades AS daily
+            WHERE toStartOfMonth(daily.datetime) > ifNull(
+                (
+                    SELECT toStartOfMonth(max(datetime))
+                    FROM {CLICKHOUSE_DATABASE}.binance_trades
+                ),
+                toDateTime('1969-12-01 00:00:00')
+            )
+        """
+        )
+        context.log.info(
+            f"View {CLICKHOUSE_DATABASE}.binance_trades_complete has been created successfully."
+        )
+
+        return {
+            "status": "success",
+            "view": f"{CLICKHOUSE_DATABASE}.binance_trades_complete",
+            "action": "recreated" if was_dropped else "created",
+        }
+
+    except Exception as e:
+        context.log.error(f"Error creating binance_trades_complete view: {str(e)}")
+        return {"status": "error", "message": str(e)}
+
+    finally:
+        if client:
+            try:
+                client.disconnect()
+            except Exception as e:
+                context.log.warning(f"Error disconnecting from ClickHouse: {str(e)}")

--- a/tdw_control_plane/assets/daily_trades_to_tdw.py
+++ b/tdw_control_plane/assets/daily_trades_to_tdw.py
@@ -1,21 +1,172 @@
-import os
 import csv
-import requests
-import zipfile
 import hashlib
+import os
+import tempfile
+import zipfile
 from datetime import datetime, timedelta
-from io import BytesIO
+from io import TextIOWrapper
+
+import requests
 from clickhouse_driver import Client as ClickhouseClient
-from dagster import asset, DailyPartitionsDefinition
+from dagster import DailyPartitionsDefinition, asset
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 CLICKHOUSE_TABLE = os.environ.get("CLICKHOUSE_TABLE", "binance_daily_trades")
 
+DOWNLOAD_TIMEOUT = (30, 300)
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+INSERT_BATCH_SIZE = 100_000
+
 daily_partitions = DailyPartitionsDefinition(start_date="2017-08-17")
+
+
+def _get_clickhouse_password():
+    if not CLICKHOUSE_PASSWORD:
+        raise RuntimeError(
+            "CLICKHOUSE_PASSWORD environment variable must be set before creating the ClickHouse client."
+        )
+
+    return CLICKHOUSE_PASSWORD
+
+
+def _build_requests_session() -> requests.Session:
+    session = requests.Session()
+    retries = Retry(
+        total=3,
+        connect=3,
+        read=3,
+        backoff_factor=1,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset(["GET", "HEAD"]),
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _download_to_tempfile(session: requests.Session, url: str) -> tuple[str, int, str]:
+    downloaded_bytes = 0
+    zip_checksum = hashlib.sha256()
+    tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+
+    try:
+        with session.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                if not chunk:
+                    continue
+
+                downloaded_bytes += len(chunk)
+                zip_checksum.update(chunk)
+                tmp_file.write(chunk)
+    except Exception:
+        tmp_file.close()
+        os.unlink(tmp_file.name)
+        raise
+
+    tmp_file.close()
+    return tmp_file.name, downloaded_bytes, zip_checksum.hexdigest()
+
+
+def _compute_csv_checksum(zip_path: str, csv_filename: str) -> str:
+    csv_checksum = hashlib.sha256()
+
+    with zipfile.ZipFile(zip_path) as zip_ref:
+        with zip_ref.open(csv_filename) as csv_file:
+            while chunk := csv_file.read(DOWNLOAD_CHUNK_SIZE):
+                csv_checksum.update(chunk)
+
+    return csv_checksum.hexdigest()
+
+
+def _normalize_datetime_seconds(timestamp: int) -> int:
+    timestamp_len = len(str(timestamp))
+    if timestamp_len == 13:
+        return timestamp // 1_000
+    if timestamp_len == 16:
+        return timestamp // 1_000_000
+
+    raise ValueError(f"Invalid timestamp length: {timestamp}")
+
+
+def _insert_batch(client: ClickhouseClient, batch: list[tuple]):
+    client.execute(
+        f"""
+        INSERT INTO {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+        (
+            trade_id,
+            price,
+            quantity,
+            quote_quantity,
+            timestamp,
+            is_buyer_maker,
+            is_best_match,
+            datetime
+        ) SETTINGS async_insert=1, wait_for_async_insert=1
+        VALUES
+        """,
+        batch,
+        settings={"max_execution_time": 900},
+    )
+
+
+def _insert_csv_batches(
+    context,
+    client: ClickhouseClient,
+    zip_path: str,
+    csv_filename: str,
+) -> int:
+    row_count = 0
+    batch = []
+
+    with zipfile.ZipFile(zip_path) as zip_ref:
+        with zip_ref.open(csv_filename) as csv_file:
+            reader = csv.reader(TextIOWrapper(csv_file, encoding="utf-8", newline=""))
+
+            for row in reader:
+                row_count += 1
+
+                trade_id = int(row[0])
+                price = float(row[1])
+                quantity = float(row[2])
+                quote_quantity = float(row[3])
+                timestamp = int(row[4])
+                is_buyer_maker = row[5].lower() == "true"
+                is_best_match = row[6].lower() == "true"
+                datetime_seconds = _normalize_datetime_seconds(timestamp)
+
+                batch.append(
+                    (
+                        trade_id,
+                        price,
+                        quantity,
+                        quote_quantity,
+                        timestamp,
+                        is_buyer_maker,
+                        is_best_match,
+                        datetime_seconds,
+                    )
+                )
+
+                if len(batch) >= INSERT_BATCH_SIZE:
+                    _insert_batch(client, batch)
+                    context.log.info(
+                        f"Inserted batch of {len(batch)} rows for {CLICKHOUSE_TABLE}."
+                    )
+                    batch = []
+
+    if batch:
+        _insert_batch(client, batch)
+        context.log.info(f"Inserted final batch of {len(batch)} rows for {CLICKHOUSE_TABLE}.")
+
+    return row_count
 
 
 @asset(
@@ -45,87 +196,37 @@ def _process_day(context, day_str, date_str):
     file_url = base_url + day_str
     checksum_url = file_url + ".CHECKSUM"
 
-    context.log.info(f"Downloading checksum from {checksum_url}")
-    checksum_response = requests.get(checksum_url)
-    checksum_response.raise_for_status()
-
-    expected_checksum = checksum_response.text.split()[0].strip()
-    context.log.info(f"Expected checksum: {expected_checksum}")
-
-    context.log.info(f"Downloading trade data from {file_url}")
-    response = requests.get(file_url)
-    response.raise_for_status()
-    zip_data = response.content
-    context.log.info(f"Downloaded {len(zip_data) / 1024 / 1024:.2f} MB of data")
-
-    actual_checksum = hashlib.sha256(zip_data).hexdigest()
-    context.log.info(f"Actual checksum: {actual_checksum}")
-    if actual_checksum != expected_checksum:
-        context.log.error(
-            f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
-        )
-        raise ValueError(
-            f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
-        )
-
-    csv_content = None
-
-    context.log.info("Extracting CSV from zip file")
-    with zipfile.ZipFile(BytesIO(zip_data)) as zip_ref:
-        csv_filename = zip_ref.namelist()[0]
-        context.log.info(f"Found CSV file: {csv_filename}")
-
-        with zip_ref.open(csv_filename) as csv_file:
-            csv_content = csv_file.read()
-
-    csv_checksum = hashlib.sha256(csv_content).hexdigest()
-    context.log.info(f"CSV checksum: {csv_checksum}")
-
-    context.log.info("Parsing CSV data")
-    data = []
-
-    csv_text = csv_content.decode("utf-8")
-    reader = csv.reader(csv_text.splitlines())
-
-    row_count = 0
-    for row in reader:
-        row_count += 1
-        trade_id = int(row[0])
-        price = float(row[1])
-        quantity = float(row[2])
-        quote_quantity = float(row[3])
-        timestamp = int(row[4])
-        is_buyer_maker = row[5].lower() == "true"
-        is_best_match = row[6].lower() == "true"
-
-        if len(str(timestamp)) == 13:
-            dt = datetime.fromtimestamp(timestamp / 1000.0)
-        elif len(str(timestamp)) == 16:
-            dt = datetime.fromtimestamp(timestamp / 1000000.0)
-        else:
-            raise ValueError(f"Invalid timestamp length: {timestamp}")
-
-        data.append(
-            (
-                trade_id,
-                price,
-                quantity,
-                quote_quantity,
-                timestamp,
-                is_buyer_maker,
-                is_best_match,
-                dt,
-            )
-        )
-
-    context.log.info(f"Parsed {row_count} rows from CSV")
-
-    csv_text = None
-    csv_content = None
-    zip_data = None
-
+    session = _build_requests_session()
+    zip_path = None
     client = None
+
     try:
+        context.log.info(f"Downloading checksum from {checksum_url}")
+        checksum_response = session.get(checksum_url, timeout=DOWNLOAD_TIMEOUT)
+        checksum_response.raise_for_status()
+        expected_checksum = checksum_response.text.split()[0].strip()
+        context.log.info(f"Expected checksum: {expected_checksum}")
+
+        context.log.info(f"Downloading trade data from {file_url}")
+        zip_path, downloaded_bytes, actual_checksum = _download_to_tempfile(session, file_url)
+        context.log.info(f"Downloaded {downloaded_bytes / 1024 / 1024:.2f} MB of data")
+        context.log.info(f"Actual checksum: {actual_checksum}")
+
+        if actual_checksum != expected_checksum:
+            context.log.error(
+                f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
+            )
+            raise ValueError(
+                f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
+            )
+
+        with zipfile.ZipFile(zip_path) as zip_ref:
+            csv_filename = zip_ref.namelist()[0]
+            context.log.info(f"Found CSV file: {csv_filename}")
+
+        csv_checksum = _compute_csv_checksum(zip_path, csv_filename)
+        context.log.info(f"CSV checksum: {csv_checksum}")
+
         context.log.info(
             f"Connecting to ClickHouse at {CLICKHOUSE_HOST}:{CLICKHOUSE_PORT}"
         )
@@ -133,7 +234,7 @@ def _process_day(context, day_str, date_str):
             host=CLICKHOUSE_HOST,
             port=CLICKHOUSE_PORT,
             user=CLICKHOUSE_USER,
-            password=CLICKHOUSE_PASSWORD,
+            password=_get_clickhouse_password(),
             database=CLICKHOUSE_DATABASE,
             compression=True,
             send_receive_timeout=900,
@@ -161,26 +262,9 @@ def _process_day(context, day_str, date_str):
             )
             context.log.info(f"Deleted existing data for {date_str}")
 
-        context.log.info(f"Inserting {len(data)} rows into ClickHouse")
-        client.execute(
-            f"""
-            INSERT INTO {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
-            (
-                trade_id,
-                price,
-                quantity,
-                quote_quantity,
-                timestamp,
-                is_buyer_maker,
-                is_best_match,
-                datetime
-            ) SETTINGS async_insert=1, wait_for_async_insert=1
-            VALUES
-            """,
-            data,
-            settings={"max_execution_time": 900},
-        )
-        context.log.info("Data insertion completed")
+        context.log.info("Parsing CSV data and inserting batches into ClickHouse")
+        row_count = _insert_csv_batches(context, client, zip_path, csv_filename)
+        context.log.info(f"Parsed and inserted {row_count} rows from CSV")
 
         context.log.info("Verifying data insertion")
         result = client.execute(
@@ -214,12 +298,12 @@ def _process_day(context, day_str, date_str):
         }
         context.log.info(f"Data verification stats: {data_verification}")
 
-        if inserted_count != len(data):
+        if inserted_count != row_count:
             context.log.error(
-                f"Row count mismatch! Expected: {len(data)}, Actual: {inserted_count}"
+                f"Row count mismatch! Expected: {row_count}, Actual: {inserted_count}"
             )
             raise ValueError(
-                f"Row count mismatch! Expected: {len(data)}, Actual: {inserted_count}"
+                f"Row count mismatch! Expected: {row_count}, Actual: {inserted_count}"
             )
 
         result_data = {
@@ -233,12 +317,14 @@ def _process_day(context, day_str, date_str):
         context.log.info(f"Successfully processed {day_str}")
         return result_data
 
-    except Exception as e:
-        raise e
+    except Exception:
+        raise
     finally:
+        session.close()
         if client:
             try:
                 client.disconnect()
             except Exception:
                 pass
-        data = None
+        if zip_path and os.path.exists(zip_path):
+            os.unlink(zip_path)

--- a/tdw_control_plane/assets/daily_trades_to_tdw.py
+++ b/tdw_control_plane/assets/daily_trades_to_tdw.py
@@ -1,0 +1,244 @@
+import os
+import csv
+import requests
+import zipfile
+import hashlib
+from datetime import datetime, timedelta
+from io import BytesIO
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import asset, DailyPartitionsDefinition
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+CLICKHOUSE_TABLE = os.environ.get("CLICKHOUSE_TABLE", "binance_daily_trades")
+
+daily_partitions = DailyPartitionsDefinition(start_date="2017-08-17")
+
+
+@asset(
+    partitions_def=daily_partitions,
+    group_name="binance_data",
+    description="Downloads, validates, extracts, and loads daily Binance BTC trade data into TDW",
+)
+def insert_daily_binance_trades_to_tdw(context):
+    partition_date_str = context.asset_partition_key_for_output()
+
+    if partition_date_str is None:
+        target_date = datetime.now() - timedelta(days=1)
+        date_str = target_date.strftime("%Y-%m-%d")
+    else:
+        date_str = partition_date_str
+
+    day_str = f"BTCUSDT-trades-{date_str}.zip"
+    context.log.info(
+        f"Processing selected partition: {partition_date_str}, file: {day_str}"
+    )
+
+    return _process_day(context, day_str, date_str)
+
+
+def _process_day(context, day_str, date_str):
+    base_url = "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
+    file_url = base_url + day_str
+    checksum_url = file_url + ".CHECKSUM"
+
+    context.log.info(f"Downloading checksum from {checksum_url}")
+    checksum_response = requests.get(checksum_url)
+    checksum_response.raise_for_status()
+
+    expected_checksum = checksum_response.text.split()[0].strip()
+    context.log.info(f"Expected checksum: {expected_checksum}")
+
+    context.log.info(f"Downloading trade data from {file_url}")
+    response = requests.get(file_url)
+    response.raise_for_status()
+    zip_data = response.content
+    context.log.info(f"Downloaded {len(zip_data) / 1024 / 1024:.2f} MB of data")
+
+    actual_checksum = hashlib.sha256(zip_data).hexdigest()
+    context.log.info(f"Actual checksum: {actual_checksum}")
+    if actual_checksum != expected_checksum:
+        context.log.error(
+            f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
+        )
+        raise ValueError(
+            f"Checksum mismatch! Expected: {expected_checksum}, Actual: {actual_checksum}"
+        )
+
+    csv_content = None
+
+    context.log.info("Extracting CSV from zip file")
+    with zipfile.ZipFile(BytesIO(zip_data)) as zip_ref:
+        csv_filename = zip_ref.namelist()[0]
+        context.log.info(f"Found CSV file: {csv_filename}")
+
+        with zip_ref.open(csv_filename) as csv_file:
+            csv_content = csv_file.read()
+
+    csv_checksum = hashlib.sha256(csv_content).hexdigest()
+    context.log.info(f"CSV checksum: {csv_checksum}")
+
+    context.log.info("Parsing CSV data")
+    data = []
+
+    csv_text = csv_content.decode("utf-8")
+    reader = csv.reader(csv_text.splitlines())
+
+    row_count = 0
+    for row in reader:
+        row_count += 1
+        trade_id = int(row[0])
+        price = float(row[1])
+        quantity = float(row[2])
+        quote_quantity = float(row[3])
+        timestamp = int(row[4])
+        is_buyer_maker = row[5].lower() == "true"
+        is_best_match = row[6].lower() == "true"
+
+        if len(str(timestamp)) == 13:
+            dt = datetime.fromtimestamp(timestamp / 1000.0)
+        elif len(str(timestamp)) == 16:
+            dt = datetime.fromtimestamp(timestamp / 1000000.0)
+        else:
+            raise ValueError(f"Invalid timestamp length: {timestamp}")
+
+        data.append(
+            (
+                trade_id,
+                price,
+                quantity,
+                quote_quantity,
+                timestamp,
+                is_buyer_maker,
+                is_best_match,
+                dt,
+            )
+        )
+
+    context.log.info(f"Parsed {row_count} rows from CSV")
+
+    csv_text = None
+    csv_content = None
+    zip_data = None
+
+    client = None
+    try:
+        context.log.info(
+            f"Connecting to ClickHouse at {CLICKHOUSE_HOST}:{CLICKHOUSE_PORT}"
+        )
+        client = ClickhouseClient(
+            host=CLICKHOUSE_HOST,
+            port=CLICKHOUSE_PORT,
+            user=CLICKHOUSE_USER,
+            password=CLICKHOUSE_PASSWORD,
+            database=CLICKHOUSE_DATABASE,
+            compression=True,
+            send_receive_timeout=900,
+        )
+
+        context.log.info(f"Checking for existing data for {date_str}")
+        check_result = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+            WHERE toDate(datetime) = toDate('{date_str}')
+        """
+        )
+        existing_count = check_result[0][0]
+
+        if existing_count > 0:
+            context.log.info(
+                f"Found {existing_count} existing records for {date_str}. Deleting before reinserting."
+            )
+            client.execute(
+                f"""
+                ALTER TABLE {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+                DELETE WHERE toDate(datetime) = toDate('{date_str}')
+            """
+            )
+            context.log.info(f"Deleted existing data for {date_str}")
+
+        context.log.info(f"Inserting {len(data)} rows into ClickHouse")
+        client.execute(
+            f"""
+            INSERT INTO {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+            (
+                trade_id,
+                price,
+                quantity,
+                quote_quantity,
+                timestamp,
+                is_buyer_maker,
+                is_best_match,
+                datetime
+            ) SETTINGS async_insert=1, wait_for_async_insert=1
+            VALUES
+            """,
+            data,
+            settings={"max_execution_time": 900},
+        )
+        context.log.info("Data insertion completed")
+
+        context.log.info("Verifying data insertion")
+        result = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+            WHERE toDate(datetime) = toDate('{date_str}')
+        """
+        )
+        inserted_count = result[0][0]
+        context.log.info(f"Found {inserted_count} rows in ClickHouse after insertion")
+
+        context.log.info("Computing verification statistics")
+        stats_result = client.execute(
+            f"""
+            SELECT
+                min(trade_id),
+                max(trade_id),
+                avg(price),
+                count(distinct trade_id) % 1000
+            FROM {CLICKHOUSE_DATABASE}.{CLICKHOUSE_TABLE}
+            WHERE toDate(datetime) = toDate('{date_str}')
+        """
+        )
+
+        data_verification = {
+            "min_trade_id": stats_result[0][0],
+            "max_trade_id": stats_result[0][1],
+            "avg_price": stats_result[0][2],
+            "id_uniqueness_check": stats_result[0][3],
+        }
+        context.log.info(f"Data verification stats: {data_verification}")
+
+        if inserted_count != len(data):
+            context.log.error(
+                f"Row count mismatch! Expected: {len(data)}, Actual: {inserted_count}"
+            )
+            raise ValueError(
+                f"Row count mismatch! Expected: {len(data)}, Actual: {inserted_count}"
+            )
+
+        result_data = {
+            "date": day_str,
+            "rows_inserted": inserted_count,
+            "zip_checksum": actual_checksum,
+            "csv_checksum": csv_checksum,
+            "data_verification": data_verification,
+        }
+
+        context.log.info(f"Successfully processed {day_str}")
+        return result_data
+
+    except Exception as e:
+        raise e
+    finally:
+        if client:
+            try:
+                client.disconnect()
+            except Exception:
+                pass
+        data = None

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -7,12 +7,31 @@
 # 5. Add the job to the jobs list
 # 6. If applicable, add a schedule for the job and add it to the schedules list
 
-from dagster import Definitions, define_asset_job, schedule
+import os
+from datetime import datetime, timedelta, timezone
 
+import requests
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import (
+    Definitions,
+    RunRequest,
+    ScheduleEvaluationContext,
+    define_asset_job,
+    schedule,
+)
+
+from .assets.cleanup_binance_daily_trades import (
+    cleanup_binance_daily_trades_for_finalized_month,
+)
 from .assets.daily_trades_to_origo import insert_daily_binance_trades_to_origo
+from .assets.daily_trades_to_tdw import insert_daily_binance_trades_to_tdw
 from .assets.monthly_trades_to_tdw import insert_monthly_binance_trades_to_tdw
 from .assets.create_tdw_database import create_tdw_database
+from .assets.create_binance_daily_trades_table import create_binance_daily_trades_table
 from .assets.create_binance_trades_table import create_binance_trades_table
+from .assets.create_binance_trades_complete_view import (
+    create_binance_trades_complete_view,
+)
 from .assets.create_binance_trades_monthly_summary import create_binance_trades_monthly_summary
 from .assets.create_binance_trades_daily_summary import create_binance_trades_daily_summary
 from .assets.create_binance_trades_hourly_summary import create_binance_trades_hourly_summary
@@ -28,6 +47,12 @@ from .assets.monthly_futures_agg_trades_to_tdw import create_binance_futures_agg
 from .assets.monthly_futures_agg_trades_to_tdw import insert_monthly_binance_futures_agg_trades_to_tdw
 from .assets.create_origo_database import create_origo_database
 from .assets.create_binance_trades_table_origo import create_binance_trades_table_origo
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 
 
 # Database Maintenance Jobs
@@ -45,10 +70,18 @@ create_binance_trades_table_job = define_asset_job(
     name="create_binance_trades_table_job",
     selection=["create_binance_trades_table"])
 
+create_binance_daily_trades_table_job = define_asset_job(
+    name="create_binance_daily_trades_table_job",
+    selection=["create_binance_daily_trades_table"])
+
 create_binance_trades_table_origo_job = define_asset_job(
     name="create_binance_trades_table_origo_job",
     selection=["create_binance_trades_table_origo"]
 )
+
+create_binance_trades_complete_view_job = define_asset_job(
+    name="create_binance_trades_complete_view_job",
+    selection=["create_binance_trades_complete_view"])
 
 create_binance_agg_trades_table_job = define_asset_job(
     name="create_binance_agg_trades_table_job",
@@ -72,9 +105,20 @@ insert_daily_binance_trades_job = define_asset_job(
     name="insert_daily_trades_to_origo_job",
     selection=["insert_daily_binance_trades_to_origo"])
 
+insert_daily_binance_trades_tdw_job = define_asset_job(
+    name="insert_daily_trades_to_tdw_job",
+    selection=["insert_daily_binance_trades_to_tdw"])
+
 insert_monthly_binance_agg_trades_job = define_asset_job(
     name="insert_monthly_agg_trades_to_tdw_job",
     selection=["insert_monthly_binance_agg_trades_to_tdw"])
+
+roll_forward_monthly_binance_trades_job = define_asset_job(
+    name="roll_forward_monthly_binance_trades_job",
+    selection=[
+        "insert_monthly_binance_trades_to_tdw",
+        "cleanup_binance_daily_trades_for_finalized_month",
+    ])
 
 insert_monthly_binance_futures_trades_job = define_asset_job(
     name="insert_monthly_futures_trades_to_tdw_job",
@@ -115,6 +159,88 @@ create_binance_trades_month_of_year_summary_job = define_asset_job(
     selection=["create_binance_trades_month_of_year_summary"])
 
 
+def _get_clickhouse_client():
+    return ClickhouseClient(
+        host=CLICKHOUSE_HOST,
+        port=CLICKHOUSE_PORT,
+        user=CLICKHOUSE_USER,
+        password=CLICKHOUSE_PASSWORD,
+        database=CLICKHOUSE_DATABASE,
+    )
+
+
+def _table_exists(table_name: str) -> bool:
+    client = None
+    try:
+        client = _get_clickhouse_client()
+        result = client.execute(
+            f"""
+            SELECT count(*)
+            FROM system.tables
+            WHERE database = '{CLICKHOUSE_DATABASE}'
+              AND name = '{table_name}'
+        """
+        )
+        return bool(result[0][0])
+    finally:
+        if client:
+            client.disconnect()
+
+
+def _count_rows_for_day(table_name: str, date_str: str) -> int:
+    if not _table_exists(table_name):
+        return 0
+
+    client = None
+    try:
+        client = _get_clickhouse_client()
+        result = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.{table_name}
+            WHERE toDate(datetime) = toDate('{date_str}')
+        """
+        )
+        return result[0][0]
+    finally:
+        if client:
+            client.disconnect()
+
+
+def _count_rows_for_month(table_name: str, month_start: str) -> int:
+    if not _table_exists(table_name):
+        return 0
+
+    client = None
+    try:
+        client = _get_clickhouse_client()
+        result = client.execute(
+            f"""
+            SELECT count(*)
+            FROM {CLICKHOUSE_DATABASE}.{table_name}
+            WHERE datetime >= toDate('{month_start}')
+              AND datetime < addMonths(toDate('{month_start}'), 1)
+        """
+        )
+        return result[0][0]
+    finally:
+        if client:
+            client.disconnect()
+
+
+def _binance_archive_available(file_url: str) -> bool:
+    checksum_url = f"{file_url}.CHECKSUM"
+    try:
+        response = requests.get(checksum_url, timeout=30)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def _scheduled_time(context: ScheduleEvaluationContext) -> datetime:
+    return context.scheduled_execution_time or datetime.now(timezone.utc)
+
+
 @schedule(
     job=insert_daily_binance_trades_job,
     cron_schedule="0 1 * * *",
@@ -123,13 +249,70 @@ create_binance_trades_month_of_year_summary_job = define_asset_job(
 def daily_pipeline_schedule():
     return {}
 
+
+@schedule(
+    job=insert_daily_binance_trades_tdw_job,
+    cron_schedule="0 */4 * * *",
+    execution_timezone="UTC",
+)
+def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
+    scheduled_time = _scheduled_time(context)
+    target_date = (scheduled_time - timedelta(days=1)).date().isoformat()
+
+    if not _table_exists("binance_daily_trades"):
+        return None
+
+    if _count_rows_for_day("binance_daily_trades", target_date) > 0:
+        return None
+
+    file_url = (
+        "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
+        f"BTCUSDT-trades-{target_date}.zip"
+    )
+    if not _binance_archive_available(file_url):
+        return None
+
+    return RunRequest(partition_key=target_date)
+
+
+@schedule(
+    job=roll_forward_monthly_binance_trades_job,
+    cron_schedule="0 9 * * *",
+    execution_timezone="UTC",
+)
+def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
+    scheduled_time = _scheduled_time(context)
+    current_month_start = scheduled_time.date().replace(day=1)
+    previous_month_date = current_month_start - timedelta(days=1)
+    previous_month_start = previous_month_date.replace(day=1).isoformat()
+    previous_month_label = previous_month_date.strftime("%Y-%m")
+
+    if not _table_exists("binance_trades"):
+        return None
+
+    if _count_rows_for_month("binance_trades", previous_month_start) > 0:
+        return None
+
+    file_url = (
+        "https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/"
+        f"BTCUSDT-trades-{previous_month_label}.zip"
+    )
+    if not _binance_archive_available(file_url):
+        return None
+
+    return RunRequest(partition_key=previous_month_start)
+
 defs = Definitions(
     assets=[create_tdw_database,
             create_origo_database,
             create_binance_trades_table,
+            create_binance_daily_trades_table,
             create_binance_trades_table_origo,
+            create_binance_trades_complete_view,
             insert_monthly_binance_trades_to_tdw,
             insert_daily_binance_trades_to_origo,
+            insert_daily_binance_trades_to_tdw,
+            cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
             create_binance_trades_hourly_summary,
@@ -144,14 +327,22 @@ defs = Definitions(
             create_binance_futures_agg_trades_table,
             insert_monthly_binance_futures_agg_trades_to_tdw],
     
-    schedules=[daily_pipeline_schedule],
+    schedules=[
+        daily_pipeline_schedule,
+        daily_tdw_pipeline_schedule,
+        monthly_tdw_rollforward_schedule,
+    ],
     
     jobs=[create_tdw_database_job,
           create_origo_database_job,
           create_binance_trades_table_job,
+          create_binance_daily_trades_table_job,
           create_binance_trades_table_origo_job,
+          create_binance_trades_complete_view_job,
           insert_monthly_binance_trades_job,
           insert_daily_binance_trades_job,
+          insert_daily_binance_trades_tdw_job,
+          roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,
           create_binance_trades_hourly_summary_job,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -53,6 +53,7 @@ CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
 CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+MAX_DAILY_BACKFILL_RUNS_PER_TICK = 31
 
 
 # Database Maintenance Jobs
@@ -228,6 +229,54 @@ def _count_rows_for_month(table_name: str, month_start: str) -> int:
             client.disconnect()
 
 
+def _latest_day_in_table(table_name: str):
+    if not _table_exists(table_name):
+        return None
+
+    client = None
+    try:
+        client = _get_clickhouse_client()
+        result = client.execute(
+            f"""
+            SELECT max(toDate(datetime))
+            FROM {CLICKHOUSE_DATABASE}.{table_name}
+        """
+        )
+        return result[0][0]
+    finally:
+        if client:
+            client.disconnect()
+
+
+def _existing_days_in_range(table_name: str, start_date: str, end_date: str) -> set:
+    if not _table_exists(table_name):
+        return set()
+
+    client = None
+    try:
+        client = _get_clickhouse_client()
+        result = client.execute(
+            f"""
+            SELECT DISTINCT toDate(datetime) AS day
+            FROM {CLICKHOUSE_DATABASE}.{table_name}
+            WHERE toDate(datetime) >= toDate('{start_date}')
+              AND toDate(datetime) <= toDate('{end_date}')
+        """
+        )
+        return {row[0] for row in result if row[0] is not None}
+    finally:
+        if client:
+            client.disconnect()
+
+
+def _next_daily_overlay_start_day():
+    latest_monthly_day = _latest_day_in_table("binance_trades")
+    if latest_monthly_day is None:
+        return None
+
+    return latest_monthly_day + timedelta(days=1)
+
+
 def _binance_archive_available(file_url: str) -> bool:
     checksum_url = f"{file_url}.CHECKSUM"
     try:
@@ -257,22 +306,43 @@ def daily_pipeline_schedule():
 )
 def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
     scheduled_time = _scheduled_time(context)
-    target_date = (scheduled_time - timedelta(days=1)).date().isoformat()
+    end_date = (scheduled_time - timedelta(days=1)).date()
 
     if not _table_exists("binance_daily_trades"):
         return None
 
-    if _count_rows_for_day("binance_daily_trades", target_date) > 0:
+    start_day = _next_daily_overlay_start_day()
+    if start_day is None or start_day > end_date:
         return None
 
-    file_url = (
-        "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
-        f"BTCUSDT-trades-{target_date}.zip"
+    existing_days = _existing_days_in_range(
+        "binance_daily_trades",
+        start_day.isoformat(),
+        end_date.isoformat(),
     )
-    if not _binance_archive_available(file_url):
+
+    run_requests = []
+    current_day = start_day
+    while current_day <= end_date and len(run_requests) < MAX_DAILY_BACKFILL_RUNS_PER_TICK:
+        if current_day not in existing_days:
+            target_date = current_day.isoformat()
+            file_url = (
+                "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
+                f"BTCUSDT-trades-{target_date}.zip"
+            )
+            if _binance_archive_available(file_url):
+                run_requests.append(
+                    RunRequest(
+                        partition_key=target_date,
+                        run_key=f"binance_daily_trades::{target_date}",
+                    )
+                )
+        current_day += timedelta(days=1)
+
+    if not run_requests:
         return None
 
-    return RunRequest(partition_key=target_date)
+    return run_requests
 
 
 @schedule(
@@ -300,7 +370,10 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
     if not _binance_archive_available(file_url):
         return None
 
-    return RunRequest(partition_key=previous_month_start)
+    return RunRequest(
+        partition_key=previous_month_start,
+        run_key=f"binance_trades::{previous_month_start}",
+    )
 
 defs = Definitions(
     assets=[create_tdw_database,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -16,6 +16,7 @@ from dagster import (
     Definitions,
     RunRequest,
     ScheduleEvaluationContext,
+    SkipReason,
     define_asset_job,
     schedule,
 )
@@ -51,7 +52,7 @@ from .assets.create_binance_trades_table_origo import create_binance_trades_tabl
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ["CLICKHOUSE_PASSWORD"]
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 MAX_DAILY_BACKFILL_RUNS_PER_TICK = 31
 
@@ -165,9 +166,18 @@ def _get_clickhouse_client():
         host=CLICKHOUSE_HOST,
         port=CLICKHOUSE_PORT,
         user=CLICKHOUSE_USER,
-        password=CLICKHOUSE_PASSWORD,
+        password=_get_clickhouse_password(),
         database=CLICKHOUSE_DATABASE,
     )
+
+
+def _get_clickhouse_password():
+    if not CLICKHOUSE_PASSWORD:
+        raise RuntimeError(
+            "CLICKHOUSE_PASSWORD environment variable must be set before using ClickHouse-dependent schedules."
+        )
+
+    return CLICKHOUSE_PASSWORD
 
 
 def _table_exists(table_name: str) -> bool:
@@ -189,9 +199,6 @@ def _table_exists(table_name: str) -> bool:
 
 
 def _count_rows_for_day(table_name: str, date_str: str) -> int:
-    if not _table_exists(table_name):
-        return 0
-
     client = None
     try:
         client = _get_clickhouse_client()
@@ -209,9 +216,6 @@ def _count_rows_for_day(table_name: str, date_str: str) -> int:
 
 
 def _count_rows_for_month(table_name: str, month_start: str) -> int:
-    if not _table_exists(table_name):
-        return 0
-
     client = None
     try:
         client = _get_clickhouse_client()
@@ -230,9 +234,6 @@ def _count_rows_for_month(table_name: str, month_start: str) -> int:
 
 
 def _latest_day_in_table(table_name: str):
-    if not _table_exists(table_name):
-        return None
-
     client = None
     try:
         client = _get_clickhouse_client()
@@ -249,9 +250,6 @@ def _latest_day_in_table(table_name: str):
 
 
 def _existing_days_in_range(table_name: str, start_date: str, end_date: str) -> set:
-    if not _table_exists(table_name):
-        return set()
-
     client = None
     try:
         client = _get_clickhouse_client()
@@ -309,11 +307,14 @@ def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
     end_date = (scheduled_time - timedelta(days=1)).date()
 
     if not _table_exists("binance_daily_trades"):
-        return None
+        return SkipReason("tdw.binance_daily_trades does not exist yet.")
+
+    if not _table_exists("binance_trades"):
+        return SkipReason("tdw.binance_trades does not exist yet.")
 
     start_day = _next_daily_overlay_start_day()
     if start_day is None or start_day > end_date:
-        return None
+        return SkipReason("No missing daily overlay partitions need to be materialized.")
 
     existing_days = _existing_days_in_range(
         "binance_daily_trades",
@@ -340,7 +341,7 @@ def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
         current_day += timedelta(days=1)
 
     if not run_requests:
-        return None
+        return SkipReason("No available Binance daily archives were found for missing overlay days.")
 
     return run_requests
 
@@ -358,17 +359,17 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
     previous_month_label = previous_month_date.strftime("%Y-%m")
 
     if not _table_exists("binance_trades"):
-        return None
+        return SkipReason("tdw.binance_trades does not exist yet.")
 
     if _count_rows_for_month("binance_trades", previous_month_start) > 0:
-        return None
+        return SkipReason(f"Monthly Binance trades for {previous_month_start} are already loaded.")
 
     file_url = (
         "https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/"
         f"BTCUSDT-trades-{previous_month_label}.zip"
     )
     if not _binance_archive_available(file_url):
-        return None
+        return SkipReason(f"Monthly Binance archive {previous_month_label} is not available yet.")
 
     return RunRequest(
         partition_key=previous_month_start,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -54,7 +54,8 @@ CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
 CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
 CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
-MAX_DAILY_BACKFILL_RUNS_PER_TICK = 31
+MAX_DAILY_BACKFILL_RUNS_PER_TICK = 14
+MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS = 14
 
 
 # Database Maintenance Jobs
@@ -315,6 +316,12 @@ def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
     start_day = _next_daily_overlay_start_day()
     if start_day is None or start_day > end_date:
         return SkipReason("No missing daily overlay partitions need to be materialized.")
+
+    backfill_gap_days = (end_date - start_day).days + 1
+    if backfill_gap_days > MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS:
+        return SkipReason(
+            "Daily overlay gap is larger than the automated backfill threshold; trigger a manual backfill."
+        )
 
     existing_days = _existing_days_in_range(
         "binance_daily_trades",


### PR DESCRIPTION
## What changed

This adds a daily Binance trade overlay in TDW without changing the existing monthly `tdw.binance_trades` ingestion path.

- adds `tdw.binance_daily_trades` as a separate rolling daily table
- adds `tdw.binance_trades_complete` as a plain view that combines final monthly data with the still-open daily overlay without duplicates
- adds cleanup logic so finalized months are removed from the daily overlay after the monthly archive lands
- adds automated Dagster schedules for daily overlay ingestion and monthly roll-forward

## Why

The monthly table remains the trusted canonical source, but it is only complete once Binance publishes the monthly archive. This change fills the gap with official daily archive files so consumers can query a fresher combined view while preserving the existing monthly contract.

## Impact

- `tdw.binance_trades` remains unchanged and continues to represent final monthly data
- `tdw.binance_daily_trades` holds the rolling open-period overlay
- consumers that want the freshest complete picture can query `tdw.binance_trades_complete`
- after deploy, the new table and view need a one-time setup run in Dagster before the schedules fully take over

## Validation

- `python3 -m compileall tdw_control_plane`
