### PR TITLE
[codex] add pyarrow for query_arrow runtime support

### DIFF
--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -4,6 +4,7 @@ clickhouse-driver
 clickhouse-cityhash
 clickhouse_connect
 polars
+pyarrow
 huggingface_hub
 requests
 aiohttp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "clickhouse-driver",
   "clickhouse_connect",
   "polars",
+  "pyarrow",
   "huggingface_hub",
   "lz4>=4.0.0",
   "clickhouse-cityhash>=1.0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ matplotlib
 clickhouse-driver
 clickhouse_connect
 polars
+pyarrow
 huggingface_hub
 lz4>=4.0.0
 clickhouse-cityhash>=1.0.2


### PR DESCRIPTION
## What changed

This hotfix adds `pyarrow` to every install path used by the TDW control plane image.

- add `pyarrow` to `docker-requirements.txt`
- add `pyarrow` to `requirements.txt`
- add `pyarrow` to `pyproject.toml`

## Why

The newly merged Hugging Face export path uses `clickhouse_connect`'s `query_arrow(...)`, which requires `pyarrow` at runtime. Without it, the manual backfill run fails with:

- `clickhouse_connect.driver.exceptions.NotSupportedError: PyArrow package is not installed`

## Impact

After deploy, `publish_binance_spot_klines_to_huggingface_job` should be able to execute the Arrow query path successfully.
