### PR TITLE
[codex] move TDW deploy to GitHub image pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.pytest_cache
+.mypy_cache
+.ruff_cache
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.DS_Store
+.env
+.venv
+venv
+dist
+build
+dagster-instance
+

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -154,9 +154,9 @@ jobs:
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
           cd "$DEPLOY_DIR"
-          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
-          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d --wait clickhouse dagster dagit
-          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml exec -T dagster python - <<'PY'
+          docker compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
+          docker compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d --wait clickhouse dagster dagit
+          docker compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml exec -T dagster python - <<'PY'
           from tdw_control_plane.utils.get_clickhouse_client import get_clickhouse_client
 
           rows = get_clickhouse_client().query("SELECT 1").result_rows

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -19,16 +19,25 @@ jobs:
     name: Build Images And Deploy
     runs-on: ubuntu-latest
     env:
-      TDW_HOST: ${{ vars.TDW_HOST != '' && vars.TDW_HOST || '37.27.112.167' }}
-      TDW_USER: ${{ vars.TDW_USER != '' && vars.TDW_USER || 'root' }}
-      DEPLOY_DIR: ${{ vars.DEPLOY_DIR != '' && vars.DEPLOY_DIR || '/opt/tdw-control-plane' }}
-      PROJECT_NAME: ${{ vars.TDW_PROJECT_NAME != '' && vars.TDW_PROJECT_NAME || 'tdw-control-plane' }}
-      HUGGINGFACE_DATASET_REPO_ID: ${{ vars.HUGGINGFACE_DATASET_REPO_ID != '' && vars.HUGGINGFACE_DATASET_REPO_ID || 'vaquum/binance_btcusdt_1m_klines' }}
-      TDW_KNOWN_HOSTS: ${{ vars.TDW_KNOWN_HOSTS != '' && vars.TDW_KNOWN_HOSTS || '37.27.112.167 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIv/0Zuyg5mIwqOIkD/1K7EOUg+XWNTKT2g7PwDQeOzG' }}
+      TDW_HOST: ${{ vars.TDW_HOST }}
+      TDW_USER: ${{ vars.TDW_USER }}
+      DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
+      PROJECT_NAME: ${{ vars.TDW_PROJECT_NAME }}
+      HUGGINGFACE_DATASET_REPO_ID: ${{ vars.HUGGINGFACE_DATASET_REPO_ID }}
+      TDW_KNOWN_HOSTS: ${{ vars.TDW_KNOWN_HOSTS }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Validate deploy configuration
+        run: |
+          test -n "$TDW_HOST"
+          test -n "$TDW_USER"
+          test -n "$DEPLOY_DIR"
+          test -n "$PROJECT_NAME"
+          test -n "$HUGGINGFACE_DATASET_REPO_ID"
+          test -n "$TDW_KNOWN_HOSTS"
 
       - name: Set image names
         run: |

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -19,11 +19,12 @@ jobs:
     name: Build Images And Deploy
     runs-on: ubuntu-latest
     env:
-      TDW_HOST: 37.27.112.167
-      TDW_USER: root
-      DEPLOY_DIR: /opt/tdw-control-plane
-      PROJECT_NAME: tdw-control-plane
-      HUGGINGFACE_DATASET_REPO_ID: vaquum/binance_btcusdt_1m_klines
+      TDW_HOST: ${{ vars.TDW_HOST != '' && vars.TDW_HOST || '37.27.112.167' }}
+      TDW_USER: ${{ vars.TDW_USER != '' && vars.TDW_USER || 'root' }}
+      DEPLOY_DIR: ${{ vars.DEPLOY_DIR != '' && vars.DEPLOY_DIR || '/opt/tdw-control-plane' }}
+      PROJECT_NAME: ${{ vars.TDW_PROJECT_NAME != '' && vars.TDW_PROJECT_NAME || 'tdw-control-plane' }}
+      HUGGINGFACE_DATASET_REPO_ID: ${{ vars.HUGGINGFACE_DATASET_REPO_ID != '' && vars.HUGGINGFACE_DATASET_REPO_ID || 'vaquum/binance_btcusdt_1m_klines' }}
+      TDW_KNOWN_HOSTS: ${{ vars.TDW_KNOWN_HOSTS != '' && vars.TDW_KNOWN_HOSTS || '37.27.112.167 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIv/0Zuyg5mIwqOIkD/1K7EOUg+XWNTKT2g7PwDQeOzG' }}
 
     steps:
       - name: Checkout repository
@@ -73,17 +74,19 @@ jobs:
           CLICKHOUSE_PASSWORD: test-password
           HF_TOKEN: test-token
           HUGGINGFACE_DATASET_REPO_ID: ${{ env.HUGGINGFACE_DATASET_REPO_ID }}
-        run: docker compose -f docker-compose.deploy.yml config > /tmp/docker-compose.deploy.rendered.yml
+        run: docker compose -f docker-compose.deploy.yml config > /dev/null
 
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.TDW_PRIVATE_KEY }}
 
-      - name: Trust deployment host
+      - name: Configure pinned deployment host key
         run: |
           mkdir -p ~/.ssh
-          ssh-keyscan -H "$TDW_HOST" >> ~/.ssh/known_hosts
+          chmod 700 ~/.ssh
+          printf '%s\n' "$TDW_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Upload deploy compose file
         run: |
@@ -97,30 +100,61 @@ jobs:
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          GHCR_TOKEN_B64=$(printf '%s' "$GHCR_TOKEN" | base64 -w0)
-          CLICKHOUSE_PASSWORD_B64=$(printf '%s' "$CLICKHOUSE_PASSWORD" | base64 -w0)
-          HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
+          DEPLOY_ENV_FILE="/tmp/tdw-deploy.env"
+          trap 'rm -f "$DEPLOY_ENV_FILE"' EXIT
+
+          python3 - <<'PY' > "$DEPLOY_ENV_FILE"
+          import os
+          import shlex
+
+          values = {
+              "GHCR_USERNAME": os.environ["GHCR_USERNAME"],
+              "GHCR_TOKEN": os.environ["GHCR_TOKEN"],
+              "APP_IMAGE": os.environ["APP_IMAGE"],
+              "CLICKHOUSE_IMAGE": os.environ["CLICKHOUSE_IMAGE"],
+              "CLICKHOUSE_PASSWORD": os.environ["CLICKHOUSE_PASSWORD"],
+              "HF_TOKEN": os.environ["HF_TOKEN"],
+              "HUGGINGFACE_DATASET_REPO_ID": os.environ["HUGGINGFACE_DATASET_REPO_ID"],
+              "PROJECT_NAME": os.environ["PROJECT_NAME"],
+          }
+
+          for key, value in values.items():
+              print(f"{key}={shlex.quote(value)}")
+          PY
+
+          scp "$DEPLOY_ENV_FILE" "$TDW_USER@$TDW_HOST:$DEPLOY_DIR/.deploy.env"
 
           ssh "$TDW_USER@$TDW_HOST" \
-            "APP_IMAGE='$APP_IMAGE' CLICKHOUSE_IMAGE='$CLICKHOUSE_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
+            "DEPLOY_DIR='$DEPLOY_DIR' TDW_HOST='$TDW_HOST' bash -s" <<'REMOTE'
           set -euo pipefail
 
           export DOCKER_CONFIG
           DOCKER_CONFIG="$(mktemp -d)"
+          SECRETS_FILE="$DEPLOY_DIR/.deploy.env"
           cleanup() {
             rm -rf "$DOCKER_CONFIG"
+            rm -f "$SECRETS_FILE"
           }
           trap cleanup EXIT
+          chmod 600 "$SECRETS_FILE"
 
-          GHCR_TOKEN="$(printf '%s' "$GHCR_TOKEN_B64" | base64 -d)"
-          CLICKHOUSE_PASSWORD="$(printf '%s' "$CLICKHOUSE_PASSWORD_B64" | base64 -d)"
-          HF_TOKEN="$(printf '%s' "$HF_TOKEN_B64" | base64 -d)"
-          export APP_IMAGE CLICKHOUSE_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
+          set -a
+          . "$SECRETS_FILE"
+          set +a
 
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
           cd "$DEPLOY_DIR"
-          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
-          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d clickhouse dagster dagit
-          docker image prune -f
+          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
+          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d --wait clickhouse dagster dagit
+          docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml exec -T dagster python - <<'PY'
+          from tdw_control_plane.utils.get_clickhouse_client import get_clickhouse_client
+
+          rows = get_clickhouse_client().query("SELECT 1").result_rows
+          if rows != [(1,)]:
+              raise SystemExit(f"Unexpected ClickHouse smoke-test result: {rows}")
+          print(rows)
+          PY
           REMOTE
+
+          rm -f "$DEPLOY_ENV_FILE"

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           echo "APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "APP_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:latest" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:latest" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,9 +56,20 @@ jobs:
             ${{ env.APP_IMAGE }}
             ${{ env.APP_IMAGE_LATEST }}
 
+      - name: Build and push ClickHouse image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.clickhouse
+          push: true
+          tags: |
+            ${{ env.CLICKHOUSE_IMAGE }}
+            ${{ env.CLICKHOUSE_IMAGE_LATEST }}
+
       - name: Validate deploy compose file
         env:
           APP_IMAGE: ${{ env.APP_IMAGE }}
+          CLICKHOUSE_IMAGE: ${{ env.CLICKHOUSE_IMAGE }}
           CLICKHOUSE_PASSWORD: test-password
           HF_TOKEN: test-token
           HUGGINGFACE_DATASET_REPO_ID: ${{ env.HUGGINGFACE_DATASET_REPO_ID }}
@@ -89,7 +102,7 @@ jobs:
           HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
 
           ssh "$TDW_USER@$TDW_HOST" \
-            "APP_IMAGE='$APP_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
+            "APP_IMAGE='$APP_IMAGE' CLICKHOUSE_IMAGE='$CLICKHOUSE_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
           set -euo pipefail
 
           export DOCKER_CONFIG
@@ -102,12 +115,12 @@ jobs:
           GHCR_TOKEN="$(printf '%s' "$GHCR_TOKEN_B64" | base64 -d)"
           CLICKHOUSE_PASSWORD="$(printf '%s' "$CLICKHOUSE_PASSWORD_B64" | base64 -d)"
           HF_TOKEN="$(printf '%s' "$HF_TOKEN_B64" | base64 -d)"
-          export APP_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
+          export APP_IMAGE CLICKHOUSE_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
 
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
           cd "$DEPLOY_DIR"
           docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
-          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d
+          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d clickhouse dagster dagit
           docker image prune -f
           REMOTE

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -33,8 +33,6 @@ jobs:
         run: |
           echo "APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "APP_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:latest" >> "$GITHUB_ENV"
-          echo "CLICKHOUSE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:${GITHUB_SHA}" >> "$GITHUB_ENV"
-          echo "CLICKHOUSE_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:latest" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,21 +54,9 @@ jobs:
             ${{ env.APP_IMAGE }}
             ${{ env.APP_IMAGE_LATEST }}
 
-      - name: Build and push ClickHouse image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile.clickhouse
-          push: true
-          tags: |
-            ${{ env.CLICKHOUSE_IMAGE }}
-            ${{ env.CLICKHOUSE_IMAGE_LATEST }}
-
       - name: Validate deploy compose file
         env:
           APP_IMAGE: ${{ env.APP_IMAGE }}
-          CLICKHOUSE_IMAGE: ${{ env.CLICKHOUSE_IMAGE }}
-          CLICKHOUSE_PASSWORD: test-password
           HF_TOKEN: test-token
           HUGGINGFACE_DATASET_REPO_ID: ${{ env.HUGGINGFACE_DATASET_REPO_ID }}
         run: docker compose -f docker-compose.deploy.yml config > /tmp/docker-compose.deploy.rendered.yml
@@ -94,15 +80,13 @@ jobs:
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           GHCR_TOKEN_B64=$(printf '%s' "$GHCR_TOKEN" | base64 -w0)
-          CLICKHOUSE_PASSWORD_B64=$(printf '%s' "$CLICKHOUSE_PASSWORD" | base64 -w0)
           HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
 
           ssh "$TDW_USER@$TDW_HOST" \
-            "APP_IMAGE='$APP_IMAGE' CLICKHOUSE_IMAGE='$CLICKHOUSE_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
+            "APP_IMAGE='$APP_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
           set -euo pipefail
 
           export DOCKER_CONFIG
@@ -113,9 +97,8 @@ jobs:
           trap cleanup EXIT
 
           GHCR_TOKEN="$(printf '%s' "$GHCR_TOKEN_B64" | base64 -d)"
-          CLICKHOUSE_PASSWORD="$(printf '%s' "$CLICKHOUSE_PASSWORD_B64" | base64 -d)"
           HF_TOKEN="$(printf '%s' "$HF_TOKEN_B64" | base64 -d)"
-          export APP_IMAGE CLICKHOUSE_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
+          export APP_IMAGE HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
 
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Validate deploy compose file
         env:
           APP_IMAGE: ${{ env.APP_IMAGE }}
+          CLICKHOUSE_PASSWORD: test-password
           HF_TOKEN: test-token
           HUGGINGFACE_DATASET_REPO_ID: ${{ env.HUGGINGFACE_DATASET_REPO_ID }}
         run: docker compose -f docker-compose.deploy.yml config > /tmp/docker-compose.deploy.rendered.yml
@@ -80,13 +81,15 @@ jobs:
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           GHCR_TOKEN_B64=$(printf '%s' "$GHCR_TOKEN" | base64 -w0)
+          CLICKHOUSE_PASSWORD_B64=$(printf '%s' "$CLICKHOUSE_PASSWORD" | base64 -w0)
           HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
 
           ssh "$TDW_USER@$TDW_HOST" \
-            "APP_IMAGE='$APP_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
+            "APP_IMAGE='$APP_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
           set -euo pipefail
 
           export DOCKER_CONFIG
@@ -97,8 +100,9 @@ jobs:
           trap cleanup EXIT
 
           GHCR_TOKEN="$(printf '%s' "$GHCR_TOKEN_B64" | base64 -d)"
+          CLICKHOUSE_PASSWORD="$(printf '%s' "$CLICKHOUSE_PASSWORD_B64" | base64 -d)"
           HF_TOKEN="$(printf '%s' "$HF_TOKEN_B64" | base64 -d)"
-          export APP_IMAGE HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
+          export APP_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
 
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 

--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -1,0 +1,126 @@
+name: Deploy On Merge
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build Images And Deploy
+    runs-on: ubuntu-latest
+    env:
+      TDW_HOST: 37.27.112.167
+      TDW_USER: root
+      DEPLOY_DIR: /opt/tdw-control-plane
+      PROJECT_NAME: tdw-control-plane
+      HUGGINGFACE_DATASET_REPO_ID: vaquum/binance_btcusdt_1m_klines
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set image names
+        run: |
+          echo "APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "APP_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:latest" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:latest" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Dagster image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.APP_IMAGE }}
+            ${{ env.APP_IMAGE_LATEST }}
+
+      - name: Build and push ClickHouse image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.clickhouse
+          push: true
+          tags: |
+            ${{ env.CLICKHOUSE_IMAGE }}
+            ${{ env.CLICKHOUSE_IMAGE_LATEST }}
+
+      - name: Validate deploy compose file
+        env:
+          APP_IMAGE: ${{ env.APP_IMAGE }}
+          CLICKHOUSE_IMAGE: ${{ env.CLICKHOUSE_IMAGE }}
+          CLICKHOUSE_PASSWORD: test-password
+          HF_TOKEN: test-token
+          HUGGINGFACE_DATASET_REPO_ID: ${{ env.HUGGINGFACE_DATASET_REPO_ID }}
+        run: docker compose -f docker-compose.deploy.yml config > /tmp/docker-compose.deploy.rendered.yml
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TDW_PRIVATE_KEY }}
+
+      - name: Trust deployment host
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$TDW_HOST" >> ~/.ssh/known_hosts
+
+      - name: Upload deploy compose file
+        run: |
+          ssh "$TDW_USER@$TDW_HOST" "mkdir -p '$DEPLOY_DIR'"
+          scp docker-compose.deploy.yml "$TDW_USER@$TDW_HOST:$DEPLOY_DIR/docker-compose.deploy.yml"
+
+      - name: Deploy updated images
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          GHCR_TOKEN_B64=$(printf '%s' "$GHCR_TOKEN" | base64 -w0)
+          CLICKHOUSE_PASSWORD_B64=$(printf '%s' "$CLICKHOUSE_PASSWORD" | base64 -w0)
+          HF_TOKEN_B64=$(printf '%s' "$HF_TOKEN" | base64 -w0)
+
+          ssh "$TDW_USER@$TDW_HOST" \
+            "APP_IMAGE='$APP_IMAGE' CLICKHOUSE_IMAGE='$CLICKHOUSE_IMAGE' DEPLOY_DIR='$DEPLOY_DIR' PROJECT_NAME='$PROJECT_NAME' GHCR_USERNAME='$GHCR_USERNAME' GHCR_TOKEN_B64='$GHCR_TOKEN_B64' CLICKHOUSE_PASSWORD_B64='$CLICKHOUSE_PASSWORD_B64' HF_TOKEN_B64='$HF_TOKEN_B64' HUGGINGFACE_DATASET_REPO_ID='$HUGGINGFACE_DATASET_REPO_ID' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          export DOCKER_CONFIG
+          DOCKER_CONFIG="$(mktemp -d)"
+          cleanup() {
+            rm -rf "$DOCKER_CONFIG"
+          }
+          trap cleanup EXIT
+
+          GHCR_TOKEN="$(printf '%s' "$GHCR_TOKEN_B64" | base64 -d)"
+          CLICKHOUSE_PASSWORD="$(printf '%s' "$CLICKHOUSE_PASSWORD_B64" | base64 -d)"
+          HF_TOKEN="$(printf '%s' "$HF_TOKEN_B64" | base64 -d)"
+          export APP_IMAGE CLICKHOUSE_IMAGE CLICKHOUSE_PASSWORD HF_TOKEN HUGGINGFACE_DATASET_REPO_ID
+
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+          cd "$DEPLOY_DIR"
+          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml pull
+          docker-compose -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d
+          docker image prune -f
+          REMOTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && apt-get install -y git openssh-client libgomp1
 COPY docker-requirements.txt .
 RUN pip install --no-cache-dir -r docker-requirements.txt
 
-ENV DAGSTER_HOME=/opt/trades-warehouse
-ENV PYTHONPATH=/opt/trades-warehouse
-WORKDIR /opt/trades-warehouse
-COPY . /opt/trades-warehouse
+ENV DAGSTER_HOME=/opt/app
+ENV PYTHONPATH=/opt/app
+WORKDIR /opt/app
+COPY . /opt/app
 RUN mkdir -p /opt/dagster-instance && pip install --no-cache-dir .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.20
 
 ENV PIP_DEFAULT_TIMEOUT=100
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ COPY docker-requirements.txt .
 RUN pip install --no-cache-dir -r docker-requirements.txt
 
 ENV DAGSTER_HOME=/opt/trades-warehouse
+ENV PYTHONPATH=/opt/trades-warehouse
 WORKDIR /opt/trades-warehouse
 COPY . /opt/trades-warehouse
+RUN mkdir -p /opt/dagster-instance && pip install --no-cache-dir .

--- a/Dockerfile.clickhouse
+++ b/Dockerfile.clickhouse
@@ -1,3 +1,3 @@
-FROM clickhouse/clickhouse-server@sha256:8745843b17f92db1765025009772ec1d87dfdcaa95deabca6b802a66cb669d30
+FROM clickhouse/clickhouse-server:25.3.2.39@sha256:8745843b17f92db1765025009772ec1d87dfdcaa95deabca6b802a66cb669d30
 
 COPY clickhouse-config.xml /etc/clickhouse-server/config.d/clickhouse-config.xml

--- a/Dockerfile.clickhouse
+++ b/Dockerfile.clickhouse
@@ -1,3 +1,0 @@
-FROM clickhouse/clickhouse-server:latest
-
-COPY clickhouse-config.xml /etc/clickhouse-server/config.d/clickhouse-config.xml

--- a/Dockerfile.clickhouse
+++ b/Dockerfile.clickhouse
@@ -1,0 +1,3 @@
+FROM clickhouse/clickhouse-server@sha256:8745843b17f92db1765025009772ec1d87dfdcaa95deabca6b802a66cb669d30
+
+COPY clickhouse-config.xml /etc/clickhouse-server/config.d/clickhouse-config.xml

--- a/Dockerfile.clickhouse
+++ b/Dockerfile.clickhouse
@@ -1,0 +1,3 @@
+FROM clickhouse/clickhouse-server:latest
+
+COPY clickhouse-config.xml /etc/clickhouse-server/config.d/clickhouse-config.xml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Control plane for `trade-warehouse` (tdw).
 
 ## Docs
 
-`main` deploys the Dagster application services automatically through GitHub Actions.
-The workflow builds the app image, pushes it to GitHub Container Registry, and deploys
-`dagster` plus `dagit` to the remote host over SSH with runtime secrets injected from
-GitHub repo secrets. ClickHouse remains on its existing production path.
+`main` deploys the repo-defined production services automatically through GitHub Actions.
+The workflow builds the Dagster and ClickHouse images, pushes them to GitHub Container
+Registry, and deploys `clickhouse`, `dagster`, and `dagit` to the remote host over SSH
+with runtime secrets injected from GitHub repo secrets.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Control plane for `trade-warehouse` (tdw).
 
 ## Docs
 
-`main` deploys automatically through GitHub Actions. The workflow builds the Dagster
-and ClickHouse images, pushes them to GitHub Container Registry, and deploys them
-to the remote host over SSH with runtime secrets injected from GitHub repo secrets.
+`main` deploys the Dagster application services automatically through GitHub Actions.
+The workflow builds the app image, pushes it to GitHub Container Registry, and deploys
+`dagster` plus `dagit` to the remote host over SSH with runtime secrets injected from
+GitHub repo secrets. ClickHouse remains on its existing production path.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,6 @@ Control plane for `trade-warehouse` (tdw).
 
 ## Docs
 
-No documentation.
+`main` deploys automatically through GitHub Actions. The workflow builds the Dagster
+and ClickHouse images, pushes them to GitHub Container Registry, and deploys them
+to the remote host over SSH with runtime secrets injected from GitHub repo secrets.

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -53,4 +53,8 @@ services:
 
 volumes:
   clickhouse-data:
+    name: tdw-control-plane_clickhouse-data
+    external: true
   dagster-instance:
+    name: tdw-control-plane_dagster-instance
+    external: true

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,4 +1,22 @@
 services:
+  clickhouse:
+    image: ${CLICKHOUSE_IMAGE}
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    environment:
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
   dagit:
     image: ${APP_IMAGE}
     ports:
@@ -11,6 +29,9 @@ services:
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:
       - dagster-instance:/opt/dagster-instance
+    depends_on:
+      clickhouse:
+        condition: service_healthy
     command: dagit -h 0.0.0.0 -p 3000
     restart: unless-stopped
 
@@ -24,8 +45,12 @@ services:
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:
       - dagster-instance:/opt/dagster-instance
+    depends_on:
+      clickhouse:
+        condition: service_healthy
     command: dagster-daemon run
     restart: unless-stopped
 
 volumes:
+  clickhouse-data:
   dagster-instance:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,54 @@
+services:
+  clickhouse:
+    image: ${CLICKHOUSE_IMAGE}
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    environment:
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  dagit:
+    image: ${APP_IMAGE}
+    ports:
+      - "4000:3000"
+    environment:
+      - DAGSTER_HOME=/opt/trades-warehouse
+      - PYTHONPATH=/opt/trades-warehouse
+      - HF_TOKEN=${HF_TOKEN}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
+    volumes:
+      - dagster-instance:/opt/dagster-instance
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    command: dagit -h 0.0.0.0 -p 3000
+    restart: unless-stopped
+
+  dagster:
+    image: ${APP_IMAGE}
+    environment:
+      - DAGSTER_HOME=/opt/trades-warehouse
+      - PYTHONPATH=/opt/trades-warehouse
+      - HF_TOKEN=${HF_TOKEN}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
+    volumes:
+      - dagster-instance:/opt/dagster-instance
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    command: dagster-daemon run
+    restart: unless-stopped
+
+volumes:
+  clickhouse-data:
+  dagster-instance:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,54 +1,29 @@
 services:
-  clickhouse:
-    image: ${CLICKHOUSE_IMAGE}
-    ports:
-      - "8123:8123"
-      - "9000:9000"
-    volumes:
-      - clickhouse-data:/var/lib/clickhouse
-    environment:
-      - CLICKHOUSE_USER=default
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
-    restart: unless-stopped
-
   dagit:
     image: ${APP_IMAGE}
     ports:
       - "4000:3000"
     environment:
-      - DAGSTER_HOME=/opt/trades-warehouse
-      - PYTHONPATH=/opt/trades-warehouse
+      - DAGSTER_HOME=/opt/app
+      - PYTHONPATH=/opt/app
       - HF_TOKEN=${HF_TOKEN}
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:
       - dagster-instance:/opt/dagster-instance
-    depends_on:
-      clickhouse:
-        condition: service_healthy
     command: dagit -h 0.0.0.0 -p 3000
     restart: unless-stopped
 
   dagster:
     image: ${APP_IMAGE}
     environment:
-      - DAGSTER_HOME=/opt/trades-warehouse
-      - PYTHONPATH=/opt/trades-warehouse
+      - DAGSTER_HOME=/opt/app
+      - PYTHONPATH=/opt/app
       - HF_TOKEN=${HF_TOKEN}
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:
       - dagster-instance:/opt/dagster-instance
-    depends_on:
-      clickhouse:
-        condition: service_healthy
     command: dagster-daemon run
     restart: unless-stopped
 
 volumes:
-  clickhouse-data:
   dagster-instance:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,14 +1,14 @@
 services:
   clickhouse:
-    image: ${CLICKHOUSE_IMAGE}
+    image: ${CLICKHOUSE_IMAGE:?CLICKHOUSE_IMAGE is required}
     ports:
-      - "8123:8123"
-      - "9000:9000"
+      - "127.0.0.1:8123:8123"
+      - "127.0.0.1:9000:9000"
     volumes:
       - clickhouse-data:/var/lib/clickhouse
     environment:
       - CLICKHOUSE_USER=default
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8123/ping"]
       interval: 5s
@@ -18,15 +18,15 @@ services:
     restart: unless-stopped
 
   dagit:
-    image: ${APP_IMAGE}
+    image: ${APP_IMAGE:?APP_IMAGE is required}
     ports:
       - "4000:3000"
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
-      - HF_TOKEN=${HF_TOKEN}
-      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      - HF_TOKEN=${HF_TOKEN:?HF_TOKEN is required}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID:?HUGGINGFACE_DATASET_REPO_ID is required}
     volumes:
       - dagster-instance:/opt/dagster-instance
     depends_on:
@@ -36,13 +36,13 @@ services:
     restart: unless-stopped
 
   dagster:
-    image: ${APP_IMAGE}
+    image: ${APP_IMAGE:?APP_IMAGE is required}
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
-      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
-      - HF_TOKEN=${HF_TOKEN}
-      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      - HF_TOKEN=${HF_TOKEN:?HF_TOKEN is required}
+      - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID:?HUGGINGFACE_DATASET_REPO_ID is required}
     volumes:
       - dagster-instance:/opt/dagster-instance
     depends_on:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
       - HF_TOKEN=${HF_TOKEN}
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:
@@ -18,6 +19,7 @@ services:
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
       - HF_TOKEN=${HF_TOKEN}
       - HUGGINGFACE_DATASET_REPO_ID=${HUGGINGFACE_DATASET_REPO_ID}
     volumes:

--- a/tdw_control_plane/assets/README.md
+++ b/tdw_control_plane/assets/README.md
@@ -5,7 +5,7 @@
 3) Follow the instructions at the head of `tdw_control_plane/definitions.py`
 4) Make Pull Request with the changes committed
 
-NOTE: Changes merged to `main` deploy the Dagster application services automatically
-through GitHub Actions. The workflow builds the app image, pushes it to GitHub Container
-Registry, and deploys `dagster` plus `dagit` to the remote host over SSH without relying
-on a server-side `.env` file.
+NOTE: Changes merged to `main` deploy the repo-defined production services automatically
+through GitHub Actions. The workflow builds the Dagster and ClickHouse images, pushes
+them to GitHub Container Registry, and deploys `clickhouse`, `dagster`, and `dagit`
+to the remote host over SSH without relying on a server-side `.env` file.

--- a/tdw_control_plane/assets/README.md
+++ b/tdw_control_plane/assets/README.md
@@ -5,4 +5,6 @@
 3) Follow the instructions at the head of `tdw_control_plane/definitions.py`
 4) Make Pull Request with the changes committed
 
-NOTE: For the changes to take effect in `tdw`, user `root` must run the command `@deploy` on the server. 
+NOTE: Changes merged to `main` deploy automatically through GitHub Actions. The workflow
+builds the images, pushes them to GitHub Container Registry, and deploys them to the
+remote host over SSH without relying on a server-side `.env` file.

--- a/tdw_control_plane/assets/README.md
+++ b/tdw_control_plane/assets/README.md
@@ -5,6 +5,7 @@
 3) Follow the instructions at the head of `tdw_control_plane/definitions.py`
 4) Make Pull Request with the changes committed
 
-NOTE: Changes merged to `main` deploy automatically through GitHub Actions. The workflow
-builds the images, pushes them to GitHub Container Registry, and deploys them to the
-remote host over SSH without relying on a server-side `.env` file.
+NOTE: Changes merged to `main` deploy the Dagster application services automatically
+through GitHub Actions. The workflow builds the app image, pushes it to GitHub Container
+Registry, and deploys `dagster` plus `dagit` to the remote host over SSH without relying
+on a server-side `.env` file.


### PR DESCRIPTION
## Summary
- move the full repo-defined TDW stack (`clickhouse`, `dagster`, `dagit`) to a GitHub-driven image deployment path
- build and push the app and ClickHouse images from GitHub Actions on merge to `main`
- deploy the stack over SSH with `CLICKHOUSE_PASSWORD` and `HF_TOKEN` injected from GitHub repo secrets instead of relying on a server-side `.env`

## Red Lines
- Do not create a second stack. The deploy must target the existing Compose project name: `tdw-control-plane`.
- Do not rename services. The deploy must keep `clickhouse`, `dagster`, and `dagit` as the service names.
- Do not rename or recreate persistent volumes. The deploy must keep `tdw-control-plane_clickhouse-data` and `tdw-control-plane_dagster-instance`.
- Do not change the network identity. The deploy must keep `tdw-control-plane_default`.
- Do not depend on a server-side `.env` for `CLICKHOUSE_PASSWORD` or `HF_TOKEN`.
- Do not introduce a new kind of disruption relative to the current `@deploy`. Today `@deploy` already recreates `clickhouse`, `dagster`, and `dagit` in place.

## Safety Notes
- `Dockerfile.clickhouse` is pinned to the live production ClickHouse version and digest: `25.3.2.39@sha256:...`.
- `Dockerfile` is pinned to Python `3.10.20` to avoid silent interpreter drift.
- deploy target details now come from GitHub repo variables (`TDW_HOST`, `TDW_USER`, `DEPLOY_DIR`, `TDW_PROJECT_NAME`, `TDW_KNOWN_HOSTS`, `HUGGINGFACE_DATASET_REPO_ID`) and are validated at workflow start
- the workflow uses a pinned host key instead of `ssh-keyscan` at deploy time
- remote secrets are passed through a temporary `--env-file` with `chmod 600` and cleanup rather than inline SSH environment arguments
- the workflow deploys the repo-defined services in place with `docker compose --env-file "$SECRETS_FILE" -p "$PROJECT_NAME" -f docker-compose.deploy.yml up -d --wait clickhouse dagster dagit`
- a post-deploy smoke test runs `SELECT 1` from the `dagster` container against ClickHouse before the workflow exits
- this preserves the existing volume-backed data, but it still recreates the three containers in place, just like the current `@deploy` model

## Testing
- `docker compose -f docker-compose.deploy.yml config` with dummy env
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy_on_merge.yml"); puts "workflow yaml ok"'`
- remote `docker-compose -p tdw-control-plane -f /tmp/docker-compose.deploy.yml config` on `37.27.112.167` with injected env