### PR TITLE
[codex] publish daily BTCUSDT 1m klines to Hugging Face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+
+## Unreleased
+
+- Add `tdw_control_plane.query.get_binance_spot_klines` as the TDW-owned Binance spot kline query.
+- Add a daily Hugging Face export asset and sensor for BTCUSDT 1-minute klines sourced from `tdw.binance_trades_complete`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
+      - HF_TOKEN=${HF_TOKEN:-}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID:-vaquum/binance_btcusdt_1m_klines}
     volumes:
       - .:/opt/app
       - dagster-instance:/opt/dagster-instance
@@ -41,6 +43,8 @@ services:
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
+      - HF_TOKEN=${HF_TOKEN:-}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID:-vaquum/binance_btcusdt_1m_klines}
     volumes:
       - .:/opt/app
       - dagster-instance:/opt/dagster-instance

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -4,5 +4,6 @@ clickhouse-driver
 clickhouse-cityhash
 clickhouse_connect
 polars
+huggingface_hub
 requests
 aiohttp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
   "requests",
   "matplotlib",
   "clickhouse-driver",
+  "clickhouse_connect",
+  "polars",
+  "huggingface_hub",
   "lz4>=4.0.0",
   "clickhouse-cityhash>=1.0.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,8 @@ pandas
 requests
 matplotlib
 clickhouse-driver
+clickhouse_connect
+polars
+huggingface_hub
 lz4>=4.0.0
 clickhouse-cityhash>=1.0.2

--- a/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
@@ -118,7 +118,8 @@ def publish_binance_spot_klines_to_huggingface(context: AssetExecutionContext):
         start_date_limit=EXPORT_START_DATE,
         end_date_limit=export_end_exclusive,
         table_name="binance_trades_complete",
-    ).drop(["median", "iqr"])
+        include_quantiles=False,
+    )
 
     if data.height == 0:
         raise RuntimeError(
@@ -166,6 +167,7 @@ def publish_binance_spot_klines_to_huggingface(context: AssetExecutionContext):
             repo_id=dataset_repo_id,
             repo_type="dataset",
             commit_message=commit_message,
+            delete_patterns=[f"{EXPORT_FILENAME_PREFIX}*.parquet"],
         )
 
     latest_datetime = data["datetime"].max()

--- a/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
@@ -1,0 +1,182 @@
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from dagster import AssetExecutionContext, asset
+from huggingface_hub import HfApi
+
+from tdw_control_plane.assets.daily_trades_to_tdw import daily_partitions
+from tdw_control_plane.query import get_binance_spot_klines
+
+EXPORT_START_DATE = "2020-01-01 00:00:00"
+EXPORT_FILENAME_PREFIX = "btcusdt_1m_kline_20200101_to_"
+
+
+def _get_huggingface_token() -> str:
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "HF_TOKEN or HUGGINGFACE_HUB_TOKEN must be set before publishing to Hugging Face."
+        )
+
+    return token
+
+
+def _get_huggingface_dataset_repo_id() -> str:
+    return os.environ.get(
+        "HUGGINGFACE_DATASET_REPO_ID",
+        "vaquum/binance_btcusdt_1m_klines",
+    )
+
+
+def _build_dataset_card(export_end_date: str, row_count: int, file_name: str) -> str:
+    return f"""# BTCUSDT 1m spot klines
+
+This dataset is exported daily from `tdw.binance_trades_complete` using TDW's `get_binance_spot_klines` query at 1-minute resolution.
+
+Latest snapshot:
+
+- file: `{file_name}`
+- start date: `2020-01-01`
+- rows: `{row_count}`
+- end date: `{export_end_date}`
+- columns: `datetime`, `open`, `high`, `low`, `close`, `mean`, `std`, `volume`, `maker_ratio`, `no_of_trades`, `open_liquidity`, `high_liquidity`, `low_liquidity`, `close_liquidity`, `liquidity_sum`, `maker_volume`, `maker_liquidity`
+
+Notes:
+
+- Source market: Binance spot BTCUSDT
+- Source table: `tdw.binance_trades_complete`
+- `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
+- Timestamps are UTC
+"""
+
+
+def _build_snapshot_metadata(
+    export_end_date: str,
+    file_name: str,
+    row_count: int,
+    file_sha256: str,
+) -> str:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    return (
+        json.dumps(
+            {
+                "file_name": file_name,
+                "export_start_date": "2020-01-01",
+                "export_end_date": export_end_date,
+                "row_count": row_count,
+                "sha256": file_sha256,
+                "generated_at_utc": generated_at,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _sha256_for_file(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@asset(
+    partitions_def=daily_partitions,
+    group_name="binance_data",
+    description="Exports daily BTCUSDT 1m spot klines from tdw.binance_trades_complete and publishes the latest snapshot to Hugging Face.",
+)
+def publish_binance_spot_klines_to_huggingface(context: AssetExecutionContext):
+    partition_date_str = context.asset_partition_key_for_output()
+    if partition_date_str is None:
+        raise RuntimeError(
+            "publish_binance_spot_klines_to_huggingface requires a daily partition key."
+        )
+
+    export_end_date = partition_date_str
+    export_end_exclusive = (
+        datetime.strptime(export_end_date, "%Y-%m-%d") + timedelta(days=1)
+    ).strftime("%Y-%m-%d 00:00:00")
+    dataset_repo_id = _get_huggingface_dataset_repo_id()
+
+    file_name = (
+        f"{EXPORT_FILENAME_PREFIX}{export_end_date.replace('-', '')}.parquet"
+    )
+
+    context.log.info(
+        f"Building Binance spot klines snapshot through {export_end_date} UTC."
+    )
+    data = get_binance_spot_klines(
+        kline_size=60,
+        start_date_limit=EXPORT_START_DATE,
+        end_date_limit=export_end_exclusive,
+        table_name="binance_trades_complete",
+    ).drop(["median", "iqr"])
+
+    if data.height == 0:
+        raise RuntimeError(
+            f"No kline rows were returned for export through {export_end_date}."
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        parquet_path = tmp_path / file_name
+        readme_path = tmp_path / "README.md"
+        metadata_path = tmp_path / "latest.json"
+
+        context.log.info(f"Writing snapshot to {parquet_path}.")
+        data.write_parquet(parquet_path, compression="zstd")
+        file_sha256 = _sha256_for_file(parquet_path)
+
+        readme_path.write_text(
+            _build_dataset_card(
+                export_end_date=export_end_date,
+                row_count=data.height,
+                file_name=file_name,
+            ),
+            encoding="utf-8",
+        )
+        metadata_path.write_text(
+            _build_snapshot_metadata(
+                export_end_date=export_end_date,
+                file_name=file_name,
+                row_count=data.height,
+                file_sha256=file_sha256,
+            ),
+            encoding="utf-8",
+        )
+
+        api = HfApi(token=_get_huggingface_token())
+        api.create_repo(
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            exist_ok=True,
+        )
+
+        commit_message = f"Add BTCUSDT 1m klines snapshot through {export_end_date}"
+        api.upload_folder(
+            folder_path=str(tmp_path),
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            commit_message=commit_message,
+        )
+
+    latest_datetime = data["datetime"].max()
+    context.log.info(
+        f"Published {file_name} to {dataset_repo_id} with {data.height} rows."
+    )
+
+    return {
+        "repo_id": dataset_repo_id,
+        "file_name": file_name,
+        "rows_exported": data.height,
+        "latest_datetime": str(latest_datetime),
+        "sha256": file_sha256,
+    }

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -13,10 +13,12 @@ from datetime import datetime, timedelta, timezone
 import requests
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import (
+    AssetKey,
     Definitions,
     RunRequest,
     ScheduleEvaluationContext,
     SkipReason,
+    asset_sensor,
     define_asset_job,
     schedule,
 )
@@ -26,6 +28,9 @@ from .assets.cleanup_binance_daily_trades import (
 )
 from .assets.daily_trades_to_origo import insert_daily_binance_trades_to_origo
 from .assets.daily_trades_to_tdw import insert_daily_binance_trades_to_tdw
+from .assets.publish_binance_spot_klines_to_huggingface import (
+    publish_binance_spot_klines_to_huggingface,
+)
 from .assets.monthly_trades_to_tdw import insert_monthly_binance_trades_to_tdw
 from .assets.create_tdw_database import create_tdw_database
 from .assets.create_binance_daily_trades_table import create_binance_daily_trades_table
@@ -111,6 +116,10 @@ insert_daily_binance_trades_job = define_asset_job(
 insert_daily_binance_trades_tdw_job = define_asset_job(
     name="insert_daily_trades_to_tdw_job",
     selection=["insert_daily_binance_trades_to_tdw"])
+
+publish_binance_spot_klines_to_huggingface_job = define_asset_job(
+    name="publish_binance_spot_klines_to_huggingface_job",
+    selection=["publish_binance_spot_klines_to_huggingface"])
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
     name="insert_monthly_agg_trades_to_tdw_job",
@@ -383,6 +392,25 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
         run_key=f"binance_trades::{previous_month_start}",
     )
 
+
+@asset_sensor(
+    asset_key=AssetKey("insert_daily_binance_trades_to_tdw"),
+    job=publish_binance_spot_klines_to_huggingface_job,
+)
+def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
+    if not asset_event.dagster_event:
+        return SkipReason("No Dagster event was attached to the daily TDW materialization.")
+
+    partition_key = asset_event.dagster_event.partition
+    if partition_key is None:
+        return SkipReason("Daily TDW materialization did not include a partition key.")
+
+    return RunRequest(
+        partition_key=partition_key,
+        run_key=f"publish_binance_spot_klines_to_hf::{partition_key}",
+    )
+
+
 defs = Definitions(
     assets=[create_tdw_database,
             create_origo_database,
@@ -393,6 +421,7 @@ defs = Definitions(
             insert_monthly_binance_trades_to_tdw,
             insert_daily_binance_trades_to_origo,
             insert_daily_binance_trades_to_tdw,
+            publish_binance_spot_klines_to_huggingface,
             cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
@@ -413,6 +442,10 @@ defs = Definitions(
         daily_tdw_pipeline_schedule,
         monthly_tdw_rollforward_schedule,
     ],
+
+    sensors=[
+        publish_binance_spot_klines_to_huggingface_sensor,
+    ],
     
     jobs=[create_tdw_database_job,
           create_origo_database_job,
@@ -423,6 +456,7 @@ defs = Definitions(
           insert_monthly_binance_trades_job,
           insert_daily_binance_trades_job,
           insert_daily_binance_trades_tdw_job,
+          publish_binance_spot_klines_to_huggingface_job,
           roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,

--- a/tdw_control_plane/query/__init__.py
+++ b/tdw_control_plane/query/__init__.py
@@ -1,0 +1,3 @@
+from .get_binance_spot_klines import get_binance_spot_klines
+
+__all__ = ["get_binance_spot_klines"]

--- a/tdw_control_plane/query/get_binance_spot_klines.py
+++ b/tdw_control_plane/query/get_binance_spot_klines.py
@@ -1,0 +1,105 @@
+import logging
+import re
+import time
+
+import polars as pl
+
+from tdw_control_plane.utils.get_clickhouse_client import get_clickhouse_client
+
+logger = logging.getLogger(__name__)
+
+
+def get_binance_spot_klines(
+    n_rows: int | None = None,
+    kline_size: int = 1,
+    start_date_limit: str | None = None,
+    end_date_limit: str | None = None,
+    show_summary: bool = False,
+    table_name: str = "binance_trades_complete",
+) -> pl.DataFrame:
+    """Query Binance BTCUSDT spot klines from TDW.
+
+    This is TDW's canonical spot-kline query and mirrors the existing
+    HistoricalData.get_spot_klines semantics while sourcing data from
+    tdw.binance_trades_complete by default.
+    """
+
+    if re.fullmatch(r"[A-Za-z0-9_]+", table_name) is None:
+        raise ValueError(f"Invalid ClickHouse table name: {table_name}")
+
+    client = get_clickhouse_client()
+    try:
+        limit = f"LIMIT {n_rows}" if n_rows is not None else ""
+
+        where_clauses = []
+        if start_date_limit is not None:
+            where_clauses.append(f"datetime >= toDateTime('{start_date_limit}')")
+        if end_date_limit is not None:
+            where_clauses.append(f"datetime < toDateTime('{end_date_limit}')")
+
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses) + " "
+        else:
+            where_sql = ""
+
+        query = (
+            f"SELECT "
+            f"    toDateTime({kline_size} * intDiv(toUnixTimestamp(datetime), {kline_size})) AS datetime, "
+            f"    argMin(price, trade_id)       AS open, "
+            f"    max(price)                    AS high, "
+            f"    min(price)                    AS low, "
+            f"    argMax(price, trade_id)       AS close, "
+            f"    avg(price)                    AS mean, "
+            f"    stddevPopStable(price)        AS std, "
+            f"    quantileExact(0.5)(price)     AS median, "
+            f"    quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr, "
+            f"    sumKahan(quantity)            AS volume, "
+            f"    avg(is_buyer_maker)           AS maker_ratio, "
+            f"    count()                       AS no_of_trades, "
+            f"    argMin(price * quantity, trade_id)    AS open_liquidity, "
+            f"    max(price * quantity)         AS high_liquidity, "
+            f"    min(price * quantity)         AS low_liquidity, "
+            f"    argMax(price * quantity, trade_id)    AS close_liquidity, "
+            f"    sum(price * quantity)         AS liquidity_sum, "
+            f"    sumKahan(is_buyer_maker * quantity)   AS maker_volume, "
+            f"    sum(is_buyer_maker * price * quantity) AS maker_liquidity "
+            f"FROM tdw.{table_name} "
+            f"{where_sql}"
+            f"GROUP BY datetime "
+            f"ORDER BY datetime ASC "
+            f"{limit}"
+        )
+
+        start = time.time()
+        arrow_table = client.query_arrow(query)
+        polars_df = pl.from_arrow(arrow_table)
+
+        polars_df = polars_df.with_columns([
+            (pl.col("datetime").cast(pl.Int64) * 1000)
+            .cast(pl.Datetime("ms", time_zone="UTC"))
+            .alias("datetime")
+        ])
+
+        polars_df = polars_df.with_columns([
+            pl.col("mean").round(5),
+            pl.col("std").round(6),
+            pl.col("volume").round(9),
+            pl.col("liquidity_sum").round(1),
+            pl.col("maker_liquidity").round(1),
+        ])
+
+        polars_df = polars_df.sort("datetime")
+
+        if show_summary:
+            elapsed = time.time() - start
+            logger.info(
+                "%s s | %d rows | %d cols | %.2f GB RAM",
+                f"{elapsed:.2f}",
+                polars_df.shape[0],
+                polars_df.shape[1],
+                polars_df.estimated_size() / (1024 ** 3),
+            )
+
+        return polars_df
+    finally:
+        client.close()

--- a/tdw_control_plane/query/get_binance_spot_klines.py
+++ b/tdw_control_plane/query/get_binance_spot_klines.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import re
 import time
@@ -7,6 +8,40 @@ import polars as pl
 from tdw_control_plane.utils.get_clickhouse_client import get_clickhouse_client
 
 logger = logging.getLogger(__name__)
+_SUPPORTED_DATETIME_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def _validate_positive_int(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+
+    if type(value) is not int:
+        raise TypeError(f"{field_name} must be an int.")
+
+    if value < 1:
+        raise ValueError(f"{field_name} must be at least 1.")
+
+    return value
+
+
+def _normalize_datetime_literal(value: str | None, field_name: str) -> str | None:
+    if value is None:
+        return None
+
+    for fmt in _SUPPORTED_DATETIME_FORMATS:
+        try:
+            parsed = datetime.strptime(value, fmt)
+            return parsed.strftime("%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            continue
+
+    raise ValueError(
+        f"{field_name} must match one of: YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, YYYY-MM-DDTHH:MM:SS."
+    )
 
 
 def get_binance_spot_klines(
@@ -16,43 +51,74 @@ def get_binance_spot_klines(
     end_date_limit: str | None = None,
     show_summary: bool = False,
     table_name: str = "binance_trades_complete",
+    include_quantiles: bool = True,
 ) -> pl.DataFrame:
     """Query Binance BTCUSDT spot klines from TDW.
 
     This is TDW's canonical spot-kline query and mirrors the existing
     HistoricalData.get_spot_klines semantics while sourcing data from
     tdw.binance_trades_complete by default.
+
+    Args:
+        n_rows: Optional maximum number of rows to return.
+        kline_size: Bucket width in seconds used for kline aggregation.
+            For example, ``60`` means 1-minute klines.
+        start_date_limit: Optional inclusive lower datetime bound. Accepts
+            `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or `YYYY-MM-DDTHH:MM:SS`.
+        end_date_limit: Optional exclusive upper datetime bound. Accepts
+            `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or `YYYY-MM-DDTHH:MM:SS`.
+        show_summary: Whether to log query timing and dataframe size details.
+        table_name: ClickHouse source table name.
+        include_quantiles: Whether to include `median` and `iqr` columns.
     """
 
     if re.fullmatch(r"[A-Za-z0-9_]+", table_name) is None:
         raise ValueError(f"Invalid ClickHouse table name: {table_name}")
 
+    n_rows = _validate_positive_int(n_rows, "n_rows")
+    kline_size = _validate_positive_int(kline_size, "kline_size")
+    start_date_limit = _normalize_datetime_literal(start_date_limit, "start_date_limit")
+    end_date_limit = _normalize_datetime_literal(end_date_limit, "end_date_limit")
+
     client = get_clickhouse_client()
     try:
-        limit = f"LIMIT {n_rows}" if n_rows is not None else ""
+        query_parameters: dict[str, int | str] = {
+            "bucket_seconds": kline_size,
+        }
+        limit = "LIMIT {limit_rows:UInt64}" if n_rows is not None else ""
+        if n_rows is not None:
+            query_parameters["limit_rows"] = n_rows
 
         where_clauses = []
         if start_date_limit is not None:
-            where_clauses.append(f"datetime >= toDateTime('{start_date_limit}')")
+            where_clauses.append("datetime >= toDateTime({start_dt:String})")
+            query_parameters["start_dt"] = start_date_limit
         if end_date_limit is not None:
-            where_clauses.append(f"datetime < toDateTime('{end_date_limit}')")
+            where_clauses.append("datetime < toDateTime({end_dt:String})")
+            query_parameters["end_dt"] = end_date_limit
 
         if where_clauses:
             where_sql = "WHERE " + " AND ".join(where_clauses) + " "
         else:
             where_sql = ""
 
+        quantile_sql = ""
+        if include_quantiles:
+            quantile_sql = (
+                "    quantileExact(0.5)(price)     AS median, "
+                "    quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr, "
+            )
+
         query = (
             f"SELECT "
-            f"    toDateTime({kline_size} * intDiv(toUnixTimestamp(datetime), {kline_size})) AS datetime, "
+            f"    toDateTime({{bucket_seconds:UInt32}} * intDiv(toUnixTimestamp(datetime), {{bucket_seconds:UInt32}})) AS datetime, "
             f"    argMin(price, trade_id)       AS open, "
             f"    max(price)                    AS high, "
             f"    min(price)                    AS low, "
             f"    argMax(price, trade_id)       AS close, "
             f"    avg(price)                    AS mean, "
             f"    stddevPopStable(price)        AS std, "
-            f"    quantileExact(0.5)(price)     AS median, "
-            f"    quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr, "
+            f"{quantile_sql}"
             f"    sumKahan(quantity)            AS volume, "
             f"    avg(is_buyer_maker)           AS maker_ratio, "
             f"    count()                       AS no_of_trades, "
@@ -71,7 +137,7 @@ def get_binance_spot_klines(
         )
 
         start = time.time()
-        arrow_table = client.query_arrow(query)
+        arrow_table = client.query_arrow(query, parameters=query_parameters)
         polars_df = pl.from_arrow(arrow_table)
 
         polars_df = polars_df.with_columns([


### PR DESCRIPTION
## What changed

This PR adds a TDW-owned Binance spot kline query and a daily Hugging Face publishing path for BTCUSDT 1-minute klines.

- add `tdw_control_plane.query.get_binance_spot_klines` as the canonical spot-kline query backed by `tdw.binance_trades_complete`
- add a partitioned Dagster asset that exports BTCUSDT 1m klines from `2020-01-01` through the latest full UTC day, drops `median` and `iqr`, and uploads the dated Parquet snapshot to Hugging Face
- trigger that export via an asset sensor after successful `insert_daily_binance_trades_to_tdw` materializations
- pass `HF_TOKEN` and `HUGGINGFACE_DATASET_REPO_ID` into the Dagster containers through `docker-compose.yml`
- default the dataset repo to `vaquum/binance_btcusdt_1m_klines`

## Why

We want a TDW-native daily dataset publication flow that does not depend on Limen, while preserving the exact query semantics used today for Binance spot klines.

## Impact

After deploy, the daily TDW update flow can automatically publish snapshots named like `btcusdt_1m_kline_20200101_to_YYYYMMDD.parquet` to Hugging Face, using repo-provided runtime env vars.

## Validation

- `python3 -m py_compile tdw_control_plane/query/__init__.py tdw_control_plane/query/get_binance_spot_klines.py tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py tdw_control_plane/definitions.py`
- `HF_TOKEN=test docker compose config`
- live TDW query check via the existing local tunnel, including writing a sample parquet snapshot for `2026-04-10` with the expected 1440 one-minute rows and the correct dated filename
