### PR TITLE
[codex] sync runtime HF token from GitHub secret

### DIFF
--- a/.github/workflows/sync_runtime_secrets.yml
+++ b/.github/workflows/sync_runtime_secrets.yml
@@ -1,0 +1,110 @@
+name: Sync Runtime Secrets
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-runtime-secrets
+  cancel-in-progress: false
+
+jobs:
+  sync_runtime_secrets:
+    name: Sync Runtime Secrets
+    runs-on: ubuntu-latest
+    env:
+      TDW_HOST: 37.27.112.167
+      TDW_USER: root
+      HUGGINGFACE_DATASET_REPO_ID: vaquum/binance_btcusdt_1m_klines
+
+    steps:
+      - name: Validate required secrets
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TDW_PRIVATE_KEY: ${{ secrets.TDW_PRIVATE_KEY }}
+        run: |
+          test -n "$HF_TOKEN"
+          test -n "$TDW_PRIVATE_KEY"
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TDW_PRIVATE_KEY }}
+
+      - name: Trust TDW host key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$TDW_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync Hugging Face settings into server .env
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
+          DATASET_REPO_B64=$(printf '%s' "$HUGGINGFACE_DATASET_REPO_ID" | base64 -w0)
+
+          ssh "$TDW_USER@$TDW_HOST" \
+            "HF_TOKEN_B64='$HF_TOKEN_B64' DATASET_REPO_B64='$DATASET_REPO_B64' python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          path = Path('/opt/tdw-control-plane/.env')
+          path.parent.mkdir(parents=True, exist_ok=True)
+
+          managed_values = {
+              'HF_TOKEN': base64.b64decode(os.environ['HF_TOKEN_B64']).decode(),
+              'HUGGINGFACE_DATASET_REPO_ID': base64.b64decode(os.environ['DATASET_REPO_B64']).decode(),
+          }
+
+          existing_lines = path.read_text().splitlines() if path.exists() else []
+          updated_lines = []
+          seen_keys = set()
+
+          for line in existing_lines:
+              stripped = line.strip()
+              if not stripped or stripped.startswith('#') or '=' not in line:
+                  updated_lines.append(line)
+                  continue
+
+              key, _ = line.split('=', 1)
+              if key in managed_values:
+                  updated_lines.append(f'{key}={managed_values[key]}')
+                  seen_keys.add(key)
+              else:
+                  updated_lines.append(line)
+
+          for key, value in managed_values.items():
+              if key not in seen_keys:
+                  updated_lines.append(f'{key}={value}')
+
+          path.write_text('\n'.join(updated_lines) + '\n')
+          os.chmod(path, 0o600)
+          PY"
+
+      - name: Verify managed keys are present
+        run: |
+          ssh "$TDW_USER@$TDW_HOST" \
+            "python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('/opt/tdw-control-plane/.env')
+          data = path.read_text().splitlines()
+          managed = {
+              line.split('=', 1)[0]: line.split('=', 1)[1]
+              for line in data
+              if line and not line.startswith('#') and '=' in line
+          }
+
+          for key in ('HF_TOKEN', 'HUGGINGFACE_DATASET_REPO_ID'):
+              value = managed.get(key, '')
+              if not value:
+                  raise SystemExit(f'{key} is missing or empty in {path}')
+
+          print('Runtime secrets synced successfully.')
+          PY"

--- a/tdw_control_plane/assets/README.md
+++ b/tdw_control_plane/assets/README.md
@@ -6,3 +6,7 @@
 4) Make Pull Request with the changes committed
 
 NOTE: For the changes to take effect in `tdw`, user `root` must run the command `@deploy` on the server. 
+
+The Hugging Face publisher depends on `HF_TOKEN`, which is synced into `/opt/tdw-control-plane/.env`
+from the GitHub repo secret by the `Sync Runtime Secrets` workflow. `docker-compose` reads that `.env`
+file automatically during `@deploy`, so the server does not need manual shell exports for this token.


### PR DESCRIPTION
## Summary\n- add a repo-managed workflow that syncs HF_TOKEN and the Hugging Face dataset repo id into /opt/tdw-control-plane/.env on the server\n- keep the existing manual @deploy flow intact while making docker-compose pick up the GitHub repo secret cleanly\n- document the secret sync in the assets README\n\n## Testing\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync_runtime_secrets.yml"); puts "yaml ok"'\n