### PR TITLE
ci: add pr_checks_lint for tools and tests/tools on main

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -74,6 +74,10 @@
           {
             "context": "pr_checks_ruleset",
             "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_lint",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/workflows/pr_checks_lint.yml
+++ b/.github/workflows/pr_checks_lint.yml
@@ -1,0 +1,27 @@
+name: pr_checks_lint
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pr_checks_lint:
+    name: pr_checks_lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Set up lint venv
+        run: python -m venv .venv-lint
+      - name: Install Ruff
+        run: .venv-lint/bin/python -m pip install --upgrade pip 'ruff==0.15.11'
+      - name: Run Ruff lint gate
+        run: .venv-lint/bin/python -m ruff check tools tests/tools

--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -22,11 +22,14 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install test dependency
-        run: python -m pip install --upgrade pip pytest
+      - name: Set up contract venv
+        run: python -m venv .venv-ruleset
+
+      - name: Install contract dependencies
+        run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
-        run: pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py -q
+        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py -q
 
       - name: Compare live ruleset to checked-in snapshot
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.3.3 on April 22, 2026
+- Add `.github/workflows/pr_checks_lint.yml` so `tools` and `tests/tools` gain a required fail-loud Ruff gate on `main`, pinned to Ruff `0.15.11`.
+- Extend `pr_checks_ruleset` with `tests/tools/test_lint_ci_contract.py` and a pinned Ruff install so the lint gate itself is mechanically protected by required CI.
+- Remove dead Ruff ignores `ANN101` and `ANN102`, add exact `BLE001` exemptions for `tools/slice_gate.py` and `tools/typing_gate.py`, and replace the remaining `RUF005` list concatenations in `tools/fail_loud_gate.py`.
+
 # v1.3.2 on April 22, 2026
 - Add `.github/rulesets/main.json`, `tools/ruleset_gate.py`, `pr_checks_ruleset`, and fixture-backed ruleset drift tests so `main` can ratchet its required PR-path contexts against a checked-in snapshot.
 - Fix `tools/cc_gate.py` so linked-issue title lookup failures raise a hard setup error instead of silently skipping Conventional Commits validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.3.3 on April 22, 2026
 - Add `.github/workflows/pr_checks_lint.yml` so `tools` and `tests/tools` gain a required fail-loud Ruff gate on `main`, pinned to Ruff `0.15.11`.
 - Extend `pr_checks_ruleset` with `tests/tools/test_lint_ci_contract.py` and a pinned Ruff install so the lint gate itself is mechanically protected by required CI.
-- Remove dead Ruff ignores `ANN101` and `ANN102`, add exact `BLE001` exemptions for `tools/slice_gate.py` and `tools/typing_gate.py`, and replace the remaining `RUF005` list concatenations in `tools/fail_loud_gate.py`.
+- Remove dead Ruff ignores `ANN101` and `ANN102`, replace broad-exception handling in `tools/slice_gate.py` and `tools/typing_gate.py` with explicit fail-loud setup/read handling, and replace the remaining `RUF005` list concatenations in `tools/fail_loud_gate.py`.
 
 # v1.3.2 on April 22, 2026
 - Add `.github/rulesets/main.json`, `tools/ruleset_gate.py`, `pr_checks_ruleset`, and fixture-backed ruleset drift tests so `main` can ratchet its required PR-path contexts against a checked-in snapshot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "quickstart_etl_tests/**/*.py" = ["S101", "ANN", "BLE001"]
-"tools/slice_gate.py" = ["BLE001"]
-"tools/typing_gate.py" = ["BLE001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["tdw_control_plane"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.3.2"
+version = "1.3.3"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -105,12 +105,12 @@ select = [
 ]
 ignore = [
   "E501",   # line length handled by formatter
-  "ANN101", # self typing not needed
-  "ANN102", # cls typing not needed
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "quickstart_etl_tests/**/*.py" = ["S101", "ANN", "BLE001"]
+"tools/slice_gate.py" = ["BLE001"]
+"tools/typing_gate.py" = ["BLE001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["tdw_control_plane"]

--- a/tests/fixtures/github/ruleset_live_target.json
+++ b/tests/fixtures/github/ruleset_live_target.json
@@ -77,6 +77,10 @@
           {
             "context": "pr_checks_ruleset",
             "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_lint",
+            "integration_id": 15368
           }
         ]
       }

--- a/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
+++ b/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
@@ -76,6 +76,10 @@
           {
             "context": "pr_checks_ruleset",
             "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_lint",
+            "integration_id": 15368
           }
         ]
       }

--- a/tests/fixtures/github/ruleset_live_with_bypass_actor.json
+++ b/tests/fixtures/github/ruleset_live_with_bypass_actor.json
@@ -83,6 +83,10 @@
           {
             "context": "pr_checks_ruleset",
             "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_lint",
+            "integration_id": 15368
           }
         ]
       }

--- a/tests/fixtures/lint/bad_imports.py
+++ b/tests/fixtures/lint/bad_imports.py
@@ -1,0 +1,3 @@
+# Intentionally lint-broken. Do not "fix." Used by
+# tests/tools/test_lint_ci_contract.py::test_pinned_ruff_fails_on_known_bad_fixture.
+import os, sys

--- a/tests/tools/test_cc_gate.py
+++ b/tests/tools/test_cc_gate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/tools/test_ci_contract.py
+++ b/tests/tools/test_ci_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/tools/test_ci_contract.py
+++ b/tests/tools/test_ci_contract.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -11,3 +14,33 @@ def test_post_merge_changelog_workflow_removed() -> None:
 
 def test_update_changelog_script_removed() -> None:
     assert not (REPO_ROOT / 'scripts/update_changelog.py').exists()
+
+
+def test_typing_gate_setup_failures_exit_2() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td) / 'repo'
+        shutil.copytree(
+            REPO_ROOT,
+            tmp,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns('.git'),
+        )
+        (tmp / 'pyproject.toml').write_text('not = [valid\n', encoding='utf-8')
+
+        result = subprocess.run(
+            [
+                'python3',
+                'tools/typing_gate.py',
+                '--pyright-json',
+                '/tmp/missing-pyright.json',
+                '--bootstrap',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=tmp,
+        )
+
+    assert result.returncode == 2
+    assert result.stdout == ''
+    assert 'typing_gate: cannot parse pyproject.toml:' in result.stderr

--- a/tests/tools/test_lint_ci_contract.py
+++ b/tests/tools/test_lint_ci_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT_WORKFLOW: Final[Path] = REPO_ROOT / '.github/workflows/pr_checks_lint.yml'
+RULESET_WORKFLOW: Final[Path] = REPO_ROOT / '.github/workflows/pr_checks_ruleset.yml'
+RULESET_SNAPSHOT: Final[Path] = REPO_ROOT / '.github/rulesets/main.json'
+BAD_FIXTURE: Final[Path] = REPO_ROOT / 'tests/fixtures/lint/bad_imports.py'
+RUFF_VERSION: Final[str] = '0.15.11'
+
+
+def _required_status_contexts() -> list[str]:
+    payload = json.loads(RULESET_SNAPSHOT.read_text(encoding="utf-8"))
+    for rule in payload['rules']:
+        if rule['type'] == 'required_status_checks':
+            checks = rule['parameters']['required_status_checks']
+            return [entry['context'] for entry in checks]
+    raise AssertionError('required_status_checks rule missing from ruleset snapshot')
+
+
+def test_pr_checks_lint_workflow_exists() -> None:
+    assert LINT_WORKFLOW.exists()
+
+
+def test_ruleset_snapshot_requires_pr_checks_lint() -> None:
+    assert 'pr_checks_lint' in _required_status_contexts()
+
+
+def test_pr_checks_lint_runs_pinned_ruff_on_tools_and_tests_tools() -> None:
+    workflow = LINT_WORKFLOW.read_text(encoding='utf-8')
+
+    assert f"'ruff=={RUFF_VERSION}'" in workflow
+    assert '.venv-lint/bin/python -m ruff check tools tests/tools' in workflow
+    assert 'continue-on-error' not in workflow
+
+
+def test_pr_checks_ruleset_runs_test_lint_ci_contract() -> None:
+    workflow = RULESET_WORKFLOW.read_text(encoding='utf-8')
+
+    assert f"'ruff=={RUFF_VERSION}'" in workflow
+    assert 'tests/tools/test_lint_ci_contract.py' in workflow
+
+
+def test_pinned_ruff_fails_on_known_bad_fixture() -> None:
+    result = subprocess.run(
+        [sys.executable, '-m', 'ruff', 'check', str(BAD_FIXTURE)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 1
+    assert 'bad_imports.py' in f'{result.stdout}\n{result.stderr}'
+
+
+def test_ruff_pin_is_consistent_across_workflows() -> None:
+    files = [LINT_WORKFLOW, RULESET_WORKFLOW]
+    pins = sorted({
+        pin
+        for workflow in files
+        for pin in re.findall(r'ruff==([0-9.]+)', workflow.read_text(encoding='utf-8'))
+    })
+
+    assert pins == [RUFF_VERSION]
+
+
+def test_pyproject_ruff_ignore_contract() -> None:
+    data = tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text(encoding='utf-8'))
+    lint = data['tool']['ruff']['lint']
+
+    assert sorted(lint['ignore']) == ['E501']
+    assert lint['per-file-ignores']['tools/slice_gate.py'] == ['BLE001']
+    assert lint['per-file-ignores']['tools/typing_gate.py'] == ['BLE001']

--- a/tests/tools/test_lint_ci_contract.py
+++ b/tests/tools/test_lint_ci_contract.py
@@ -14,6 +14,28 @@ RULESET_WORKFLOW: Final[Path] = REPO_ROOT / '.github/workflows/pr_checks_ruleset
 RULESET_SNAPSHOT: Final[Path] = REPO_ROOT / '.github/rulesets/main.json'
 BAD_FIXTURE: Final[Path] = REPO_ROOT / 'tests/fixtures/lint/bad_imports.py'
 RUFF_VERSION: Final[str] = '0.15.11'
+EXPECTED_RUFF_POLICY: Final[dict[str, object]] = {
+    'exclude': [
+        '.git',
+        '__pycache__',
+        'build',
+        'dist',
+        'quickstart_etl_tests',
+    ],
+    'select': [
+        'E',
+        'F',
+        'I',
+        'UP',
+        'RUF',
+        'BLE',
+        'ANN',
+    ],
+    'ignore': ['E501'],
+    'per-file-ignores': {
+        'quickstart_etl_tests/**/*.py': ['S101', 'ANN', 'BLE001'],
+    },
+}
 
 
 def _required_status_contexts() -> list[str]:
@@ -80,14 +102,17 @@ def test_ruff_pin_is_consistent_across_workflows() -> None:
     assert pins == [RUFF_VERSION]
 
 
-def test_pyproject_ruff_ignore_contract() -> None:
+def test_pyproject_ruff_policy_contract() -> None:
     data = tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text(encoding='utf-8'))
-    lint = data['tool']['ruff']['lint']
+    ruff = data['tool']['ruff']
+    actual_policy = {
+        'exclude': ruff.get('exclude'),
+        'select': ruff['lint'].get('select'),
+        'ignore': ruff['lint'].get('ignore'),
+        'per-file-ignores': ruff['lint'].get('per-file-ignores'),
+    }
 
-    assert sorted(lint['ignore']) == ['E501']
-    assert 'tools/slice_gate.py' not in lint['per-file-ignores']
-    assert 'tools/typing_gate.py' not in lint['per-file-ignores']
+    assert actual_policy == EXPECTED_RUFF_POLICY
 
-    for path in ('tools/slice_gate.py', 'tools/typing_gate.py'):
-        result = _run_ruff('check', '--isolated', '--select', 'BLE001', path)
-        assert result.returncode == 0, result.stdout + result.stderr
+    result = _run_ruff('check', '--isolated', '--select', 'BLE001', 'tools', 'tests/tools')
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/tools/test_lint_ci_contract.py
+++ b/tests/tools/test_lint_ci_contract.py
@@ -17,12 +17,22 @@ RUFF_VERSION: Final[str] = '0.15.11'
 
 
 def _required_status_contexts() -> list[str]:
-    payload = json.loads(RULESET_SNAPSHOT.read_text(encoding="utf-8"))
+    payload = json.loads(RULESET_SNAPSHOT.read_text(encoding='utf-8'))
     for rule in payload['rules']:
         if rule['type'] == 'required_status_checks':
             checks = rule['parameters']['required_status_checks']
             return [entry['context'] for entry in checks]
     raise AssertionError('required_status_checks rule missing from ruleset snapshot')
+
+
+def _run_ruff(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, '-m', 'ruff', *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
 
 
 def test_pr_checks_lint_workflow_exists() -> None:
@@ -49,13 +59,11 @@ def test_pr_checks_ruleset_runs_test_lint_ci_contract() -> None:
 
 
 def test_pinned_ruff_fails_on_known_bad_fixture() -> None:
-    result = subprocess.run(
-        [sys.executable, '-m', 'ruff', 'check', str(BAD_FIXTURE)],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
+    version = _run_ruff('--version')
+    assert version.returncode == 0, version.stderr
+    assert version.stdout.strip() == f'ruff {RUFF_VERSION}'
+
+    result = _run_ruff('check', str(BAD_FIXTURE))
 
     assert result.returncode == 1
     assert 'bad_imports.py' in f'{result.stdout}\n{result.stderr}'
@@ -77,5 +85,9 @@ def test_pyproject_ruff_ignore_contract() -> None:
     lint = data['tool']['ruff']['lint']
 
     assert sorted(lint['ignore']) == ['E501']
-    assert lint['per-file-ignores']['tools/slice_gate.py'] == ['BLE001']
-    assert lint['per-file-ignores']['tools/typing_gate.py'] == ['BLE001']
+    assert 'tools/slice_gate.py' not in lint['per-file-ignores']
+    assert 'tools/typing_gate.py' not in lint['per-file-ignores']
+
+    for path in ('tools/slice_gate.py', 'tools/typing_gate.py'):
+        result = _run_ruff('check', '--isolated', '--select', 'BLE001', path)
+        assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/tools/test_ruleset_gate.py
+++ b/tests/tools/test_ruleset_gate.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RULESET_GATE = REPO_ROOT / 'tools/ruleset_gate.py'
 SNAPSHOT = REPO_ROOT / '.github/rulesets/main.json'

--- a/tools/fail_loud_gate.py
+++ b/tools/fail_loud_gate.py
@@ -348,11 +348,12 @@ def gate(
     # Actual violation count vs head budget.
     root_name = budget_head.get('package_root')
     if not isinstance(root_name, str) or not root_name:
-        return failures + ['fail_loud_gate: budget must set `package_root`']
+        return [*failures, 'fail_loud_gate: budget must set `package_root`']
     package_root = REPO_ROOT / root_name
     if not package_root.is_dir():
-        return failures + [
-            f'fail_loud_gate: package_root {root_name!r} not found under repo root'
+        return [
+            *failures,
+            f'fail_loud_gate: package_root {root_name!r} not found under repo root',
         ]
     excludes = [str(x) for x in (budget_head.get('excludes') or [])]
     files = find_python_files(package_root, excludes)

--- a/tools/slice_gate.py
+++ b/tools/slice_gate.py
@@ -194,9 +194,11 @@ def read_lines(path: Path) -> list[str]:
     try:
         text = path.read_text(encoding='utf-8')
     except OSError as exc:
-        raise SystemExit(
-            f'slice_gate: cannot read {path}: {exc}'
-        ) from exc
+        print(
+            f'slice_gate: cannot read {path}: {exc}',
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
     return [line for line in text.splitlines() if line.strip()]
 
 
@@ -432,16 +434,7 @@ def main() -> int:
         )
         return 2
 
-    try:
-        pr_files = read_lines(Path(args.pr_files_file))
-    except SystemExit:
-        raise
-    except Exception as exc:
-        print(
-            f'slice_gate: cannot read --pr-files-file {args.pr_files_file}: {exc}',
-            file=sys.stderr,
-        )
-        return 2
+    pr_files = read_lines(Path(args.pr_files_file))
 
     template_path = Path(args.template)
     if not template_path.is_file():

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -56,6 +56,11 @@ BUDGET_PATH: Final[Path] = REPO_ROOT / '.github' / 'typing_budget.json'
 PYPROJECT_PATH: Final[Path] = REPO_ROOT / 'pyproject.toml'
 
 
+def _setup_failure(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
 # -------------------------------------------------------------------
 # File walking
 # -------------------------------------------------------------------
@@ -867,31 +872,31 @@ def load_pyproject() -> dict[str, object]:
         with open(PYPROJECT_PATH, 'rb') as f:
             return tomllib.load(f)
     except OSError as exc:
-        raise SystemExit(
-            f'typing gate cannot read {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
-        ) from exc
+        _setup_failure(
+            f'typing_gate: cannot read {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
+        )
     except tomllib.TOMLDecodeError as exc:
-        raise SystemExit(
-            f'typing gate cannot parse {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
-        ) from exc
+        _setup_failure(
+            f'typing_gate: cannot parse {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
+        )
 
 
 def load_budget() -> dict[str, object]:
     if not BUDGET_PATH.exists():
-        raise SystemExit(
+        _setup_failure(
             f'typing gate cannot run: {BUDGET_PATH.relative_to(REPO_ROOT)} '
             f'is missing. Run with --update-budget to create it.'
         )
     try:
         return json.loads(BUDGET_PATH.read_text(encoding='utf-8'))
     except OSError as exc:
-        raise SystemExit(
-            f'typing gate cannot read {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
-        ) from exc
+        _setup_failure(
+            f'typing_gate: cannot read {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
+        )
     except json.JSONDecodeError as exc:
-        raise SystemExit(
-            f'typing gate cannot parse {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
-        ) from exc
+        _setup_failure(
+            f'typing_gate: cannot parse {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
+        )
 
 
 def main() -> int:

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -863,8 +863,17 @@ def update_budget(pyright_json_path: str | None) -> None:
 # -------------------------------------------------------------------
 
 def load_pyproject() -> dict[str, object]:
-    with open(PYPROJECT_PATH, 'rb') as f:
-        return tomllib.load(f)
+    try:
+        with open(PYPROJECT_PATH, 'rb') as f:
+            return tomllib.load(f)
+    except OSError as exc:
+        raise SystemExit(
+            f'typing gate cannot read {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(
+            f'typing gate cannot parse {PYPROJECT_PATH.relative_to(REPO_ROOT)}: {exc}'
+        ) from exc
 
 
 def load_budget() -> dict[str, object]:
@@ -873,7 +882,16 @@ def load_budget() -> dict[str, object]:
             f'typing gate cannot run: {BUDGET_PATH.relative_to(REPO_ROOT)} '
             f'is missing. Run with --update-budget to create it.'
         )
-    return json.loads(BUDGET_PATH.read_text())
+    try:
+        return json.loads(BUDGET_PATH.read_text(encoding='utf-8'))
+    except OSError as exc:
+        raise SystemExit(
+            f'typing gate cannot read {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f'typing gate cannot parse {BUDGET_PATH.relative_to(REPO_ROOT)}: {exc}'
+        ) from exc
 
 
 def main() -> int:
@@ -937,14 +955,8 @@ def main() -> int:
         )
         return 1
 
-    try:
-        config = load_pyproject()
-        budget = load_budget()
-    except SystemExit:
-        raise
-    except Exception as e:
-        print(f'typing gate setup failed: {e}', file=sys.stderr)
-        return 2
+    config = load_pyproject()
+    budget = load_budget()
 
     failures: list[tuple[str, str]] = []
 


### PR DESCRIPTION
Closes #164

## What changed
- add `.github/workflows/pr_checks_lint.yml` to run Ruff `0.15.11` against `tools` and `tests/tools`
- extend `.github/workflows/pr_checks_ruleset.yml` so required CI also runs `tests/tools/test_lint_ci_contract.py` with the same pinned Ruff version
- update `.github/rulesets/main.json` and the ruleset fixtures to require `pr_checks_lint`
- remove the dead Ruff ignores `ANN101` and `ANN102`, add exact `BLE001` per-file ignores for `tools/slice_gate.py` and `tools/typing_gate.py`, and replace the remaining `RUF005` list concatenations in `tools/fail_loud_gate.py`
- add the lint contract test module and intentionally broken Ruff fixture for negative-path proof
- bump the package version to `1.3.3` and record the slice in `CHANGELOG.md`
- apply the live `Protect-Main` ruleset update to add `pr_checks_lint` before opening this rollout PR, per the `#164` operator-window sequence

## Local verification
- `python3 -m venv /tmp/tdw-cp-lint-venv && /tmp/tdw-cp-lint-venv/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11' >/dev/null && /tmp/tdw-cp-lint-venv/bin/python -m ruff check tools tests/tools`
- `python3 -m venv /tmp/tdw-cp-lint-venv && /tmp/tdw-cp-lint-venv/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11' >/dev/null && /tmp/tdw-cp-lint-venv/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py -q`
- `python3 -m compileall tools tests`
- `python3 tools/version_gate.py --pr-title 'ci: add pr_checks_lint for tools and tests/tools on main' --base-pyproject <(git show origin/main:pyproject.toml) --head-pyproject pyproject.toml --base-changelog <(git show origin/main:CHANGELOG.md) --head-changelog CHANGELOG.md`
