### PR TITLE
ci: sync ruleset gate fixtures after pr_checks_lint and pr_checks_tests landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.1 on April 22, 2026
+- Sync `tests/fixtures/github/ruleset_live_unexpected_field.json` to the current 9-context protected-check set on `main`, including `pr_checks_lint` and `pr_checks_tests`.
+- Add `test_unexpected_field_fixture_preserves_required_contexts` so `pr_checks_ruleset` fails if that negative fixture ever drifts from the checked-in ruleset snapshot's required-status list.
+
 # v1.4.0 on April 22, 2026
 - Move the runtime image to Python `3.11.12` so Docker matches the package and CI interpreter contract.
 - Replace the Origo path with a daily-source-native Binance spot trades template: idempotent `create_origo_database`, idempotent `create_binance_daily_spot_trades_table_origo`, and fail-loud `insert_daily_binance_spot_trades_to_origo`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.4.0"
+version = "1.4.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/github/ruleset_live_unexpected_field.json
+++ b/tests/fixtures/github/ruleset_live_unexpected_field.json
@@ -77,6 +77,14 @@
           {
             "context": "pr_checks_ruleset",
             "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_lint",
+            "integration_id": 15368
+          },
+          {
+            "context": "pr_checks_tests",
+            "integration_id": 15368
           }
         ]
       }

--- a/tests/tools/test_ruleset_gate.py
+++ b/tests/tools/test_ruleset_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -52,6 +53,33 @@ def test_unexpected_top_level_field_in_live_is_drift() -> None:
     result = run_gate('ruleset_live_unexpected_field.json')
     assert result.returncode == 1
     assert 'unexpected live ruleset field(s)' in result.stderr
+
+
+def test_unexpected_field_fixture_preserves_required_contexts() -> None:
+    snapshot = json.loads(SNAPSHOT.read_text(encoding='utf-8'))
+    unexpected = json.loads((FIXTURES / 'ruleset_live_unexpected_field.json').read_text(encoding='utf-8'))
+
+    def required_contexts(payload: dict[str, object]) -> list[str]:
+        rules = payload['rules']
+        assert isinstance(rules, list)
+        for rule in rules:
+            assert isinstance(rule, dict)
+            if rule.get('type') == 'required_status_checks':
+                parameters = rule['parameters']
+                assert isinstance(parameters, dict)
+                required_status_checks = parameters['required_status_checks']
+                assert isinstance(required_status_checks, list)
+                return [
+                    entry['context']
+                    for entry in required_status_checks
+                    if isinstance(entry, dict)
+                ]
+        raise AssertionError('required_status_checks rule not found')
+
+    snapshot_contexts = required_contexts(snapshot)
+    unexpected_contexts = required_contexts(unexpected)
+
+    assert unexpected_contexts == snapshot_contexts
 
 
 def test_ignored_live_fields_match_named_set() -> None:


### PR DESCRIPTION
## Summary
- sync the unexpected-field ruleset fixture to the current 9 required contexts on `main`
- add a regression test that pins that fixture's required-status set to the checked-in snapshot
- bump the package version to `1.4.1` and record the slice in `CHANGELOG.md`

## Testing
- `/tmp/tdw-162-venv/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py -q`
- `python3 -m compileall tests tools`
- `python3 tools/version_gate.py --pr-title 'ci: sync ruleset gate fixtures after pr_checks_lint and pr_checks_tests landed' --base-pyproject /tmp/tdw-162-base-pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/tdw-162-base-CHANGELOG.md --head-changelog CHANGELOG.md`
- `python3 tools/ruleset_gate.py --ruleset-file .github/rulesets/main.json --repo Vaquum/tdw-control-plane --ruleset-id 5406599`

Closes #162.