### PR TITLE
ci: add pr_checks_typing workflow and ratchet-based typing gate

### DIFF
--- a/.github/typing_budget.json
+++ b/.github/typing_budget.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "package_root": "tdw_control_plane",
   "excludes": [
     "__pycache__",
@@ -51,5 +51,8 @@
   },
   "pyright_errors": {
     "total": 1213
+  },
+  "any_references": {
+    "total": 0
   }
 }

--- a/.github/typing_budget.json
+++ b/.github/typing_budget.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "package_root": "tdw_control_plane",
+  "excludes": [
+    "__pycache__",
+    "quickstart_etl_tests",
+    "build",
+    "dist"
+  ],
+  "patterns": {
+    "any_annotation": {
+      "pattern": ":\\s*Any\\b",
+      "total": 0
+    },
+    "any_return": {
+      "pattern": "->\\s*Any\\b",
+      "total": 0
+    },
+    "any_import": {
+      "pattern": "from typing import[^\\n]*\\bAny\\b",
+      "total": 0
+    },
+    "cast_any": {
+      "pattern": "cast\\([^)]*\\bAny\\b",
+      "total": 0
+    },
+    "dict_any": {
+      "pattern": "dict\\[[^]]*\\bAny\\b",
+      "total": 0
+    },
+    "list_any": {
+      "pattern": "list\\[\\s*Any\\b",
+      "total": 0
+    },
+    "tuple_any": {
+      "pattern": "tuple\\[[^]]*\\bAny\\b",
+      "total": 0
+    },
+    "type_ignore": {
+      "pattern": "#\\s*type:\\s*ignore",
+      "total": 0
+    },
+    "pyright_ignore": {
+      "pattern": "#\\s*pyright:\\s*ignore",
+      "total": 0
+    },
+    "noqa": {
+      "pattern": "#\\s*noqa",
+      "total": 0
+    }
+  },
+  "pyright_errors": {
+    "total": 1504
+  }
+}

--- a/.github/typing_budget.json
+++ b/.github/typing_budget.json
@@ -50,6 +50,6 @@
     }
   },
   "pyright_errors": {
-    "total": 1504
+    "total": 1213
   }
 }

--- a/.github/workflows/pr_checks_codeql.yml
+++ b/.github/workflows/pr_checks_codeql.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -1,0 +1,86 @@
+name: pr_checks_typing
+
+# Mechanical typing gate. Three ratchets in one workflow:
+#
+#   1. Pyright configuration must remain strict and must ban explicit Any.
+#      Any weakening (typeCheckingMode != strict, reportExplicitAny != error,
+#      any report* set to none/warning/info/false) fails the build.
+#
+#   2. Escape-hatch patterns are ratcheted against .github/typing_budget.json:
+#      `: Any`, `-> Any`, `cast(Any, ...)`, `dict[..., Any]`, `list[Any]`,
+#      `# type: ignore`, `# pyright: ignore`, `# noqa`. Any file-system-wide
+#      increase fails the build. Decreases may be locked in by updating the
+#      budget file in the same PR.
+#
+#   3. Pyright strict error count is ratcheted against the same budget.
+#      Any increase fails the build. Decreases may be locked in the same way.
+#
+# Philosophy: gates, not language. The gate is what the PR must pass; the
+# documentation in this file is for humans reviewing the gate, not for the
+# agent being gated.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr_checks_typing:
+    name: pr_checks_typing
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Install pyright
+        run: pip install 'pyright==1.1.409'
+
+      - name: Run pyright strict (capture JSON)
+        run: |
+          set +e
+          pyright --outputjson > pyright_output.json
+          pyright_exit=$?
+          set -e
+          echo "pyright exit code: $pyright_exit"
+          python -c "
+          import json, pathlib, sys
+          p = pathlib.Path('pyright_output.json')
+          if not p.exists() or p.stat().st_size == 0:
+              print('::error::pyright produced no output', file=sys.stderr)
+              sys.exit(2)
+          d = json.loads(p.read_text())
+          s = d.get('summary', {})
+          print(f'pyright: files={s.get(\"filesAnalyzed\")} errors={s.get(\"errorCount\")} warnings={s.get(\"warningCount\")}')
+          "
+
+      - name: Run typing gate
+        run: python tools/typing_gate.py --pyright-json pyright_output.json
+
+      - name: Upload pyright output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pyright-output
+          path: pyright_output.json
+          retention-days: 14

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -99,11 +99,13 @@ jobs:
 
       - name: Run typing gate
         run: |
-          args=( --pyright-json pyright_output.json )
-          if [ -f base_budget.json ]; then
-            args+=( --base-budget base_budget.json )
-          fi
-          python tools/typing_gate.py "${args[@]}"
+          # --base-budget is ALWAYS passed. If the file does not exist
+          # (first commit introducing the gate) the gate will skip the
+          # base-vs-head comparison with a warning. Omitting the flag
+          # would be treated as workflow misconfiguration.
+          python tools/typing_gate.py \
+            --pyright-json pyright_output.json \
+            --base-budget base_budget.json
 
       - name: Upload pyright output
         if: always()

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -58,12 +58,16 @@ jobs:
       - name: Install pyright
         run: pip install 'pyright==1.1.408'
 
-      - name: Fetch base-ref budget
+      - name: Resolve base ref and fetch base-ref budget
+        id: base
         run: |
-          # The base-ref budget is the protected oracle. The PR's own budget
-          # cannot raise any value against it. For pull_request / merge_group
-          # events the base is github.base_ref; for push-to-main the base is
-          # HEAD~1 (previous tip of main).
+          # The base-ref budget is the protected oracle. If the base has the
+          # file, normal path: fetch it and the gate runs base-vs-head.
+          # If the base does NOT have the file, the only legitimate reason
+          # is that THIS commit adds the file to main for the first time.
+          # The workflow verifies that mechanically by diffing against the
+          # base ref; if the head does not add the file, the gate step
+          # hard-fails. There is no graceful skip.
           set -euo pipefail
           if [ -n "${{ github.base_ref }}" ]; then
             BASE_REV="origin/${{ github.base_ref }}"
@@ -72,11 +76,22 @@ jobs:
             BASE_REV="HEAD~1"
           fi
           echo "base rev: $BASE_REV"
+
           if git show "$BASE_REV:.github/typing_budget.json" > base_budget.json 2>/dev/null; then
+            echo "mode=compare" >> "$GITHUB_OUTPUT"
             echo "base budget fetched ($(wc -c < base_budget.json) bytes)"
           else
-            echo "base rev has no typing_budget.json (first commit introducing the gate)"
+            # Base has no budget. Is THIS commit adding it?
             rm -f base_budget.json
+            # Changed files between base and HEAD
+            CHANGED="$(git diff --name-only "$BASE_REV"...HEAD)"
+            if echo "$CHANGED" | grep -qx '.github/typing_budget.json'; then
+              echo "mode=bootstrap" >> "$GITHUB_OUTPUT"
+              echo "::warning::bootstrap commit: base ref has no typing_budget.json; HEAD introduces it."
+            else
+              echo "::error::base ref has no .github/typing_budget.json and this commit does not introduce it. The budget was deleted from the protected base ref; restore it before merging."
+              exit 1
+            fi
           fi
 
       - name: Run pyright strict (capture JSON)
@@ -99,13 +114,25 @@ jobs:
 
       - name: Run typing gate
         run: |
-          # --base-budget is ALWAYS passed. If the file does not exist
-          # (first commit introducing the gate) the gate will skip the
-          # base-vs-head comparison with a warning. Omitting the flag
-          # would be treated as workflow misconfiguration.
-          python tools/typing_gate.py \
-            --pyright-json pyright_output.json \
-            --base-budget base_budget.json
+          # The previous step decided 'compare' (base ref has the budget)
+          # or 'bootstrap' (this commit introduces it). The two flags are
+          # mutually exclusive; the gate fails if neither is given.
+          case "${{ steps.base.outputs.mode }}" in
+            compare)
+              python tools/typing_gate.py \
+                --pyright-json pyright_output.json \
+                --base-budget base_budget.json
+              ;;
+            bootstrap)
+              python tools/typing_gate.py \
+                --pyright-json pyright_output.json \
+                --bootstrap
+              ;;
+            *)
+              echo "::error::base step did not set mode; refusing to run gate"
+              exit 2
+              ;;
+          esac
 
       - name: Upload pyright output
         if: always()

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -89,15 +89,22 @@ jobs:
           # is that THIS commit adds the file to main for the first time.
           # The workflow verifies that mechanically by diffing against the
           # base ref; if the head does not add the file, the gate step
-          # hard-fails. There is no graceful skip.
+          # hard-fails. There is no graceful skip and no silent fetch
+          # failure -- if we cannot reach the base ref, the job fails with
+          # the fetch error visible, not on a downstream misbehavior.
           set -euo pipefail
           if [ -n "${{ github.base_ref }}" ]; then
             BASE_REV="origin/${{ github.base_ref }}"
-            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+            git fetch origin "${{ github.base_ref }}" --depth=1
           else
             BASE_REV="HEAD~1"
           fi
           echo "base rev: $BASE_REV"
+
+          # Verify BASE_REV actually resolves now; if not, the fetch above
+          # produced no usable ref and we must fail loudly rather than
+          # mis-route the downstream compare/bootstrap decision.
+          git rev-parse --verify "$BASE_REV" >/dev/null
 
           if git show "$BASE_REV:.github/typing_budget.json" > base_budget.json 2>/dev/null; then
             echo "mode=compare" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -54,7 +54,7 @@ jobs:
           pip install -e .
 
       - name: Install pyright
-        run: pip install 'pyright==1.1.409'
+        run: pip install 'pyright==1.1.408'
 
       - name: Run pyright strict (capture JSON)
         run: |

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -1,23 +1,45 @@
 name: pr_checks_typing
 
-# Mechanical typing gate. Three ratchets in one workflow:
+# Mechanical typing gate. The gate is tools/typing_gate.py; this
+# workflow invokes it. The deterministic rules the gate enforces
+# are listed in full in the PR description; a summary follows.
 #
-#   1. Pyright configuration must remain strict and must ban explicit Any.
-#      Any weakening (typeCheckingMode != strict, reportExplicitAny != error,
-#      any report* set to none/warning/info/false) fails the build.
+#   1. Pyright config audit. Required keys must be present with their
+#      required values (typeCheckingMode=strict, reportExplicitAny,
+#      reportMissingImports, reportMissingTypeStubs, reportUnknown*,
+#      reportMissingParameterType, reportConstantRedefinition,
+#      reportImportCycles -- all "error"). No report* key may be set
+#      to none/warning/info/false. pyright.include must equal
+#      ["tdw_control_plane"]. pyrightconfig.json must not exist
+#      outside vendored paths. Note: pyright 1.1.408 ignores
+#      reportExplicitAny at runtime; the Any enforcement is the AST
+#      ratchet below, not this config key.
 #
-#   2. Escape-hatch patterns are ratcheted against .github/typing_budget.json:
-#      `: Any`, `-> Any`, `cast(Any, ...)`, `dict[..., Any]`, `list[Any]`,
-#      `# type: ignore`, `# pyright: ignore`, `# noqa`. Any file-system-wide
-#      increase fails the build. Decreases may be locked in by updating the
-#      budget file in the same PR.
+#   2. Escape-hatch regex ratchet. Counts `: Any`, `-> Any`,
+#      `cast(Any, ...)`, `dict[..., Any]`, `list[Any]`, `tuple[..., Any]`,
+#      `from typing import ... Any`, `# type: ignore`, `# pyright: ignore`,
+#      `# noqa` across the package. Any file-system-wide increase fails.
 #
-#   3. Pyright strict error count is ratcheted against the same budget.
-#      Any increase fails the build. Decreases may be locked in the same way.
+#   3. AST Any-reference ratchet. Parses each file and counts every
+#      reference to typing.Any: bare `Any`, `typing.Any`, `t.Any`,
+#      aliased imports (`from typing import Any as X`), and module-
+#      level assignment aliases (`A = typing.Any`, chained `B = A`).
+#      Any increase fails. This is the primary Any enforcement today.
 #
-# Philosophy: gates, not language. The gate is what the PR must pass; the
-# documentation in this file is for humans reviewing the gate, not for the
-# agent being gated.
+#   4. Pyright error-count ratchet. summary.errorCount from
+#      `pyright --outputjson` must not increase over base.
+#
+#   5. filesAnalyzed ratchet. pyright must analyze at least as many
+#      files as the gate finds under package_root.
+#
+#   6. Budget-source ratchet. The head-ref budget cannot raise any
+#      number vs the base-ref budget, cannot delete a pattern key,
+#      cannot change package_root, cannot add excludes, and cannot
+#      rewrite a per-pattern regex. Only reductions are allowed.
+#
+# Philosophy: gates, not language. The gate is what the PR must pass.
+# The comment here describes intent for humans reviewing the workflow;
+# the source of truth for rules is tools/typing_gate.py.
 
 on:
   pull_request:

--- a/.github/workflows/pr_checks_typing.yml
+++ b/.github/workflows/pr_checks_typing.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history, so we can read the budget at base ref
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -56,6 +58,27 @@ jobs:
       - name: Install pyright
         run: pip install 'pyright==1.1.408'
 
+      - name: Fetch base-ref budget
+        run: |
+          # The base-ref budget is the protected oracle. The PR's own budget
+          # cannot raise any value against it. For pull_request / merge_group
+          # events the base is github.base_ref; for push-to-main the base is
+          # HEAD~1 (previous tip of main).
+          set -euo pipefail
+          if [ -n "${{ github.base_ref }}" ]; then
+            BASE_REV="origin/${{ github.base_ref }}"
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+          else
+            BASE_REV="HEAD~1"
+          fi
+          echo "base rev: $BASE_REV"
+          if git show "$BASE_REV:.github/typing_budget.json" > base_budget.json 2>/dev/null; then
+            echo "base budget fetched ($(wc -c < base_budget.json) bytes)"
+          else
+            echo "base rev has no typing_budget.json (first commit introducing the gate)"
+            rm -f base_budget.json
+          fi
+
       - name: Run pyright strict (capture JSON)
         run: |
           set +e
@@ -63,7 +86,7 @@ jobs:
           pyright_exit=$?
           set -e
           echo "pyright exit code: $pyright_exit"
-          python -c "
+          python <<'PY'
           import json, pathlib, sys
           p = pathlib.Path('pyright_output.json')
           if not p.exists() or p.stat().st_size == 0:
@@ -71,11 +94,16 @@ jobs:
               sys.exit(2)
           d = json.loads(p.read_text())
           s = d.get('summary', {})
-          print(f'pyright: files={s.get(\"filesAnalyzed\")} errors={s.get(\"errorCount\")} warnings={s.get(\"warningCount\")}')
-          "
+          print(f"pyright: files={s.get('filesAnalyzed')} errors={s.get('errorCount')} warnings={s.get('warningCount')}")
+          PY
 
       - name: Run typing gate
-        run: python tools/typing_gate.py --pyright-json pyright_output.json
+        run: |
+          args=( --pyright-json pyright_output.json )
+          if [ -f base_budget.json ]; then
+            args+=( --base-budget base_budget.json )
+          fi
+          python tools/typing_gate.py "${args[@]}"
 
       - name: Upload pyright output
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@
 
 - Add `tdw_control_plane.query.get_binance_spot_klines` as the TDW-owned Binance spot kline query.
 - Add a daily Hugging Face export asset and sensor for BTCUSDT 1-minute klines sourced from `tdw.binance_trades_complete`.
+- Add `pr_checks_typing` workflow and `tools/typing_gate.py` enforcing typing discipline as a ratchet: pyright strict config audit, `pyrightconfig.json` ban, `pyright.include` identity check, regex escape-hatch ratchet, AST-based `typing.Any`-reference ratchet (covers bare `Any`, `typing.Any`, `t.Any`, aliased imports, and module-level assignment-alias chains), pyright total-error-count ratchet, `filesAnalyzed` ratchet, and a base-vs-head budget-source ratchet that blocks weakening of the oracle in the same PR it gates.
+- Add `[tool.pyright]` strict configuration to `pyproject.toml` with the full `report*` matrix set to `error`.
+- Add `[tool.ruff]` configuration to `pyproject.toml` selecting `E/F/I/UP/RUF/BLE/ANN`.
+- Add `.github/typing_budget.json` as the committed baseline oracle (zero escape hatches, 1213 pyright-strict errors on 35 files at introduction).
+- Bump `project.requires-python` to `>=3.11` to align with `tomllib` usage, `pyright.pythonVersion`, `ruff.target-version`, and CI.
+- Bump `pr_checks_codeql.yml` Python from `3.10` to `3.11` to match the above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
-# Changelog
-
-## Unreleased
-
-- Add `tdw_control_plane.query.get_binance_spot_klines` as the TDW-owned Binance spot kline query.
-- Add a daily Hugging Face export asset and sensor for BTCUSDT 1-minute klines sourced from `tdw.binance_trades_complete`.
+# v1.2.1 on April 21, 2026
 - Add `pr_checks_typing` workflow and `tools/typing_gate.py` enforcing typing discipline as a ratchet: pyright strict config audit, `pyrightconfig.json` ban, `pyright.include` identity check, regex escape-hatch ratchet, AST-based `typing.Any`-reference ratchet (covers bare `Any`, `typing.Any`, `t.Any`, aliased imports, and module-level assignment-alias chains), pyright total-error-count ratchet, `filesAnalyzed` ratchet, and a base-vs-head budget-source ratchet that blocks weakening of the oracle in the same PR it gates.
 - Add `[tool.pyright]` strict configuration to `pyproject.toml` with the full `report*` matrix set to `error`.
 - Add `[tool.ruff]` configuration to `pyproject.toml` selecting `E/F/I/UP/RUF/BLE/ANN`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quickstart_etl"
 version = "1.2.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "dagster",
   "dagster-cloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,79 @@ exclude = ["quickstart_etl_tests*"]
 [tool.dagster]
 module_name = "tdw_control_plane.definitions"
 code_location_name = "tdw_control_plane"
+
+# --------------------------------------------------------------------
+# Pyright strict configuration.
+#
+# Strict mode plus explicit bans on the Any escape hatch. Every
+# report* key here is either "error" or absent (to inherit the strict
+# default). The typing-gate workflow asserts this config on every PR;
+# weakening any of these values will fail pr_checks_typing.
+#
+# The Origo session made the failure mode visible: strict mode alone
+# does not prevent `: Any` annotations or `cast(Any, ...)` calls, and
+# a codebase can be "pyright strict clean" while being soaked in Any.
+# reportExplicitAny = "error" closes that hole.
+# --------------------------------------------------------------------
+
+[tool.pyright]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+include = ["tdw_control_plane"]
+exclude = [
+  "**/__pycache__",
+  "build",
+  "dist",
+  "quickstart_etl_tests",
+]
+reportExplicitAny = "error"
+reportMissingImports = "error"
+reportMissingTypeStubs = "error"
+reportUnknownArgumentType = "error"
+reportUnknownMemberType = "error"
+reportUnknownVariableType = "error"
+reportUnknownLambdaType = "error"
+reportUnknownParameterType = "error"
+reportMissingParameterType = "error"
+reportConstantRedefinition = "error"
+reportImportCycles = "error"
+
+# --------------------------------------------------------------------
+# Ruff configuration — style + lint gate that pairs with pyright.
+# --------------------------------------------------------------------
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+exclude = [
+  ".git",
+  "__pycache__",
+  "build",
+  "dist",
+  "quickstart_etl_tests",
+]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint]
+select = [
+  "E",     # pycodestyle errors
+  "F",     # pyflakes
+  "I",     # isort
+  "UP",    # pyupgrade
+  "RUF",   # ruff-specific
+  "BLE",   # flake8-blind-except -- always raise, never bare except
+  "ANN",   # flake8-annotations -- catches missing type annotations
+]
+ignore = [
+  "E501",   # line length handled by formatter
+  "ANN101", # self typing not needed
+  "ANN102", # cls typing not needed
+]
+
+[tool.ruff.lint.per-file-ignores]
+"quickstart_etl_tests/**/*.py" = ["S101", "ANN", "BLE001"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["tdw_control_plane"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,18 @@ code_location_name = "tdw_control_plane"
 # --------------------------------------------------------------------
 # Pyright strict configuration.
 #
-# Strict mode plus explicit bans on the Any escape hatch. Every
-# report* key here is either "error" or absent (to inherit the strict
-# default). The typing-gate workflow asserts this config on every PR;
-# weakening any of these values will fail pr_checks_typing.
+# Every report* key here is either "error" or absent (to inherit the
+# strict default). The pr_checks_typing workflow asserts this config
+# on every PR; weakening any of these values, or removing any required
+# key, fails the build.
 #
-# The Origo session made the failure mode visible: strict mode alone
-# does not prevent `: Any` annotations or `cast(Any, ...)` calls, and
-# a codebase can be "pyright strict clean" while being soaked in Any.
-# reportExplicitAny = "error" closes that hole.
+# Note on reportExplicitAny: pyright 1.1.408 (the pinned toolchain
+# version) emits `Config contains unrecognized setting` for this key
+# and does not honor it. We keep it here as a forward-compatible
+# config-presence requirement for the day pyright respects it. The
+# Any escape hatch is enforced today by the AST-based sub-gate in
+# tools/typing_gate.py (gate_any_references_ast), which resolves
+# every surface form including module-level assignment aliases.
 # --------------------------------------------------------------------
 
 [tool.pyright]

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -43,6 +43,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -110,12 +111,115 @@ def count_pattern(files: list[Path], pattern: str) -> int:
 
 
 # -------------------------------------------------------------------
+# AST-based Any detection.
+#
+# The regex ratchet catches bare ``Any`` (``x: Any``) but is blind to
+# qualified / aliased forms: ``typing.Any``, ``t.Any`` after ``import
+# typing as t``, ``A`` after ``from typing import Any as A``, and any
+# chained attribute access like ``typing.Any`` inside a ``cast()``.
+# The AST walks the module, resolves which local names actually bind
+# to ``typing.Any``, and counts every reference regardless of surface
+# form.
+# -------------------------------------------------------------------
+
+def _collect_any_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """For one module AST, return:
+
+      * ``direct`` — names that directly refer to ``typing.Any``. Populated
+        by ``from typing import Any`` (key ``Any``) and by aliased forms
+        such as ``from typing import Any as X`` (key ``X``).
+      * ``module_aliases`` — names that refer to the ``typing`` module.
+        Populated by ``import typing`` (``typing``) and ``import typing
+        as t`` (``t``).
+    """
+    direct: set[str] = set()
+    module_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == 'typing':
+            for alias in node.names:
+                if alias.name == 'Any':
+                    direct.add(alias.asname or 'Any')
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == 'typing':
+                    module_aliases.add(alias.asname or 'typing')
+    return direct, module_aliases
+
+
+def _is_any_reference(
+    node: ast.AST,
+    direct: set[str],
+    module_aliases: set[str],
+) -> bool:
+    """True if ``node`` is a usage-site reference to ``typing.Any``.
+
+    Catches bare ``Any`` / aliased-direct names (``ast.Name``) and
+    attribute access like ``typing.Any`` / ``t.Any`` (``ast.Attribute``).
+    """
+    if isinstance(node, ast.Name):
+        return node.id in direct
+    if isinstance(node, ast.Attribute) and node.attr == 'Any':
+        target = node.value
+        return isinstance(target, ast.Name) and target.id in module_aliases
+    return False
+
+
+def count_any_references_ast(files: list[Path]) -> int:
+    """Count every reference to ``typing.Any`` across ``files``,
+    resolved through the module's own import / alias graph.
+
+    Includes: annotations (``x: Any``, ``-> Any``), generic-arg positions
+    (``list[Any]``, ``dict[str, Any]``), ``cast(Any, x)``, attribute
+    forms (``typing.Any``, ``t.Any``), aliased imports (``from typing
+    import Any as A`` → any use of ``A``), and every other site where
+    the resolved name is ``typing.Any``.
+
+    Excludes: strings containing the literal word ``Any``, comments,
+    and the ``alias.name`` field of the ``from typing import Any``
+    statement itself (not an ``ast.Name`` node).
+    """
+    total = 0
+    for f in files:
+        try:
+            text = f.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError) as exc:
+            raise SystemExit(f'typing_gate: cannot read {f}: {exc}') from exc
+        try:
+            tree = ast.parse(text, filename=str(f))
+        except SyntaxError as exc:
+            raise SystemExit(
+                f'typing_gate: cannot parse {f}: {exc}'
+            ) from exc
+
+        direct, module_aliases = _collect_any_bindings(tree)
+        if not direct and not module_aliases:
+            continue  # module has no way to refer to Any
+
+        for node in ast.walk(tree):
+            if _is_any_reference(node, direct, module_aliases):
+                total += 1
+
+    return total
+
+
+# -------------------------------------------------------------------
 # GATE 1 — pyright config must be strict and must ban explicit Any
 # -------------------------------------------------------------------
 
+# Required [tool.pyright] keys.
+#
+# Not listed: reportExplicitAny. pyright 1.1.408 (the pinned version)
+# emits `Config contains unrecognized setting "reportExplicitAny"` and
+# silently ignores it. We do not claim in this gate what the toolchain
+# does not actually enforce; the Any surface is enforced by the
+# AST-based gate_any_references_ast() below, which covers `Any`,
+# `typing.Any`, aliased imports (`from typing import Any as X`), and
+# module-qualified access (`import typing as t; t.Any`) -- all forms
+# the regex-based ratchet was blind to. The pyproject.toml still sets
+# reportExplicitAny = "error" as a forward-compatible aspirational
+# value for when pyright (or whatever we upgrade to) respects it.
 REQUIRED_PYRIGHT: Final[dict[str, object]] = {
     'typeCheckingMode': 'strict',
-    'reportExplicitAny': 'error',
     'reportMissingImports': 'error',
     'reportMissingTypeStubs': 'error',
     'reportUnknownArgumentType': 'error',
@@ -237,6 +341,52 @@ def gate_escape_hatch_ratchet(budget: dict[str, object]) -> list[str]:
             )
 
     return failures
+
+
+# -------------------------------------------------------------------
+# GATE 2b — AST-based Any-reference ratchet.
+# Catches every surface form of typing.Any, not just bare `Any`.
+# -------------------------------------------------------------------
+
+def gate_any_references_ast(budget: dict[str, object]) -> list[str]:
+    package_root_name = str(budget.get('package_root', ''))
+    if not package_root_name:
+        return ['typing_budget.json must set package_root']
+    package_root = REPO_ROOT / package_root_name
+    if not package_root.is_dir():
+        return [f'package_root {package_root_name!r} not found under repo root']
+
+    excludes_raw = budget.get('excludes', [])
+    excludes = [str(x) for x in excludes_raw] if isinstance(excludes_raw, list) else []
+    files = find_python_files(package_root, excludes)
+
+    spec = budget.get('any_references')
+    if not isinstance(spec, dict):
+        return [
+            'typing_budget.json must include an any_references section '
+            "with {'total': <int>}"
+        ]
+    raw_total = spec.get('total', 0)
+    if isinstance(raw_total, bool) or not isinstance(raw_total, int):
+        return [
+            f'typing_budget.json: any_references.total must be a '
+            f'non-negative integer (got {raw_total!r})'
+        ]
+    if raw_total < 0:
+        return [
+            f'typing_budget.json: any_references.total must be '
+            f'non-negative (got {raw_total})'
+        ]
+
+    current = count_any_references_ast(files)
+    if current > raw_total:
+        return [
+            f'any_references (AST): budget={raw_total} current={current} '
+            f'(delta={current - raw_total}). Covers Any, typing.Any, '
+            f't.Any, aliased imports. Remove the new Any or lower '
+            f'the budget.'
+        ]
+    return []
 
 
 # -------------------------------------------------------------------
@@ -379,12 +529,20 @@ def gate_budget_source(
 
     failures: list[str] = []
 
-    # Pyright error ceiling
-    base_py = base_budget.get('pyright_errors')
-    head_py = head_budget.get('pyright_errors')
-    if isinstance(base_py, dict) and isinstance(head_py, dict):
-        b_total = base_py.get('total', 0)
-        h_total = head_py.get('total', 0)
+    # Top-level integer-ceiling sections (pyright_errors, any_references).
+    for section in ('pyright_errors', 'any_references'):
+        base_sec = base_budget.get(section)
+        head_sec = head_budget.get(section)
+        if not isinstance(base_sec, dict):
+            continue
+        if not isinstance(head_sec, dict):
+            failures.append(
+                f'{section} section was deleted from the head budget. '
+                f'Keys present in the base-ref budget must be preserved.'
+            )
+            continue
+        b_total = base_sec.get('total', 0)
+        h_total = head_sec.get('total', 0)
         if (
             isinstance(b_total, int)
             and not isinstance(b_total, bool)
@@ -393,7 +551,7 @@ def gate_budget_source(
             and h_total > b_total
         ):
             failures.append(
-                f'pyright_errors.total was raised from {b_total} (base) '
+                f'{section}.total was raised from {b_total} (base) '
                 f'to {h_total} (head). The oracle cannot be weakened '
                 f'by the PR it gates.'
             )
@@ -514,12 +672,18 @@ def update_budget(pyright_json_path: str | None) -> None:
         budget = json.loads(BUDGET_PATH.read_text())
     else:
         budget = {
-            'schema_version': 1,
+            'schema_version': 2,
             'package_root': 'tdw_control_plane',
             'excludes': ['__pycache__', 'quickstart_etl_tests', 'build', 'dist'],
             'patterns': {k: dict(v) for k, v in DEFAULT_PATTERNS.items()},
+            'any_references': {'total': 0},
             'pyright_errors': {'total': 0},
         }
+
+    # Migrate schema v1 -> v2 (add any_references if missing)
+    if 'any_references' not in budget:
+        budget['any_references'] = {'total': 0}
+        budget['schema_version'] = 2
 
     package_root = REPO_ROOT / str(budget['package_root'])
     excludes = [str(x) for x in budget.get('excludes', [])]
@@ -527,6 +691,8 @@ def update_budget(pyright_json_path: str | None) -> None:
 
     for name, spec in budget['patterns'].items():
         spec['total'] = count_pattern(files, str(spec['pattern']))
+
+    budget['any_references']['total'] = count_any_references_ast(files)
 
     if pyright_json_path is not None:
         try:
@@ -540,10 +706,12 @@ def update_budget(pyright_json_path: str | None) -> None:
     BUDGET_PATH.write_text(json.dumps(budget, indent=2) + '\n')
 
     total_hatches = sum(int(s['total']) for s in budget['patterns'].values())
+    any_refs = int(budget['any_references']['total'])
     pyright_total = int(budget.get('pyright_errors', {}).get('total', 0))
     print(f'budget updated -> {BUDGET_PATH.relative_to(REPO_ROOT)}')
-    print(f'  escape-hatch occurrences: {total_hatches}')
-    print(f'  pyright errors:           {pyright_total}')
+    print(f'  regex escape-hatch occurrences: {total_hatches}')
+    print(f'  AST Any references:             {any_refs}')
+    print(f'  pyright errors:                 {pyright_total}')
 
 
 # -------------------------------------------------------------------
@@ -621,6 +789,9 @@ def main() -> int:
 
     for msg in gate_escape_hatch_ratchet(budget):
         failures.append(('escape-hatch-ratchet', msg))
+
+    for msg in gate_any_references_ast(budget):
+        failures.append(('any-references-ast-ratchet', msg))
 
     for msg in gate_pyright_errors(args.pyright_json, budget):
         failures.append(('pyright-error-ratchet', msg))

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -125,15 +125,20 @@ def count_pattern(files: list[Path], pattern: str) -> int:
 def _collect_any_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """For one module AST, return:
 
-      * ``direct`` — names that directly refer to ``typing.Any``. Populated
-        by ``from typing import Any`` (key ``Any``) and by aliased forms
-        such as ``from typing import Any as X`` (key ``X``).
+      * ``direct`` — names that refer to ``typing.Any``. Populated by
+        ``from typing import Any`` (key ``Any``), aliased forms like
+        ``from typing import Any as X`` (key ``X``), AND by module-level
+        assignment aliases such as ``A = typing.Any`` (key ``A``) or
+        chained aliases ``B = A`` (key ``B``). Iteratively expanded to
+        a fixed point so ``A = typing.Any; B = A; C = B`` all resolve.
       * ``module_aliases`` — names that refer to the ``typing`` module.
         Populated by ``import typing`` (``typing``) and ``import typing
         as t`` (``t``).
     """
     direct: set[str] = set()
     module_aliases: set[str] = set()
+
+    # Pass 1: import statements.
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module == 'typing':
             for alias in node.names:
@@ -143,7 +148,53 @@ def _collect_any_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
             for alias in node.names:
                 if alias.name == 'typing':
                     module_aliases.add(alias.asname or 'typing')
+
+    # Pass 2: assignment aliases. Iterate to a fixed point so chained
+    # aliases (``A = typing.Any``; ``B = A``; ``C = B``) all resolve.
+    # Bounded at 16 rounds to prevent runaway; any real module converges
+    # in a couple of passes.
+    for _ in range(16):
+        before = len(direct)
+        for node in ast.walk(tree):
+            value: ast.AST | None = None
+            target_names: list[str] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                for t in node.targets:
+                    if isinstance(t, ast.Name):
+                        target_names.append(t.id)
+            elif isinstance(node, ast.AnnAssign):
+                value = node.value
+                if isinstance(node.target, ast.Name):
+                    target_names.append(node.target.id)
+            else:
+                continue
+            if value is None or not target_names:
+                continue
+            if _resolves_to_any(value, direct, module_aliases):
+                for name in target_names:
+                    direct.add(name)
+        if len(direct) == before:
+            break
+
     return direct, module_aliases
+
+
+def _resolves_to_any(
+    node: ast.AST,
+    direct: set[str],
+    module_aliases: set[str],
+) -> bool:
+    """True if evaluating ``node`` would produce ``typing.Any`` under
+    the current direct / module-alias bindings. Used by
+    ``_collect_any_bindings`` to expand assignment-alias chains.
+    """
+    if isinstance(node, ast.Name):
+        return node.id in direct
+    if isinstance(node, ast.Attribute) and node.attr == 'Any':
+        target = node.value
+        return isinstance(target, ast.Name) and target.id in module_aliases
+    return False
 
 
 def _is_any_reference(
@@ -153,10 +204,16 @@ def _is_any_reference(
 ) -> bool:
     """True if ``node`` is a usage-site reference to ``typing.Any``.
 
-    Catches bare ``Any`` / aliased-direct names (``ast.Name``) and
-    attribute access like ``typing.Any`` / ``t.Any`` (``ast.Attribute``).
+    Catches bare ``Any`` / aliased-direct names and attribute access
+    like ``typing.Any`` / ``t.Any``. Limits ``ast.Name`` matches to
+    load context so we do not double-count the LHS of an assignment
+    that also has a typing.Any reference on its RHS.
     """
     if isinstance(node, ast.Name):
+        # Only Load context is a usage site. Store (LHS of =), Del, and
+        # annotation targets (also Store) are bindings, not uses.
+        if not isinstance(getattr(node, 'ctx', None), ast.Load):
+            return False
         return node.id in direct
     if isinstance(node, ast.Attribute) and node.attr == 'Any':
         target = node.value
@@ -208,18 +265,32 @@ def count_any_references_ast(files: list[Path]) -> int:
 
 # Required [tool.pyright] keys.
 #
-# Not listed: reportExplicitAny. pyright 1.1.408 (the pinned version)
-# emits `Config contains unrecognized setting "reportExplicitAny"` and
-# silently ignores it. We do not claim in this gate what the toolchain
-# does not actually enforce; the Any surface is enforced by the
-# AST-based gate_any_references_ast() below, which covers `Any`,
-# `typing.Any`, aliased imports (`from typing import Any as X`), and
-# module-qualified access (`import typing as t; t.Any`) -- all forms
-# the regex-based ratchet was blind to. The pyproject.toml still sets
-# reportExplicitAny = "error" as a forward-compatible aspirational
-# value for when pyright (or whatever we upgrade to) respects it.
+# The gate asserts these keys are PRESENT in pyproject.toml with the
+# exact values below. That is a configuration-presence check: the
+# config file carries the values.
+#
+# What actually enforces what at runtime is split:
+#
+#   * reportMissingImports, reportMissingTypeStubs, reportUnknown*,
+#     reportMissingParameterType, reportConstantRedefinition,
+#     reportImportCycles: ENFORCED by pyright itself. Every error
+#     pyright emits under these rules is counted toward
+#     summary.errorCount, which gate_pyright_errors() ratchets.
+#
+#   * reportExplicitAny: pyright 1.1.408 (the pinned version) emits
+#     `Config contains unrecognized setting "reportExplicitAny"` and
+#     does not honor it. We keep it required here anyway as a
+#     forward-compatible config-presence check: the day pyright or its
+#     successor respects the setting, enforcement kicks in without a
+#     gate change. Today, the actual Any enforcement is the AST-based
+#     gate_any_references_ast() below, which resolves every surface
+#     form including module-level assignment aliases.
+#
+#   * typeCheckingMode: this must be "strict" so that all of the
+#     strict-default report* rules above are active.
 REQUIRED_PYRIGHT: Final[dict[str, object]] = {
     'typeCheckingMode': 'strict',
+    'reportExplicitAny': 'error',
     'reportMissingImports': 'error',
     'reportMissingTypeStubs': 'error',
     'reportUnknownArgumentType': 'error',
@@ -242,18 +313,34 @@ FORBIDDEN_VALUES: Final[frozenset[object]] = frozenset(
 )
 
 
+_PRUNE_DIRS: Final[frozenset[str]] = frozenset(
+    {'.git', '.venv', 'venv', 'node_modules', 'build', 'dist', '__pycache__'}
+)
+
+
+def _find_pyrightconfig_json() -> list[Path]:
+    """Walk the repo for pyrightconfig.json files with directory
+    pruning. ``Path.rglob`` descends into ``.git`` — which is huge on
+    a fetch-depth=0 CI checkout — before filtering, so we use os.walk
+    and remove prune targets from ``dirnames`` before recursing.
+    """
+    import os
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        if 'pyrightconfig.json' in filenames:
+            found.append(Path(dirpath) / 'pyrightconfig.json')
+    return sorted(found)
+
+
 def gate_pyright_config(config: dict[str, object]) -> list[str]:
     failures: list[str] = []
 
     # Pyright prefers pyrightconfig.json over [tool.pyright] in pyproject.toml.
     # A PR that drops such a file anywhere in the repo silently shadows every
     # setting this gate audits. Ban it outright.
-    for cfg in sorted(REPO_ROOT.rglob('pyrightconfig.json')):
+    for cfg in _find_pyrightconfig_json():
         rel = cfg.relative_to(REPO_ROOT)
-        # Skip vendored/dependency paths (.venv, node_modules, etc.)
-        parts = rel.parts
-        if any(p in {'.venv', 'venv', 'node_modules', 'build', 'dist', '.git'} for p in parts):
-            continue
         failures.append(
             f'pyrightconfig.json found at {rel}. '
             f'Pyright prefers this file over pyproject.toml and would '
@@ -403,7 +490,11 @@ def gate_pyright_errors(
     if not path.is_file():
         return [f'pyright output not found at {path}']
     try:
-        data = json.loads(path.read_text())
+        raw_text = path.read_text(encoding='utf-8')
+    except OSError as exc:
+        return [f'pyright output at {path} could not be read: {exc}']
+    try:
+        data = json.loads(raw_text)
     except json.JSONDecodeError as e:
         return [f'pyright output is not valid JSON: {e}']
 
@@ -529,6 +620,62 @@ def gate_budget_source(
 
     failures: list[str] = []
 
+    # Structural invariants: the scan surface cannot be narrowed.
+    #
+    # * package_root identical: cannot point the gate at a smaller subtree.
+    # * excludes: head must be a subset of base (can remove, never add).
+    #   Adding an exclude hides files from the ratchet.
+    base_root = base_budget.get('package_root')
+    head_root = head_budget.get('package_root')
+    if base_root != head_root:
+        failures.append(
+            f'package_root changed from {base_root!r} (base) to '
+            f'{head_root!r} (head). The scan surface cannot be narrowed '
+            f'by the PR it gates.'
+        )
+
+    base_excludes_raw = base_budget.get('excludes', [])
+    head_excludes_raw = head_budget.get('excludes', [])
+    base_excludes = set(base_excludes_raw) if isinstance(base_excludes_raw, list) else set()
+    head_excludes = set(head_excludes_raw) if isinstance(head_excludes_raw, list) else set()
+    added_excludes = head_excludes - base_excludes
+    if added_excludes:
+        failures.append(
+            f'excludes added in head that are not in base: '
+            f'{sorted(added_excludes)!r}. New excludes hide files from '
+            f'the escape-hatch ratchet; add them in a separate PR that '
+            f'ratchets the totals first.'
+        )
+
+    # Per-pattern regex identity: a regex in head for a key present in
+    # base must be the exact same regex. Otherwise a PR could rewrite
+    # the regex to one that never matches and keep the total at zero,
+    # neutering that ratchet key.
+    base_patterns_raw = base_budget.get('patterns')
+    head_patterns_raw = head_budget.get('patterns')
+    base_patterns: dict[str, object] = (
+        base_patterns_raw if isinstance(base_patterns_raw, dict) else {}
+    )
+    head_patterns: dict[str, object] = (
+        head_patterns_raw if isinstance(head_patterns_raw, dict) else {}
+    )
+    for key, base_spec in base_patterns.items():
+        if key not in head_patterns:
+            continue  # handled below by key-preservation check
+        head_spec = head_patterns[key]
+        if not (isinstance(base_spec, dict) and isinstance(head_spec, dict)):
+            continue
+        base_rx = base_spec.get('pattern')
+        head_rx = head_spec.get('pattern')
+        if base_rx != head_rx:
+            failures.append(
+                f'pattern {key!r} regex changed from {base_rx!r} (base) '
+                f'to {head_rx!r} (head). Regex strings for keys present '
+                f'in the base budget must remain identical; rewriting '
+                f'the regex can nullify the ratchet while leaving the '
+                f'total unchanged.'
+            )
+
     # Top-level integer-ceiling sections (pyright_errors, any_references).
     for section in ('pyright_errors', 'any_references'):
         base_sec = base_budget.get(section)
@@ -556,16 +703,9 @@ def gate_budget_source(
                 f'by the PR it gates.'
             )
 
-    # Pattern ceilings and key preservation
-    base_patterns_raw = base_budget.get('patterns')
-    head_patterns_raw = head_budget.get('patterns')
-    base_patterns: dict[str, object] = (
-        base_patterns_raw if isinstance(base_patterns_raw, dict) else {}
-    )
-    head_patterns: dict[str, object] = (
-        head_patterns_raw if isinstance(head_patterns_raw, dict) else {}
-    )
-
+    # Pattern key preservation and per-key total ratchet. base_patterns
+    # and head_patterns are already extracted above for the regex-
+    # identity check; reuse.
     for key in base_patterns:
         if key not in head_patterns:
             failures.append(
@@ -614,7 +754,11 @@ def gate_files_analyzed(
         return []
 
     try:
-        data = json.loads(path.read_text())
+        raw_text = path.read_text(encoding='utf-8')
+    except OSError as exc:
+        return [f'pyright output at {path} could not be read: {exc}']
+    try:
+        data = json.loads(raw_text)
     except json.JSONDecodeError as e:
         return [f'pyright output is not valid JSON: {e}']
     if not isinstance(data, dict):

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Typing gate — mechanical enforcement of type discipline.
+
+This gate blocks a PR that:
+
+  1. Weakens the pyright configuration (gate-config ratchet).
+  2. Introduces new ``Any`` in production code (escape-hatch ratchet).
+  3. Introduces new ``# type: ignore`` / ``# pyright: ignore`` / ``# noqa``
+     comments (escape-hatch ratchet).
+  4. Introduces new ``cast(..., Any)`` / ``cast(Any, ...)`` calls.
+  5. Increases the total pyright-strict error count (pyright-error ratchet).
+
+The gate is a ratchet, not a flat hard-fail. The budget file at
+``.github/typing_budget.json`` caps the total count of each escape-hatch
+pattern and the pyright error count. Exceeding any cap fails the build.
+Decreasing the cap is allowed — any PR may lower the numbers in the
+budget to lock in improvements.
+
+Usage:
+
+  python tools/typing_gate.py                       # run all gates
+  python tools/typing_gate.py --pyright-json <path> # include pyright gate
+  python tools/typing_gate.py --update-budget       # regenerate the budget
+
+Exit codes:
+
+  0 — all gates pass
+  1 — one or more gates failed
+  2 — gate itself could not run (missing config, file-system error, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+BUDGET_PATH: Final[Path] = REPO_ROOT / '.github' / 'typing_budget.json'
+PYPROJECT_PATH: Final[Path] = REPO_ROOT / 'pyproject.toml'
+
+
+# -------------------------------------------------------------------
+# File walking
+# -------------------------------------------------------------------
+
+def find_python_files(root: Path, excludes: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for p in sorted(root.rglob('*.py')):
+        rel = str(p.relative_to(REPO_ROOT))
+        if any(ex in rel for ex in excludes):
+            continue
+        files.append(p)
+    return files
+
+
+def count_pattern(files: list[Path], pattern: str) -> int:
+    rx = re.compile(pattern)
+    total = 0
+    for f in files:
+        try:
+            text = f.read_text(encoding='utf-8', errors='ignore')
+        except OSError:
+            continue
+        total += len(rx.findall(text))
+    return total
+
+
+# -------------------------------------------------------------------
+# GATE 1 — pyright config must be strict and must ban explicit Any
+# -------------------------------------------------------------------
+
+REQUIRED_PYRIGHT: Final[dict[str, object]] = {
+    'typeCheckingMode': 'strict',
+    'reportExplicitAny': 'error',
+    'reportMissingImports': 'error',
+    'reportMissingTypeStubs': 'error',
+    'reportUnknownArgumentType': 'error',
+    'reportUnknownMemberType': 'error',
+    'reportUnknownVariableType': 'error',
+    'reportUnknownLambdaType': 'error',
+    'reportUnknownParameterType': 'error',
+    'reportMissingParameterType': 'error',
+    'reportConstantRedefinition': 'error',
+    'reportImportCycles': 'error',
+}
+
+FORBIDDEN_VALUES: Final[frozenset[object]] = frozenset(
+    {'none', 'warning', 'information', 'info', 'false', False}
+)
+
+
+def gate_pyright_config(config: dict[str, object]) -> list[str]:
+    failures: list[str] = []
+    tool = config.get('tool')
+    pyright = tool.get('pyright') if isinstance(tool, dict) else None
+    if not isinstance(pyright, dict):
+        return ['[tool.pyright] section is missing from pyproject.toml']
+
+    for key, required in REQUIRED_PYRIGHT.items():
+        actual = pyright.get(key)
+        if actual != required:
+            failures.append(
+                f'pyright.{key} must be {required!r}, got {actual!r}'
+            )
+
+    for key, value in pyright.items():
+        if not isinstance(key, str):
+            continue
+        if key.startswith('report') and value in FORBIDDEN_VALUES:
+            failures.append(
+                f'pyright.{key} = {value!r} -- gate weakening disallowed; '
+                f"must be 'error' (or absent to inherit strict default)"
+            )
+
+    return failures
+
+
+# -------------------------------------------------------------------
+# GATE 2 — escape-hatch pattern ratchet against committed budget
+# -------------------------------------------------------------------
+
+def gate_escape_hatch_ratchet(budget: dict[str, object]) -> list[str]:
+    failures: list[str] = []
+    package_root_name = str(budget.get('package_root', ''))
+    if not package_root_name:
+        return ['typing_budget.json must set package_root']
+    package_root = REPO_ROOT / package_root_name
+    if not package_root.is_dir():
+        return [f'package_root {package_root_name!r} not found under repo root']
+
+    excludes_raw = budget.get('excludes', [])
+    excludes = [str(x) for x in excludes_raw] if isinstance(excludes_raw, list) else []
+    files = find_python_files(package_root, excludes)
+
+    patterns = budget.get('patterns')
+    if not isinstance(patterns, dict):
+        return ['typing_budget.json must define patterns']
+
+    for name, spec in patterns.items():
+        if not isinstance(spec, dict):
+            continue
+        pattern = str(spec.get('pattern', ''))
+        if not pattern:
+            continue
+        budget_total = int(spec.get('total', 0))
+        current = count_pattern(files, pattern)
+        if current > budget_total:
+            failures.append(
+                f'[{name}] budget={budget_total} current={current} '
+                f'(pattern={pattern!r}) -- ratchet exceeded. '
+                f'Remove the new escape hatch or lower the budget.'
+            )
+
+    return failures
+
+
+# -------------------------------------------------------------------
+# GATE 3 — pyright total error count ratchet
+# -------------------------------------------------------------------
+
+def gate_pyright_errors(
+    pyright_json_path: str | None,
+    budget: dict[str, object],
+) -> list[str]:
+    if pyright_json_path is None:
+        return []
+    path = Path(pyright_json_path)
+    if not path.is_file():
+        return [f'pyright output not found at {path}']
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return [f'pyright output is not valid JSON: {e}']
+
+    summary = data.get('summary', {}) if isinstance(data, dict) else {}
+    current_errors = int(summary.get('errorCount', 0))
+
+    py_budget_raw = budget.get('pyright_errors')
+    if not isinstance(py_budget_raw, dict):
+        return [
+            'typing_budget.json must include a pyright_errors section '
+            "with {'total': <int>}"
+        ]
+    budget_total = int(py_budget_raw.get('total', 0))
+
+    if current_errors > budget_total:
+        # Per-rule summary for the failure message.
+        per_rule: dict[str, int] = {}
+        diagnostics = data.get('generalDiagnostics') if isinstance(data, dict) else None
+        if isinstance(diagnostics, list):
+            for diag in diagnostics:
+                if not isinstance(diag, dict):
+                    continue
+                if diag.get('severity') != 'error':
+                    continue
+                rule = str(diag.get('rule', '<no-rule>'))
+                per_rule[rule] = per_rule.get(rule, 0) + 1
+        top = sorted(per_rule.items(), key=lambda kv: -kv[1])[:5]
+        top_str = '; '.join(f'{r}={n}' for r, n in top)
+        return [
+            f'pyright errors: budget={budget_total} current={current_errors} '
+            f'(delta={current_errors - budget_total}). Top rules: {top_str}'
+        ]
+
+    return []
+
+
+# -------------------------------------------------------------------
+# Baseline regeneration (--update-budget)
+# -------------------------------------------------------------------
+
+DEFAULT_PATTERNS: Final[dict[str, dict[str, object]]] = {
+    'any_annotation':  {'pattern': r':\s*Any\b', 'total': 0},
+    'any_return':      {'pattern': r'->\s*Any\b', 'total': 0},
+    'any_import':      {'pattern': r'from typing import[^\n]*\bAny\b', 'total': 0},
+    'cast_any':        {'pattern': r'cast\([^)]*\bAny\b', 'total': 0},
+    'dict_any':        {'pattern': r'dict\[[^]]*\bAny\b', 'total': 0},
+    'list_any':        {'pattern': r'list\[\s*Any\b', 'total': 0},
+    'tuple_any':       {'pattern': r'tuple\[[^]]*\bAny\b', 'total': 0},
+    'type_ignore':     {'pattern': r'#\s*type:\s*ignore', 'total': 0},
+    'pyright_ignore':  {'pattern': r'#\s*pyright:\s*ignore', 'total': 0},
+    'noqa':            {'pattern': r'#\s*noqa', 'total': 0},
+}
+
+
+def update_budget(pyright_json_path: str | None) -> None:
+    if BUDGET_PATH.exists():
+        budget = json.loads(BUDGET_PATH.read_text())
+    else:
+        budget = {
+            'schema_version': 1,
+            'package_root': 'tdw_control_plane',
+            'excludes': ['__pycache__', 'quickstart_etl_tests', 'build', 'dist'],
+            'patterns': {k: dict(v) for k, v in DEFAULT_PATTERNS.items()},
+            'pyright_errors': {'total': 0},
+        }
+
+    package_root = REPO_ROOT / str(budget['package_root'])
+    excludes = [str(x) for x in budget.get('excludes', [])]
+    files = find_python_files(package_root, excludes)
+
+    for name, spec in budget['patterns'].items():
+        spec['total'] = count_pattern(files, str(spec['pattern']))
+
+    if pyright_json_path is not None:
+        try:
+            data = json.loads(Path(pyright_json_path).read_text())
+            summary = data.get('summary', {})
+            budget['pyright_errors']['total'] = int(summary.get('errorCount', 0))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f'warning: could not read pyright output: {e}', file=sys.stderr)
+
+    BUDGET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BUDGET_PATH.write_text(json.dumps(budget, indent=2) + '\n')
+
+    total_hatches = sum(int(s['total']) for s in budget['patterns'].values())
+    pyright_total = int(budget.get('pyright_errors', {}).get('total', 0))
+    print(f'budget updated -> {BUDGET_PATH.relative_to(REPO_ROOT)}')
+    print(f'  escape-hatch occurrences: {total_hatches}')
+    print(f'  pyright errors:           {pyright_total}')
+
+
+# -------------------------------------------------------------------
+# Orchestration
+# -------------------------------------------------------------------
+
+def load_pyproject() -> dict[str, object]:
+    with open(PYPROJECT_PATH, 'rb') as f:
+        return tomllib.load(f)
+
+
+def load_budget() -> dict[str, object]:
+    if not BUDGET_PATH.exists():
+        raise SystemExit(
+            f'typing gate cannot run: {BUDGET_PATH.relative_to(REPO_ROOT)} '
+            f'is missing. Run with --update-budget to create it.'
+        )
+    return json.loads(BUDGET_PATH.read_text())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Typing gate')
+    parser.add_argument(
+        '--pyright-json',
+        default=None,
+        help='Path to pyright --outputjson output; enables pyright-error ratchet',
+    )
+    parser.add_argument(
+        '--update-budget',
+        action='store_true',
+        help='Regenerate .github/typing_budget.json from current repo state',
+    )
+    args = parser.parse_args()
+
+    if args.update_budget:
+        update_budget(args.pyright_json)
+        return 0
+
+    try:
+        config = load_pyproject()
+        budget = load_budget()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f'typing gate setup failed: {e}', file=sys.stderr)
+        return 2
+
+    failures: list[tuple[str, str]] = []
+
+    for msg in gate_pyright_config(config):
+        failures.append(('pyright-config', msg))
+
+    for msg in gate_escape_hatch_ratchet(budget):
+        failures.append(('escape-hatch-ratchet', msg))
+
+    for msg in gate_pyright_errors(args.pyright_json, budget):
+        failures.append(('pyright-error-ratchet', msg))
+
+    if failures:
+        print('TYPING GATE -- FAIL')
+        print('')
+        by_gate: dict[str, list[str]] = {}
+        for gate, msg in failures:
+            by_gate.setdefault(gate, []).append(msg)
+        for gate_name, msgs in by_gate.items():
+            print(f'  gate: {gate_name}')
+            for m in msgs:
+                print(f'    - {m}')
+        print('')
+        print(f'{len(failures)} failure(s). Merge blocked.')
+        return 1
+
+    print('TYPING GATE -- PASS')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -320,30 +320,54 @@ def gate_pyright_errors(
 
 def gate_budget_source(
     base_budget_path: str | None,
+    bootstrap: bool,
     head_budget: dict[str, object],
 ) -> list[str]:
+    """Compare the head budget to the budget at the protected base ref.
+    The PR cannot raise its own ceiling. Two legal states:
+
+      * ``--base-budget PATH`` with PATH existing and valid JSON: do the
+        base-vs-head comparison.
+      * ``--bootstrap``: explicit first-commit override for the PR that
+        introduces ``.github/typing_budget.json`` to main. The workflow
+        selects this mode mechanically by diffing against the base ref.
+
+    Any other state -- including a missing ``--base-budget`` file
+    without ``--bootstrap`` -- is a hard failure. A graceful skip on
+    missing file would convert ``someone deleted the budget from main``
+    into ``nothing to enforce'', which is the pattern this gate exists
+    to prevent.
+    """
+
+    if bootstrap:
+        if base_budget_path is not None:
+            return [
+                'typing_gate: --bootstrap and --base-budget are mutually '
+                'exclusive; pass exactly one.'
+            ]
+        # Bootstrap mode: the PR introduces the budget to main. The
+        # workflow confirmed this by checking that the head commit adds
+        # .github/typing_budget.json. No base-vs-head comparison in this
+        # case -- there is no base.
+        return []
+
     if base_budget_path is None:
-        # First-time run or unable to fetch base; the workflow must
-        # provide --base-budget in PR / merge_group / push-to-main.
-        # Absence here is a config error, not a graceful skip.
         return [
-            'typing_gate: --base-budget was not provided; '
-            'the workflow must fetch the budget from the protected base ref '
-            'and pass it as --base-budget'
+            'typing_gate: neither --base-budget nor --bootstrap was given. '
+            'The workflow must either (a) fetch the budget from the '
+            'protected base ref and pass --base-budget PATH, or (b) pass '
+            '--bootstrap if this commit introduces the budget.'
         ]
 
     base_path = Path(base_budget_path)
     if not base_path.is_file():
-        # Base ref has no budget file — this is the first commit that
-        # introduces the gate. In that case head is the baseline; nothing
-        # to compare against.
-        print(
-            f'typing_gate: base-ref budget not found at {base_path} '
-            f'(first commit introducing the gate?); skipping '
-            f'budget-source ratchet',
-            file=sys.stderr,
-        )
-        return []
+        return [
+            f'typing_gate: base-ref budget not found at {base_path} and '
+            f'--bootstrap was not given. Either (a) the budget was '
+            f'deleted from the protected base ref -- restore it -- or '
+            f'(b) this is the commit introducing the budget, in which '
+            f'case pass --bootstrap. Silent skip is not an option.'
+        ]
 
     try:
         base_budget = json.loads(base_path.read_text())
@@ -557,6 +581,17 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        '--bootstrap',
+        action='store_true',
+        help=(
+            'Explicit first-commit override: skip the base-vs-head '
+            'comparison because this commit introduces the budget to '
+            'the protected base ref. The workflow selects this mode '
+            'mechanically by diffing against the base ref; it must not '
+            'be set by hand.'
+        ),
+    )
+    parser.add_argument(
         '--update-budget',
         action='store_true',
         help='Regenerate .github/typing_budget.json from current repo state',
@@ -581,7 +616,7 @@ def main() -> int:
     for msg in gate_pyright_config(config):
         failures.append(('pyright-config', msg))
 
-    for msg in gate_budget_source(args.base_budget, budget):
+    for msg in gate_budget_source(args.base_budget, args.bootstrap, budget):
         failures.append(('budget-source-ratchet', msg))
 
     for msg in gate_escape_hatch_ratchet(budget):

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -881,7 +881,13 @@ def main() -> int:
     parser.add_argument(
         '--pyright-json',
         default=None,
-        help='Path to pyright --outputjson output; enables pyright-error ratchet',
+        help=(
+            'Path to pyright --outputjson output. REQUIRED for normal gate '
+            'runs (omitted only when --update-budget is set and pyright '
+            'output is not available). Without it the pyright-error and '
+            'filesAnalyzed ratchets cannot run; the gate therefore '
+            'hard-fails if this flag is absent on a normal run.'
+        ),
     )
     parser.add_argument(
         '--base-budget',
@@ -913,6 +919,23 @@ def main() -> int:
     if args.update_budget:
         update_budget(args.pyright_json)
         return 0
+
+    # Normal gate runs must supply the pyright output. A workflow edit
+    # that drops the flag would otherwise silently skip the pyright-
+    # error and filesAnalyzed ratchets. We refuse to run instead of
+    # producing a green gate on half the checks.
+    if args.pyright_json is None:
+        print(
+            'TYPING GATE -- FAIL\n\n'
+            '  gate: runtime-args\n'
+            '    - --pyright-json was not provided. Normal gate runs require '
+            'pyright output so the pyright-error-ratchet and files-analyzed-'
+            'ratchet can run. Pass --pyright-json PATH or, if regenerating '
+            'the budget, use --update-budget instead.\n\n'
+            '1 failure(s). Merge blocked.',
+            file=sys.stdout,
+        )
+        return 1
 
     try:
         config = load_pyproject()

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -48,24 +48,52 @@ PYPROJECT_PATH: Final[Path] = REPO_ROOT / 'pyproject.toml'
 # File walking
 # -------------------------------------------------------------------
 
+def _is_excluded(relative_path: Path, excludes: list[str]) -> bool:
+    """Path-part match, not substring. An exclude entry matches only if
+    its parts appear as a contiguous slice of the path's parts. This
+    prevents an entry like 'dist' from spuriously matching a file such
+    as 'tdw_control_plane/distance.py'."""
+    parts = relative_path.parts
+    for ex in excludes:
+        ex_parts = Path(ex).parts
+        if not ex_parts:
+            continue
+        w = len(ex_parts)
+        for i in range(0, max(0, len(parts) - w + 1)):
+            if parts[i:i + w] == ex_parts:
+                return True
+    return False
+
+
 def find_python_files(root: Path, excludes: list[str]) -> list[Path]:
     files: list[Path] = []
     for p in sorted(root.rglob('*.py')):
-        rel = str(p.relative_to(REPO_ROOT))
-        if any(ex in rel for ex in excludes):
+        rel = p.relative_to(REPO_ROOT)
+        if _is_excluded(rel, excludes):
             continue
         files.append(p)
     return files
 
 
 def count_pattern(files: list[Path], pattern: str) -> int:
-    rx = re.compile(pattern)
+    """Count non-overlapping matches of `pattern` across `files`. Any
+    read or decode error is a fatal setup failure (not a silent skip);
+    a silently skipped file would under-count escape hatches and let
+    regressions through."""
+    try:
+        rx = re.compile(pattern)
+    except re.error as exc:
+        raise SystemExit(
+            f'typing_gate: invalid regex in budget ({pattern!r}): {exc}'
+        ) from exc
     total = 0
     for f in files:
         try:
-            text = f.read_text(encoding='utf-8', errors='ignore')
-        except OSError:
-            continue
+            text = f.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError) as exc:
+            raise SystemExit(
+                f'typing_gate: cannot read {f}: {exc}'
+            ) from exc
         total += len(rx.findall(text))
     return total
 
@@ -143,15 +171,25 @@ def gate_escape_hatch_ratchet(budget: dict[str, object]) -> list[str]:
 
     for name, spec in patterns.items():
         if not isinstance(spec, dict):
-            continue
-        pattern = str(spec.get('pattern', ''))
-        if not pattern:
-            continue
-        budget_total = int(spec.get('total', 0))
+            return [f'typing_budget.json: pattern {name!r} must be an object']
+        pattern = spec.get('pattern')
+        if not isinstance(pattern, str) or not pattern:
+            return [f'typing_budget.json: pattern {name!r} has no regex']
+        raw_total = spec.get('total', 0)
+        if isinstance(raw_total, bool) or not isinstance(raw_total, int):
+            return [
+                f'typing_budget.json: pattern {name!r} total must be a '
+                f'non-negative integer (got {raw_total!r})'
+            ]
+        if raw_total < 0:
+            return [
+                f'typing_budget.json: pattern {name!r} total must be '
+                f'non-negative (got {raw_total})'
+            ]
         current = count_pattern(files, pattern)
-        if current > budget_total:
+        if current > raw_total:
             failures.append(
-                f'[{name}] budget={budget_total} current={current} '
+                f'[{name}] budget={raw_total} current={current} '
                 f'(pattern={pattern!r}) -- ratchet exceeded. '
                 f'Remove the new escape hatch or lower the budget.'
             )
@@ -177,8 +215,18 @@ def gate_pyright_errors(
     except json.JSONDecodeError as e:
         return [f'pyright output is not valid JSON: {e}']
 
-    summary = data.get('summary', {}) if isinstance(data, dict) else {}
-    current_errors = int(summary.get('errorCount', 0))
+    if not isinstance(data, dict):
+        return ['pyright output must be a JSON object']
+    summary = data.get('summary', {})
+    if not isinstance(summary, dict):
+        return ['pyright output .summary must be an object']
+    raw_current = summary.get('errorCount', 0)
+    if isinstance(raw_current, bool) or not isinstance(raw_current, int):
+        return [
+            f'pyright output .summary.errorCount must be an integer '
+            f'(got {raw_current!r})'
+        ]
+    current_errors = raw_current
 
     py_budget_raw = budget.get('pyright_errors')
     if not isinstance(py_budget_raw, dict):
@@ -186,7 +234,18 @@ def gate_pyright_errors(
             'typing_budget.json must include a pyright_errors section '
             "with {'total': <int>}"
         ]
-    budget_total = int(py_budget_raw.get('total', 0))
+    raw_budget_total = py_budget_raw.get('total', 0)
+    if isinstance(raw_budget_total, bool) or not isinstance(raw_budget_total, int):
+        return [
+            f'typing_budget.json: pyright_errors.total must be a '
+            f'non-negative integer (got {raw_budget_total!r})'
+        ]
+    if raw_budget_total < 0:
+        return [
+            f'typing_budget.json: pyright_errors.total must be '
+            f'non-negative (got {raw_budget_total})'
+        ]
+    budget_total = raw_budget_total
 
     if current_errors > budget_total:
         # Per-rule summary for the failure message.

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -4,23 +4,34 @@
 This gate blocks a PR that:
 
   1. Weakens the pyright configuration (gate-config ratchet).
-  2. Introduces new ``Any`` in production code (escape-hatch ratchet).
-  3. Introduces new ``# type: ignore`` / ``# pyright: ignore`` / ``# noqa``
+  2. Adds a ``pyrightconfig.json`` anywhere in the repo (pyright would
+     prefer it over ``pyproject.toml`` and bypass the strict config).
+  3. Changes ``pyright.include`` away from the required package list.
+  4. Introduces new ``Any`` in production code (escape-hatch ratchet).
+  5. Introduces new ``# type: ignore`` / ``# pyright: ignore`` / ``# noqa``
      comments (escape-hatch ratchet).
-  4. Introduces new ``cast(..., Any)`` / ``cast(Any, ...)`` calls.
-  5. Increases the total pyright-strict error count (pyright-error ratchet).
+  6. Introduces new ``cast(..., Any)`` / ``cast(Any, ...)`` calls.
+  7. Increases the total pyright-strict error count (pyright-error ratchet).
+  8. Raises ANY budget value compared to the protected base ref
+     (budget-source ratchet — the oracle cannot be weakened by the
+     same PR it gates).
+  9. Deletes a pattern key from the budget (same bypass class as #8).
+  10. Reports ``filesAnalyzed`` below the number of Python files under the
+      package root (shrinking the analysis surface is a trivial bypass).
 
 The gate is a ratchet, not a flat hard-fail. The budget file at
 ``.github/typing_budget.json`` caps the total count of each escape-hatch
 pattern and the pyright error count. Exceeding any cap fails the build.
-Decreasing the cap is allowed — any PR may lower the numbers in the
-budget to lock in improvements.
+Decreasing the cap is allowed — a PR may lower the numbers to lock in
+improvements — but all decreases are checked against the base-ref
+budget so the oracle cannot be weakened in the same PR that gates.
 
 Usage:
 
-  python tools/typing_gate.py                       # run all gates
-  python tools/typing_gate.py --pyright-json <path> # include pyright gate
-  python tools/typing_gate.py --update-budget       # regenerate the budget
+  python tools/typing_gate.py                                # head-only checks
+  python tools/typing_gate.py --pyright-json <path>          # + pyright ratchet
+  python tools/typing_gate.py --base-budget <path>           # + base-vs-head ratchet
+  python tools/typing_gate.py --update-budget [--pyright-json <path>]
 
 Exit codes:
 
@@ -117,6 +128,11 @@ REQUIRED_PYRIGHT: Final[dict[str, object]] = {
     'reportImportCycles': 'error',
 }
 
+# The `include` list pyright must analyze. Shrinking this to an empty
+# list or a non-existent path drops filesAnalyzed to zero, trivially
+# passing the error-count ratchet. Gate asserts exact match.
+REQUIRED_PYRIGHT_INCLUDE: Final[list[str]] = ['tdw_control_plane']
+
 FORBIDDEN_VALUES: Final[frozenset[object]] = frozenset(
     {'none', 'warning', 'information', 'info', 'false', False}
 )
@@ -124,10 +140,27 @@ FORBIDDEN_VALUES: Final[frozenset[object]] = frozenset(
 
 def gate_pyright_config(config: dict[str, object]) -> list[str]:
     failures: list[str] = []
+
+    # Pyright prefers pyrightconfig.json over [tool.pyright] in pyproject.toml.
+    # A PR that drops such a file anywhere in the repo silently shadows every
+    # setting this gate audits. Ban it outright.
+    for cfg in sorted(REPO_ROOT.rglob('pyrightconfig.json')):
+        rel = cfg.relative_to(REPO_ROOT)
+        # Skip vendored/dependency paths (.venv, node_modules, etc.)
+        parts = rel.parts
+        if any(p in {'.venv', 'venv', 'node_modules', 'build', 'dist', '.git'} for p in parts):
+            continue
+        failures.append(
+            f'pyrightconfig.json found at {rel}. '
+            f'Pyright prefers this file over pyproject.toml and would '
+            f'bypass the strict [tool.pyright] config. Delete it.'
+        )
+
     tool = config.get('tool')
     pyright = tool.get('pyright') if isinstance(tool, dict) else None
     if not isinstance(pyright, dict):
-        return ['[tool.pyright] section is missing from pyproject.toml']
+        failures.append('[tool.pyright] section is missing from pyproject.toml')
+        return failures
 
     for key, required in REQUIRED_PYRIGHT.items():
         actual = pyright.get(key)
@@ -135,6 +168,15 @@ def gate_pyright_config(config: dict[str, object]) -> list[str]:
             failures.append(
                 f'pyright.{key} must be {required!r}, got {actual!r}'
             )
+
+    # `include` must match exactly. Shrinking it drops filesAnalyzed.
+    actual_include = pyright.get('include')
+    if actual_include != REQUIRED_PYRIGHT_INCLUDE:
+        failures.append(
+            f'pyright.include must be exactly {REQUIRED_PYRIGHT_INCLUDE!r}, '
+            f'got {actual_include!r}. Changing this shrinks the analysis '
+            f'surface and lets errors escape the gate.'
+        )
 
     for key, value in pyright.items():
         if not isinstance(key, str):
@@ -270,6 +312,162 @@ def gate_pyright_errors(
 
 
 # -------------------------------------------------------------------
+# GATE 4 — budget-source ratchet. The PR's own budget (``head``) must
+# not raise any value and must not delete any pattern, compared to
+# the budget at the protected base ref. Without this, a PR can raise
+# its own ceiling and pass.
+# -------------------------------------------------------------------
+
+def gate_budget_source(
+    base_budget_path: str | None,
+    head_budget: dict[str, object],
+) -> list[str]:
+    if base_budget_path is None:
+        # First-time run or unable to fetch base; the workflow must
+        # provide --base-budget in PR / merge_group / push-to-main.
+        # Absence here is a config error, not a graceful skip.
+        return [
+            'typing_gate: --base-budget was not provided; '
+            'the workflow must fetch the budget from the protected base ref '
+            'and pass it as --base-budget'
+        ]
+
+    base_path = Path(base_budget_path)
+    if not base_path.is_file():
+        # Base ref has no budget file — this is the first commit that
+        # introduces the gate. In that case head is the baseline; nothing
+        # to compare against.
+        print(
+            f'typing_gate: base-ref budget not found at {base_path} '
+            f'(first commit introducing the gate?); skipping '
+            f'budget-source ratchet',
+            file=sys.stderr,
+        )
+        return []
+
+    try:
+        base_budget = json.loads(base_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f'typing_gate: cannot read base budget {base_path}: {exc}']
+
+    if not isinstance(base_budget, dict):
+        return [f'typing_gate: base budget {base_path} is not a JSON object']
+
+    failures: list[str] = []
+
+    # Pyright error ceiling
+    base_py = base_budget.get('pyright_errors')
+    head_py = head_budget.get('pyright_errors')
+    if isinstance(base_py, dict) and isinstance(head_py, dict):
+        b_total = base_py.get('total', 0)
+        h_total = head_py.get('total', 0)
+        if (
+            isinstance(b_total, int)
+            and not isinstance(b_total, bool)
+            and isinstance(h_total, int)
+            and not isinstance(h_total, bool)
+            and h_total > b_total
+        ):
+            failures.append(
+                f'pyright_errors.total was raised from {b_total} (base) '
+                f'to {h_total} (head). The oracle cannot be weakened '
+                f'by the PR it gates.'
+            )
+
+    # Pattern ceilings and key preservation
+    base_patterns_raw = base_budget.get('patterns')
+    head_patterns_raw = head_budget.get('patterns')
+    base_patterns: dict[str, object] = (
+        base_patterns_raw if isinstance(base_patterns_raw, dict) else {}
+    )
+    head_patterns: dict[str, object] = (
+        head_patterns_raw if isinstance(head_patterns_raw, dict) else {}
+    )
+
+    for key in base_patterns:
+        if key not in head_patterns:
+            failures.append(
+                f'pattern {key!r} was deleted from the budget. '
+                f'Keys present in the base-ref budget must be preserved.'
+            )
+
+    for key, base_spec in base_patterns.items():
+        if key not in head_patterns:
+            continue
+        head_spec = head_patterns[key]
+        if not (isinstance(base_spec, dict) and isinstance(head_spec, dict)):
+            continue
+        b_total = base_spec.get('total', 0)
+        h_total = head_spec.get('total', 0)
+        if (
+            isinstance(b_total, int)
+            and not isinstance(b_total, bool)
+            and isinstance(h_total, int)
+            and not isinstance(h_total, bool)
+            and h_total > b_total
+        ):
+            failures.append(
+                f'pattern {key!r} total was raised from {b_total} (base) '
+                f'to {h_total} (head). Only decreases are allowed.'
+            )
+
+    return failures
+
+
+# -------------------------------------------------------------------
+# GATE 5 — pyright filesAnalyzed must match the number of Python
+# files under the package root. Shrinking include (or hiding files
+# behind exclude) trivially drops filesAnalyzed to a smaller set and
+# lets errors escape.
+# -------------------------------------------------------------------
+
+def gate_files_analyzed(
+    pyright_json_path: str | None,
+    budget: dict[str, object],
+) -> list[str]:
+    if pyright_json_path is None:
+        return []
+    path = Path(pyright_json_path)
+    if not path.is_file():
+        return []
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return [f'pyright output is not valid JSON: {e}']
+    if not isinstance(data, dict):
+        return ['pyright output must be a JSON object']
+    summary = data.get('summary', {})
+    if not isinstance(summary, dict):
+        return ['pyright output .summary must be an object']
+
+    raw_analyzed = summary.get('filesAnalyzed', 0)
+    if isinstance(raw_analyzed, bool) or not isinstance(raw_analyzed, int):
+        return [
+            f'pyright output .summary.filesAnalyzed must be an integer '
+            f'(got {raw_analyzed!r})'
+        ]
+    analyzed = raw_analyzed
+
+    package_root_name = str(budget.get('package_root', ''))
+    if not package_root_name:
+        return ['typing_budget.json must set package_root']
+    package_root = REPO_ROOT / package_root_name
+    excludes_raw = budget.get('excludes', [])
+    excludes = [str(x) for x in excludes_raw] if isinstance(excludes_raw, list) else []
+    expected = len(find_python_files(package_root, excludes))
+
+    if analyzed < expected:
+        return [
+            f'pyright filesAnalyzed={analyzed} but the package has '
+            f'{expected} Python files. The analysis surface was '
+            f'shrunk (likely via pyright.include or pyright.exclude) '
+            f'and errors are hidden outside the analyzed set.'
+        ]
+    return []
+
+
+# -------------------------------------------------------------------
 # Baseline regeneration (--update-budget)
 # -------------------------------------------------------------------
 
@@ -350,6 +548,15 @@ def main() -> int:
         help='Path to pyright --outputjson output; enables pyright-error ratchet',
     )
     parser.add_argument(
+        '--base-budget',
+        default=None,
+        help=(
+            'Path to the budget JSON at the protected base ref. Without '
+            'this, the gate cannot check whether the head PR has raised '
+            'its own ceiling.'
+        ),
+    )
+    parser.add_argument(
         '--update-budget',
         action='store_true',
         help='Regenerate .github/typing_budget.json from current repo state',
@@ -374,11 +581,17 @@ def main() -> int:
     for msg in gate_pyright_config(config):
         failures.append(('pyright-config', msg))
 
+    for msg in gate_budget_source(args.base_budget, budget):
+        failures.append(('budget-source-ratchet', msg))
+
     for msg in gate_escape_hatch_ratchet(budget):
         failures.append(('escape-hatch-ratchet', msg))
 
     for msg in gate_pyright_errors(args.pyright_json, budget):
         failures.append(('pyright-error-ratchet', msg))
+
+    for msg in gate_files_analyzed(args.pyright_json, budget):
+        failures.append(('files-analyzed-ratchet', msg))
 
     if failures:
         print('TYPING GATE -- FAIL')


### PR DESCRIPTION
## What this gate mechanically enforces

Every rule below is deterministic. The `pr_checks_typing` workflow blocks merge if any single rule is false. Verified on CI against commit `cbccbaf` with pyright 1.1.408 and Python 3.11.

### A note before the rules: what enforces `Any` bans

`[tool.pyright]` sets `reportExplicitAny = "error"` and the gate requires this key to be present with that exact value. **However, pyright 1.1.408 emits `Config contains unrecognized setting "reportExplicitAny"` and does not honor the key at runtime.** The key is kept as a forward-compatible config-presence requirement for the day pyright (or a successor) respects it.

The actual `Any` enforcement today is **sub-gate 4** — an AST walker in `tools/typing_gate.py` that resolves every surface form of `typing.Any` (bare, attribute, aliased import, module-level assignment alias, chained alias) across the package. The regex ratchet in sub-gate 3 is an independent belt-and-suspenders check that catches the common surface forms in textual matches.

---

### Sub-gate 1 — pyright configuration audit (17 rules)

The gate fails the PR if any of these is false.

1. `pyproject.toml` contains a `[tool.pyright]` section.
2. `[tool.pyright].typeCheckingMode` is exactly `"strict"`.
3. `[tool.pyright].reportExplicitAny` is exactly `"error"` (config-presence requirement; see note above).
4. `[tool.pyright].reportMissingImports` is exactly `"error"`.
5. `[tool.pyright].reportMissingTypeStubs` is exactly `"error"`.
6. `[tool.pyright].reportUnknownArgumentType` is exactly `"error"`.
7. `[tool.pyright].reportUnknownMemberType` is exactly `"error"`.
8. `[tool.pyright].reportUnknownVariableType` is exactly `"error"`.
9. `[tool.pyright].reportUnknownLambdaType` is exactly `"error"`.
10. `[tool.pyright].reportUnknownParameterType` is exactly `"error"`.
11. `[tool.pyright].reportMissingParameterType` is exactly `"error"`.
12. `[tool.pyright].reportConstantRedefinition` is exactly `"error"`.
13. `[tool.pyright].reportImportCycles` is exactly `"error"`.
14. `[tool.pyright].include` is exactly `["tdw_control_plane"]` (shrinking this hides files).
15. No key in `[tool.pyright]` whose name starts with `report` is set to any of `"none"`, `"warning"`, `"information"`, `"info"`, `"false"`, or `false`.
16. No `pyrightconfig.json` exists anywhere in the repo outside pruned directories (`.git`, `.venv`, `venv`, `node_modules`, `build`, `dist`, `__pycache__`). Pyright prefers this file over `pyproject.toml`; its presence would silently shadow every rule in 1–15.
17. The workflow invokes the gate with **exactly one of** `--base-budget PATH` or `--bootstrap`, and `--bootstrap` is selected mechanically by the workflow (`git diff --name-only BASE...HEAD` shows `.github/typing_budget.json` was introduced in this commit), not by a human choosing it.

### Sub-gate 2 — budget-source ratchet (10 rules)

The head-ref budget is the PR's own `.github/typing_budget.json`. The base-ref budget is the same file as it exists at the protected branch tip (`origin/main` for PRs / merge-queue, `HEAD~1` for push-to-main). The gate fails the PR if any of these is false when `--base-budget` is passed.

18. `head.package_root` is identical to `base.package_root`.
19. `head.excludes` is a subset of `base.excludes` (head may remove entries; adding an entry hides files from the ratchet).
20. For every pattern key present in `base.patterns`, the same key is present in `head.patterns`.
21. For every pattern key present in both, `head.patterns[key].pattern` is byte-identical to `base.patterns[key].pattern` (the regex cannot be rewritten to one that never matches).
22. For every pattern key present in both, `head.patterns[key].total` is ≤ `base.patterns[key].total`.
23. `head.any_references` is present (the section cannot be deleted).
24. `head.any_references.total` is ≤ `base.any_references.total`.
25. `head.pyright_errors` is present (the section cannot be deleted).
26. `head.pyright_errors.total` is ≤ `base.pyright_errors.total`.
27. If `--bootstrap` is passed instead of `--base-budget`, the workflow has also verified the head commit introduces `.github/typing_budget.json` to the protected ref (otherwise the workflow hard-fails before the gate runs).

### Sub-gate 3 — escape-hatch regex ratchet (10 rules)

Counts are computed across `tdw_control_plane/**/*.py`, excluding entries in `excludes`. Each count compared against the head budget's matching total.

28. Count of `:\s*Any\b` matches is ≤ `patterns.any_annotation.total`.
29. Count of `->\s*Any\b` matches is ≤ `patterns.any_return.total`.
30. Count of `from typing import[^\n]*\bAny\b` matches is ≤ `patterns.any_import.total`.
31. Count of `cast\([^)]*\bAny\b` matches is ≤ `patterns.cast_any.total`.
32. Count of `dict\[[^]]*\bAny\b` matches is ≤ `patterns.dict_any.total`.
33. Count of `list\[\s*Any\b` matches is ≤ `patterns.list_any.total`.
34. Count of `tuple\[[^]]*\bAny\b` matches is ≤ `patterns.tuple_any.total`.
35. Count of `#\s*type:\s*ignore` matches is ≤ `patterns.type_ignore.total`.
36. Count of `#\s*pyright:\s*ignore` matches is ≤ `patterns.pyright_ignore.total`.
37. Count of `#\s*noqa` matches is ≤ `patterns.noqa.total`.

### Sub-gate 4 — AST `Any`-reference ratchet (1 rule; this is where `Any` is actually enforced today)

38. The total number of AST-resolved references to `typing.Any` across `tdw_control_plane/**/*.py` (excluding `excludes`) is ≤ `any_references.total`.

The detector catches every surface form:

- `Any` after `from typing import Any`
- `X` after `from typing import Any as X`
- `typing.Any` after `import typing`
- `t.Any` after `import typing as t`
- Module-level assignment aliases: `A = typing.Any` adds `A` to the `Any` name set.
- Chained aliases: `A = typing.Any; B = A; C = B` — all resolve to the `Any` name set at a fixed point.
- Uses in every position: annotation, return type, generic argument (`list[Any]`, `dict[str, Any]`, `Optional[Any]`), `cast(Any, x)`, variable binding.

Only `ast.Load` contexts are counted as uses, so the LHS of an alias assignment is not double-counted with its RHS.

### Sub-gate 5 — pyright error-count ratchet (1 rule)

39. `summary.errorCount` from `pyright --outputjson`, run on CI (pyright 1.1.408, Python 3.11, `include = ["tdw_control_plane"]`), is ≤ `pyright_errors.total`.

### Sub-gate 6 — `filesAnalyzed` ratchet (1 rule)

40. `summary.filesAnalyzed` from `pyright --outputjson` is ≥ the count of Python files the gate finds under `package_root` with `excludes` applied. A PR that shrinks the analysis surface via `pyright.include`, `pyright.exclude`, or both causes this rule to fail.

---

### Baseline (committed at `.github/typing_budget.json`)

| field | value |
|---|---|
| `package_root` | `"tdw_control_plane"` |
| `excludes` | `["__pycache__", "quickstart_etl_tests", "build", "dist"]` |
| `patterns.*.total` | `0` for every pattern (tdw currently has zero regex-matchable escape hatches) |
| `any_references.total` | `0` |
| `pyright_errors.total` | `1213` |

### How the numbers change

- **Lowering any value in the budget is always allowed.** To lock in an improvement: remove the escape hatches in your PR, run `python tools/typing_gate.py --update-budget --pyright-json pyright_output.json`, commit the updated `.github/typing_budget.json`, push. Sub-gate 2 verifies the new numbers are ≤ base.
- **Raising any value is never allowed** by any mechanism. No flag, no environment variable, no comment syntax, no config toggle. Sub-gate 2 compares against the budget on the protected base ref, fetched by the workflow via `git show BASE:.github/typing_budget.json`. The PR cannot re-oracle itself.
- **Adding a required pyright key** to rules 2–14 requires editing both `tools/typing_gate.py` (`REQUIRED_PYRIGHT`) and `pyproject.toml`. Removing a required key requires only editing the script — which then fails the gate's own config audit on the PR that removes it.
- **Adding a new regex pattern** to the escape-hatch ratchet requires editing `tools/typing_gate.py` (`DEFAULT_PATTERNS`) and regenerating the budget. Sub-gate 2 will require the new key to also be present in future base budgets, locked by the merge of the PR that introduces it.

### Verified transitions

| change | rules that become false | outcome |
|---|---|---|
| unmodified tree | none | PASS |
| add `: Any` to any production file | 28, 38 | FAIL |
| add `typing.Any` to any production file | 38 (regex-blind, AST catches) | FAIL |
| add `t.Any` via `import typing as t` | 38 | FAIL |
| add `A = typing.Any; x: A = 1; y: A = 2` | 38 (counts 3) | FAIL |
| chained alias `A = typing.Any; B = A; C = B; x: C = 1` | 38 (counts 4) | FAIL |
| add `cast(Any, x)` | 31, 38 | FAIL |
| set `reportExplicitAny = "none"` | 3, 15 | FAIL |
| remove `[tool.pyright]` section | 1–14 | FAIL |
| drop `pyrightconfig.json` at repo root | 16 | FAIL |
| shrink `pyright.include` to `[]` | 14, 40 | FAIL |
| narrow head-ref `package_root` | 18 | FAIL |
| add an entry to head-ref `excludes` | 19 | FAIL |
| rewrite a pattern regex in head-ref budget | 21 | FAIL |
| delete a pattern key from head-ref budget | 20 | FAIL |
| raise `pyright_errors.total` in head-ref budget | 26 | FAIL |
| raise `any_references.total` in head-ref budget | 24 | FAIL |
| typecheck regresses by one error | 39 | FAIL |
| pyright `filesAnalyzed` drops below package file count | 40 | FAIL |
| omit `--base-budget` and `--bootstrap` from invocation | 17 | FAIL |
| pass both `--base-budget` and `--bootstrap` | 17 | FAIL |
| `--bootstrap` invoked when head does not introduce the budget | (workflow fails pre-gate) | FAIL |

### Files

- `.github/workflows/pr_checks_typing.yml` — file name, `name:` field, and job name all `pr_checks_typing`.
- `tools/typing_gate.py` — single entry point for all six sub-gates.
- `.github/typing_budget.json` — the committed oracle.
- `pyproject.toml` — `[tool.pyright]` strict + full `report*` matrix, `[tool.ruff]` (E/F/I/UP/RUF/BLE/ANN).
- `.github/workflows/pr_checks_codeql.yml` — bumped `python-version` to `3.11` to match `requires-python`.