### PR TITLE
feat(origo): complete binance spot new data source template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.0 on April 23, 2026
+- Complete the first Binance spot Origo data-source template on top of `binance_daily_spot_trades` by adding the single-source `binance_spot_klines` projection and the shared `aligned_1m_exchange` projection layer.
+- Replace the old raw-only daily Origo schedule target with `refresh_binance_spot_data_source_job`, which materializes the raw daily insert plus both projection layers for the same partition.
+- Add end-to-end `tests/origo_source_native/test_origo_binance_spot_data_source_template.py` proofs for table-name contracts, exact schema, exact Binance-derived 1-minute rows, aligned dataset-source rows, and same-partition rerun idempotency.
+
 # v1.4.1 on April 22, 2026
 - Sync `tests/fixtures/github/ruleset_live_unexpected_field.json` to the current 9-context protected-check set on `main`, including `pr_checks_lint` and `pr_checks_tests`.
 - Add `test_unexpected_field_fixture_preserves_required_contexts` so `pr_checks_ruleset` fails if that negative fixture ever drifts from the checked-in ruleset snapshot's required-status list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.4.1"
+version = "1.5.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
+++ b/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
@@ -1,0 +1,89 @@
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_origo_database import (
+    ClickHouseSettings,
+    _get_clickhouse_settings,
+    _make_clickhouse_client,
+    create_origo_database,
+)
+
+ALIGNED_TABLE_NAME = 'aligned_1m_exchange'
+
+
+def _database_exists(client: ClickhouseClient, database: str) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.databases
+        WHERE name = '{database}'
+        """
+    )
+    return bool(result[0][0])
+
+
+def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_name: str) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.tables
+        WHERE database = '{settings.database}'
+          AND name = '{table_name}'
+        """
+    )
+    return bool(result[0][0])
+
+
+def _create_aligned_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {settings.database}.{ALIGNED_TABLE_NAME} (
+            dataset_source LowCardinality(String),
+            open_time UInt64,
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            volume Float64,
+            close_time UInt64,
+            quote_asset_volume Float64,
+            number_of_trades UInt64,
+            taker_buy_base_asset_volume Float64,
+            taker_buy_quote_asset_volume Float64,
+            ignore Float64
+        )
+        ENGINE = MergeTree()
+        PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time))
+        ORDER BY (dataset_source, open_time)
+        """
+    )
+
+
+@asset(
+    group_name='origo_setup',
+    deps=[create_origo_database],
+    description='Creates the aligned_1m_exchange table if it does not exist',
+)
+def create_aligned_1m_exchange_table_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        if not _database_exists(client, settings.database):
+            raise RuntimeError(
+                f'Database {settings.database} does not exist. Run create_origo_database first.'
+            )
+
+        table_existed = _table_exists(client, settings, ALIGNED_TABLE_NAME)
+        _create_aligned_table(client, settings)
+
+        context.log.info(f'Ensured table {settings.database}.{ALIGNED_TABLE_NAME} exists.')
+        return {
+            'status': 'success',
+            'table': f'{settings.database}.{ALIGNED_TABLE_NAME}',
+            'table_action': 'already_exists' if table_existed else 'created',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
+++ b/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
@@ -1,6 +1,7 @@
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
+from .create_binance_trades_table_origo import _database_exists, _table_exists
 from .create_origo_database import (
     ClickHouseSettings,
     _get_clickhouse_settings,
@@ -9,29 +10,6 @@ from .create_origo_database import (
 )
 
 ALIGNED_TABLE_NAME = 'aligned_1m_exchange'
-
-
-def _database_exists(client: ClickhouseClient, database: str) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.databases
-        WHERE name = '{database}'
-        """
-    )
-    return bool(result[0][0])
-
-
-def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_name: str) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.tables
-        WHERE database = '{settings.database}'
-          AND name = '{table_name}'
-        """
-    )
-    return bool(result[0][0])
 
 
 def _create_aligned_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:

--- a/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
@@ -1,6 +1,7 @@
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
+from .create_binance_trades_table_origo import _database_exists, _table_exists
 from .create_origo_database import (
     ClickHouseSettings,
     _get_clickhouse_settings,
@@ -9,29 +10,6 @@ from .create_origo_database import (
 )
 
 KLINES_TABLE_NAME = 'binance_spot_klines'
-
-
-def _database_exists(client: ClickhouseClient, database: str) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.databases
-        WHERE name = '{database}'
-        """
-    )
-    return bool(result[0][0])
-
-
-def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_name: str) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.tables
-        WHERE database = '{settings.database}'
-          AND name = '{table_name}'
-        """
-    )
-    return bool(result[0][0])
 
 
 def _create_klines_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:

--- a/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
@@ -1,0 +1,88 @@
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_origo_database import (
+    ClickHouseSettings,
+    _get_clickhouse_settings,
+    _make_clickhouse_client,
+    create_origo_database,
+)
+
+KLINES_TABLE_NAME = 'binance_spot_klines'
+
+
+def _database_exists(client: ClickhouseClient, database: str) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.databases
+        WHERE name = '{database}'
+        """
+    )
+    return bool(result[0][0])
+
+
+def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_name: str) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.tables
+        WHERE database = '{settings.database}'
+          AND name = '{table_name}'
+        """
+    )
+    return bool(result[0][0])
+
+
+def _create_klines_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {settings.database}.{KLINES_TABLE_NAME} (
+            open_time UInt64,
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            volume Float64,
+            close_time UInt64,
+            quote_asset_volume Float64,
+            number_of_trades UInt64,
+            taker_buy_base_asset_volume Float64,
+            taker_buy_quote_asset_volume Float64,
+            ignore Float64
+        )
+        ENGINE = MergeTree()
+        PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time))
+        ORDER BY open_time
+        """
+    )
+
+
+@asset(
+    group_name='origo_setup',
+    deps=[create_origo_database],
+    description='Creates the binance_spot_klines table if it does not exist',
+)
+def create_binance_spot_klines_table_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        if not _database_exists(client, settings.database):
+            raise RuntimeError(
+                f'Database {settings.database} does not exist. Run create_origo_database first.'
+            )
+
+        table_existed = _table_exists(client, settings, KLINES_TABLE_NAME)
+        _create_klines_table(client, settings)
+
+        context.log.info(f'Ensured table {settings.database}.{KLINES_TABLE_NAME} exists.')
+        return {
+            'status': 'success',
+            'table': f'{settings.database}.{KLINES_TABLE_NAME}',
+            'table_action': 'already_exists' if table_existed else 'created',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
+++ b/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta, timezone
-
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
@@ -13,18 +11,12 @@ from .create_binance_spot_klines_table_origo import (
 )
 from .create_origo_database import _get_clickhouse_settings, _make_clickhouse_client
 from .daily_trades_to_origo import daily_partitions
-from .refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
+from .refresh_binance_spot_klines_origo import (
+    _partition_date_from_context,
+    refresh_binance_spot_klines_origo,
+)
 
 BINANCE_SPOT_DATASET_SOURCE = 'binance_spot'
-
-
-def _partition_date_from_context(context: AssetExecutionContext) -> str:
-    partition_key = context.partition_key
-    if partition_key is not None:
-        return partition_key
-
-    target_date = datetime.now(timezone.utc) - timedelta(days=1)
-    return target_date.strftime('%Y-%m-%d')
 
 
 def _delete_partition_rows(

--- a/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
+++ b/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timedelta, timezone
+
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_aligned_1m_exchange_table_origo import (
+    ALIGNED_TABLE_NAME,
+    create_aligned_1m_exchange_table_origo,
+)
+from .create_binance_spot_klines_table_origo import (
+    KLINES_TABLE_NAME,
+    create_binance_spot_klines_table_origo,
+)
+from .create_origo_database import _get_clickhouse_settings, _make_clickhouse_client
+from .daily_trades_to_origo import daily_partitions
+from .refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
+
+BINANCE_SPOT_DATASET_SOURCE = 'binance_spot'
+
+
+def _partition_date_from_context(context: AssetExecutionContext) -> str:
+    partition_key = context.partition_key
+    if partition_key is not None:
+        return partition_key
+
+    target_date = datetime.now(timezone.utc) - timedelta(days=1)
+    return target_date.strftime('%Y-%m-%d')
+
+
+def _delete_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        ALTER TABLE {database}.{ALIGNED_TABLE_NAME}
+        DELETE WHERE dataset_source = '{BINANCE_SPOT_DATASET_SOURCE}'
+          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        """,
+        settings={'mutations_sync': 2},
+    )
+
+
+def _count_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{ALIGNED_TABLE_NAME}
+        WHERE dataset_source = '{BINANCE_SPOT_DATASET_SOURCE}'
+          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        """
+    )
+    return int(result[0][0])
+
+
+def _insert_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        INSERT INTO {database}.{ALIGNED_TABLE_NAME}
+        SELECT
+            '{BINANCE_SPOT_DATASET_SOURCE}' AS dataset_source,
+            open_time,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            close_time,
+            quote_asset_volume,
+            number_of_trades,
+            taker_buy_base_asset_volume,
+            taker_buy_quote_asset_volume,
+            ignore
+        FROM {database}.{KLINES_TABLE_NAME}
+        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        ORDER BY open_time
+        """
+    )
+
+
+@asset(
+    partitions_def=daily_partitions,
+    deps=[
+        create_aligned_1m_exchange_table_origo,
+        create_binance_spot_klines_table_origo,
+        refresh_binance_spot_klines_origo,
+    ],
+    group_name='binance_data',
+    description='Refreshes the shared aligned_1m_exchange dataset with Binance spot rows',
+)
+def refresh_aligned_1m_exchange_from_binance_spot_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date = _partition_date_from_context(context)
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        existing_count = _count_partition_rows(client, settings.database, partition_date)
+        if existing_count > 0:
+            context.log.info(
+                f'Found {existing_count} aligned Binance spot rows for {partition_date}. '
+                'Replacing that partition.'
+            )
+            _delete_partition_rows(client, settings.database, partition_date)
+
+        _insert_partition_rows(client, settings.database, partition_date)
+        inserted_count = _count_partition_rows(client, settings.database, partition_date)
+
+        return {
+            'status': 'success',
+            'partition_date': partition_date,
+            'rows_inserted': inserted_count,
+            'table': f'{settings.database}.{ALIGNED_TABLE_NAME}',
+            'dataset_source': BINANCE_SPOT_DATASET_SOURCE,
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timedelta, timezone
+
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_spot_klines_table_origo import (
+    KLINES_TABLE_NAME,
+    create_binance_spot_klines_table_origo,
+)
+from .create_origo_database import _get_clickhouse_settings, _make_clickhouse_client
+from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_trades_to_origo
+
+
+def _partition_date_from_context(context: AssetExecutionContext) -> str:
+    partition_key = context.partition_key
+    if partition_key is not None:
+        return partition_key
+
+    target_date = datetime.now(timezone.utc) - timedelta(days=1)
+    return target_date.strftime('%Y-%m-%d')
+
+
+def _delete_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        ALTER TABLE {database}.{KLINES_TABLE_NAME}
+        DELETE WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        """,
+        settings={'mutations_sync': 2},
+    )
+
+
+def _count_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{KLINES_TABLE_NAME}
+        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        """
+    )
+    return int(result[0][0])
+
+
+def _insert_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        INSERT INTO {database}.{KLINES_TABLE_NAME}
+        SELECT
+            toUnixTimestamp(toStartOfMinute(datetime)) * 1000 AS open_time,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            sum(quantity) AS volume,
+            ((toUnixTimestamp(toStartOfMinute(datetime)) + 60) * 1000) - 1 AS close_time,
+            sum(quote_quantity) AS quote_asset_volume,
+            count() AS number_of_trades,
+            sumIf(quantity, is_buyer_maker = 0) AS taker_buy_base_asset_volume,
+            sumIf(quote_quantity, is_buyer_maker = 0) AS taker_buy_quote_asset_volume,
+            toFloat64(0) AS ignore
+        FROM {database}.binance_daily_spot_trades
+        WHERE toDate(datetime) = toDate('{partition_date}')
+        GROUP BY toStartOfMinute(datetime)
+        ORDER BY open_time
+        """
+    )
+
+
+@asset(
+    partitions_def=daily_partitions,
+    deps=[
+        create_binance_spot_klines_table_origo,
+        insert_daily_binance_spot_trades_to_origo,
+    ],
+    group_name='binance_data',
+    description='Refreshes the Binance spot 1m kline projection from source-native daily trades',
+)
+def refresh_binance_spot_klines_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date = _partition_date_from_context(context)
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        existing_count = _count_partition_rows(client, settings.database, partition_date)
+        if existing_count > 0:
+            context.log.info(
+                f'Found {existing_count} existing Binance spot kline rows for {partition_date}. '
+                'Replacing that partition.'
+            )
+            _delete_partition_rows(client, settings.database, partition_date)
+
+        _insert_partition_rows(client, settings.database, partition_date)
+        inserted_count = _count_partition_rows(client, settings.database, partition_date)
+
+        return {
+            'status': 'success',
+            'partition_date': partition_date,
+            'rows_inserted': inserted_count,
+            'table': f'{settings.database}.{KLINES_TABLE_NAME}',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
+from .create_binance_trades_table_origo import RAW_TABLE_NAME
 from .create_binance_spot_klines_table_origo import (
     KLINES_TABLE_NAME,
     create_binance_spot_klines_table_origo,
@@ -70,7 +71,7 @@ def _insert_partition_rows(
             sumIf(quantity, is_buyer_maker = 0) AS taker_buy_base_asset_volume,
             sumIf(quote_quantity, is_buyer_maker = 0) AS taker_buy_quote_asset_volume,
             toFloat64(0) AS ignore
-        FROM {database}.binance_daily_spot_trades
+        FROM {database}.{RAW_TABLE_NAME}
         WHERE toDate(datetime) = toDate('{partition_date}')
         GROUP BY toStartOfMinute(datetime)
         ORDER BY open_time

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -55,6 +55,16 @@ from .assets.create_origo_database import create_origo_database
 from .assets.create_binance_trades_table_origo import (
     create_binance_daily_spot_trades_table_origo,
 )
+from .assets.create_binance_spot_klines_table_origo import (
+    create_binance_spot_klines_table_origo,
+)
+from .assets.refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
+from .assets.create_aligned_1m_exchange_table_origo import (
+    create_aligned_1m_exchange_table_origo,
+)
+from .assets.refresh_aligned_1m_exchange_from_binance_spot_origo import (
+    refresh_aligned_1m_exchange_from_binance_spot_origo,
+)
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
@@ -89,6 +99,16 @@ create_binance_daily_spot_trades_table_origo_job = define_asset_job(
     selection=["create_binance_daily_spot_trades_table_origo"]
 )
 
+create_binance_spot_klines_table_origo_job = define_asset_job(
+    name="create_binance_spot_klines_table_origo_job",
+    selection=["create_binance_spot_klines_table_origo"]
+)
+
+create_aligned_1m_exchange_table_origo_job = define_asset_job(
+    name="create_aligned_1m_exchange_table_origo_job",
+    selection=["create_aligned_1m_exchange_table_origo"]
+)
+
 create_binance_trades_complete_view_job = define_asset_job(
     name="create_binance_trades_complete_view_job",
     selection=["create_binance_trades_complete_view"])
@@ -111,9 +131,13 @@ insert_monthly_binance_trades_job = define_asset_job(
     name="insert_monthly_trades_to_tdw_job",
     selection=["insert_monthly_binance_trades_to_tdw"])
 
-insert_daily_binance_spot_trades_to_origo_job = define_asset_job(
-    name="insert_daily_binance_spot_trades_to_origo_job",
-    selection=["insert_daily_binance_spot_trades_to_origo"])
+refresh_binance_spot_data_source_job = define_asset_job(
+    name="refresh_binance_spot_data_source_job",
+    selection=[
+        "insert_daily_binance_spot_trades_to_origo",
+        "refresh_binance_spot_klines_origo",
+        "refresh_aligned_1m_exchange_from_binance_spot_origo",
+    ])
 
 insert_daily_binance_trades_tdw_job = define_asset_job(
     name="insert_daily_trades_to_tdw_job",
@@ -301,7 +325,7 @@ def _scheduled_time(context: ScheduleEvaluationContext) -> datetime:
 
 
 @schedule(
-    job=insert_daily_binance_spot_trades_to_origo_job,
+    job=refresh_binance_spot_data_source_job,
     cron_schedule="0 1 * * *",
     execution_timezone="UTC")
 
@@ -419,9 +443,13 @@ defs = Definitions(
             create_binance_trades_table,
             create_binance_daily_trades_table,
             create_binance_daily_spot_trades_table_origo,
+            create_binance_spot_klines_table_origo,
+            create_aligned_1m_exchange_table_origo,
             create_binance_trades_complete_view,
             insert_monthly_binance_trades_to_tdw,
             insert_daily_binance_spot_trades_to_origo,
+            refresh_binance_spot_klines_origo,
+            refresh_aligned_1m_exchange_from_binance_spot_origo,
             insert_daily_binance_trades_to_tdw,
             publish_binance_spot_klines_to_huggingface,
             cleanup_binance_daily_trades_for_finalized_month,
@@ -454,9 +482,11 @@ defs = Definitions(
           create_binance_trades_table_job,
           create_binance_daily_trades_table_job,
           create_binance_daily_spot_trades_table_origo_job,
+          create_binance_spot_klines_table_origo_job,
+          create_aligned_1m_exchange_table_origo_job,
           create_binance_trades_complete_view_job,
           insert_monthly_binance_trades_job,
-          insert_daily_binance_spot_trades_to_origo_job,
+          refresh_binance_spot_data_source_job,
           insert_daily_binance_trades_tdw_job,
           publish_binance_spot_klines_to_huggingface_job,
           roll_forward_monthly_binance_trades_job,

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -6,6 +6,7 @@ import socket
 import subprocess
 import sys
 import time
+import types
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -15,7 +16,7 @@ from uuid import uuid4
 
 import pytest
 from clickhouse_driver import Client as ClickhouseClient
-from dagster import materialize
+from dagster import asset, materialize
 
 from .helpers import BINANCE_FIXTURE_ROOT, ORIGO_DATABASE
 
@@ -287,3 +288,28 @@ def query_origo(clickhouse_settings: dict[str, str]) -> Any:
         return _query_rows(clickhouse_settings, query)
 
     return _run
+
+
+@pytest.fixture()
+def origo_definitions_module(
+    monkeypatch: pytest.MonkeyPatch,
+    origo_test_env: dict[str, str],
+) -> Any:
+    stub_name = 'tdw_control_plane.assets.monthly_futures_agg_trades_to_tdw'
+    stub_module = types.ModuleType(stub_name)
+
+    @asset
+    def create_binance_futures_agg_trades_table() -> dict[str, str]:
+        return {'status': 'stubbed'}
+
+    @asset
+    def insert_monthly_binance_futures_agg_trades_to_tdw() -> dict[str, str]:
+        return {'status': 'stubbed'}
+
+    stub_module.create_binance_futures_agg_trades_table = create_binance_futures_agg_trades_table
+    stub_module.insert_monthly_binance_futures_agg_trades_to_tdw = (
+        insert_monthly_binance_futures_agg_trades_to_tdw
+    )
+    monkeypatch.setitem(sys.modules, stub_name, stub_module)
+
+    return _reload_module('tdw_control_plane.definitions')

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -4,6 +4,7 @@ import importlib
 import shutil
 import socket
 import subprocess
+import sys
 import time
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -100,6 +101,13 @@ def _query_rows(settings: dict[str, str], query: str) -> list[tuple[Any, ...]]:
         return client.execute(query)
     finally:
         client.disconnect()
+
+
+def _reload_module(module_name: str) -> Any:
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
 @pytest.fixture(scope='session')
 def clickhouse_settings() -> dict[str, str]:
     if shutil.which('docker') is None:
@@ -185,14 +193,22 @@ def origo_test_env(
 
 @pytest.fixture()
 def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
-    create_origo_database_module = importlib.import_module(
-        'tdw_control_plane.assets.create_origo_database'
-    )
-    create_binance_trades_table_origo_module = importlib.import_module(
+    create_origo_database_module = _reload_module('tdw_control_plane.assets.create_origo_database')
+    create_binance_trades_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_trades_table_origo'
     )
-    daily_trades_to_origo_module = importlib.import_module(
-        'tdw_control_plane.assets.daily_trades_to_origo'
+    daily_trades_to_origo_module = _reload_module('tdw_control_plane.assets.daily_trades_to_origo')
+    create_binance_spot_klines_table_origo_module = _reload_module(
+        'tdw_control_plane.assets.create_binance_spot_klines_table_origo'
+    )
+    refresh_binance_spot_klines_origo_module = _reload_module(
+        'tdw_control_plane.assets.refresh_binance_spot_klines_origo'
+    )
+    create_aligned_1m_exchange_table_origo_module = _reload_module(
+        'tdw_control_plane.assets.create_aligned_1m_exchange_table_origo'
+    )
+    refresh_aligned_1m_exchange_from_binance_spot_origo_module = _reload_module(
+        'tdw_control_plane.assets.refresh_aligned_1m_exchange_from_binance_spot_origo'
     )
 
     return {
@@ -205,6 +221,23 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         ),
         'RAW_TABLE_NAME': create_binance_trades_table_origo_module.RAW_TABLE_NAME,
         'LEDGER_TABLE_NAME': create_binance_trades_table_origo_module.LEDGER_TABLE_NAME,
+        'create_binance_spot_klines_table_origo': (
+            create_binance_spot_klines_table_origo_module.create_binance_spot_klines_table_origo
+        ),
+        'refresh_binance_spot_klines_origo': (
+            refresh_binance_spot_klines_origo_module.refresh_binance_spot_klines_origo
+        ),
+        'KLINES_TABLE_NAME': create_binance_spot_klines_table_origo_module.KLINES_TABLE_NAME,
+        'create_aligned_1m_exchange_table_origo': (
+            create_aligned_1m_exchange_table_origo_module.create_aligned_1m_exchange_table_origo
+        ),
+        'refresh_aligned_1m_exchange_from_binance_spot_origo': (
+            refresh_aligned_1m_exchange_from_binance_spot_origo_module.refresh_aligned_1m_exchange_from_binance_spot_origo
+        ),
+        'ALIGNED_TABLE_NAME': create_aligned_1m_exchange_table_origo_module.ALIGNED_TABLE_NAME,
+        'BINANCE_SPOT_DATASET_SOURCE': (
+            refresh_aligned_1m_exchange_from_binance_spot_origo_module.BINANCE_SPOT_DATASET_SOURCE
+        ),
     }
 
 
@@ -223,6 +256,29 @@ def materialize_origo_assets(
         )
 
     return _run
+
+
+@pytest.fixture()
+def materialize_binance_spot_data_source_assets(
+    origo_assets: dict[str, Any],
+) -> Any:
+    def _run(*, partition_key: str | None = None) -> Any:
+        return materialize(
+            [
+                origo_assets['create_origo_database'],
+                origo_assets['create_binance_daily_spot_trades_table_origo'],
+                origo_assets['create_binance_spot_klines_table_origo'],
+                origo_assets['create_aligned_1m_exchange_table_origo'],
+                origo_assets['insert_daily_binance_spot_trades_to_origo'],
+                origo_assets['refresh_binance_spot_klines_origo'],
+                origo_assets['refresh_aligned_1m_exchange_from_binance_spot_origo'],
+            ],
+            partition_key=partition_key,
+        )
+
+    return _run
+
+
 
 
 @pytest.fixture()

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 from clickhouse_driver import Client as ClickhouseClient
+from clickhouse_driver.errors import NetworkError
 from dagster import asset, materialize
 
 from .helpers import BINANCE_FIXTURE_ROOT, ORIGO_DATABASE
@@ -55,6 +56,9 @@ def _wait_for_clickhouse(host: str, port: int, user: str, password: str) -> None
             last_error = exc
             time.sleep(1)
         except EOFError as exc:
+            last_error = exc
+            time.sleep(1)
+        except NetworkError as exc:
             last_error = exc
             time.sleep(1)
         finally:

--- a/tests/origo_source_native/helpers.py
+++ b/tests/origo_source_native/helpers.py
@@ -12,6 +12,27 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BINANCE_FIXTURE_ROOT = REPO_ROOT / 'tests' / 'fixtures' / 'binance'
 ORIGO_DATABASE = 'origo'
+BINANCE_SPOT_DATASET_SOURCE = 'binance_spot'
+
+KLINE_SCHEMA_COLUMNS = [
+    ('open_time', 'UInt64'),
+    ('open', 'Float64'),
+    ('high', 'Float64'),
+    ('low', 'Float64'),
+    ('close', 'Float64'),
+    ('volume', 'Float64'),
+    ('close_time', 'UInt64'),
+    ('quote_asset_volume', 'Float64'),
+    ('number_of_trades', 'UInt64'),
+    ('taker_buy_base_asset_volume', 'Float64'),
+    ('taker_buy_quote_asset_volume', 'Float64'),
+    ('ignore', 'Float64'),
+]
+
+ALIGNED_SCHEMA_COLUMNS = [
+    ('dataset_source', 'LowCardinality(String)'),
+    *KLINE_SCHEMA_COLUMNS,
+]
 
 
 def _load_fixture_zip_bytes(date_str: str) -> bytes:
@@ -79,3 +100,44 @@ def load_expected_ledger_payload(date_str: str) -> dict[str, Any]:
         'csv_checksum': hashlib.sha256(csv_bytes).hexdigest(),
         'source_row_count': len(load_expected_trade_rows(date_str)),
     }
+
+
+def load_expected_binance_spot_kline_rows(date_str: str) -> list[tuple[Any, ...]]:
+    trade_rows = load_expected_trade_rows(date_str)
+    grouped: dict[datetime, list[tuple[Any, ...]]] = {}
+
+    for row in trade_rows:
+        dt = row[7]
+        minute_start = dt.replace(second=0, microsecond=0)
+        grouped.setdefault(minute_start, []).append(row)
+
+    rows: list[tuple[Any, ...]] = []
+    for minute_start in sorted(grouped):
+        minute_rows = sorted(grouped[minute_start], key=lambda row: row[0])
+        open_time = int(minute_start.replace(tzinfo=timezone.utc).timestamp() * 1000)
+        close_time = open_time + 60000 - 1
+        rows.append(
+            (
+                open_time,
+                minute_rows[0][1],
+                max(row[1] for row in minute_rows),
+                min(row[1] for row in minute_rows),
+                minute_rows[-1][1],
+                sum(row[2] for row in minute_rows),
+                close_time,
+                sum(row[3] for row in minute_rows),
+                len(minute_rows),
+                sum(row[2] for row in minute_rows if row[5] == 0),
+                sum(row[3] for row in minute_rows if row[5] == 0),
+                0.0,
+            )
+        )
+
+    return rows
+
+
+def load_expected_aligned_1m_exchange_rows(date_str: str) -> list[tuple[Any, ...]]:
+    return [
+        (BINANCE_SPOT_DATASET_SOURCE, *row)
+        for row in load_expected_binance_spot_kline_rows(date_str)
+    ]

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .helpers import (
+    ALIGNED_SCHEMA_COLUMNS,
+    KLINE_SCHEMA_COLUMNS,
+    ORIGO_DATABASE,
+    load_expected_aligned_1m_exchange_rows,
+    load_expected_binance_spot_kline_rows,
+)
+
+
+def test_binance_spot_klines_table_name_contract(origo_assets: dict[str, object]) -> None:
+    assert origo_assets['KLINES_TABLE_NAME'] == 'binance_spot_klines'
+
+
+def test_aligned_1m_exchange_table_name_contract(origo_assets: dict[str, object]) -> None:
+    assert origo_assets['ALIGNED_TABLE_NAME'] == 'aligned_1m_exchange'
+
+
+def test_daily_pipeline_schedule_targets_binance_spot_data_source_job(
+) -> None:
+    definitions_text = (
+        Path(__file__).resolve().parents[2] / 'tdw_control_plane' / 'definitions.py'
+    ).read_text(encoding='utf-8')
+
+    assert "name=\"refresh_binance_spot_data_source_job\"" in definitions_text
+    assert 'selection=[' in definitions_text
+    assert '"insert_daily_binance_spot_trades_to_origo"' in definitions_text
+    assert '"refresh_binance_spot_klines_origo"' in definitions_text
+    assert '"refresh_aligned_1m_exchange_from_binance_spot_origo"' in definitions_text
+    assert 'job=refresh_binance_spot_data_source_job' in definitions_text
+    assert 'job=insert_daily_binance_spot_trades_to_origo_job' not in definitions_text
+
+
+def test_binance_spot_klines_schema_matches_exchange_contract(
+    materialize_binance_spot_data_source_assets,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        DESCRIBE TABLE {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        """
+    )
+
+    assert [(name, type_name) for name, type_name, *_ in rows] == KLINE_SCHEMA_COLUMNS
+
+
+def test_binance_spot_klines_exact_rows_match_expected(
+    materialize_binance_spot_data_source_assets,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        SELECT
+            open_time,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            close_time,
+            quote_asset_volume,
+            number_of_trades,
+            taker_buy_base_asset_volume,
+            taker_buy_quote_asset_volume,
+            ignore
+        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-01')
+        ORDER BY open_time
+        """
+    )
+
+    assert rows == load_expected_binance_spot_kline_rows('2024-01-01')
+
+
+def test_aligned_1m_exchange_schema_adds_dataset_source_column(
+    materialize_binance_spot_data_source_assets,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        DESCRIBE TABLE {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
+        """
+    )
+
+    assert [(name, type_name) for name, type_name, *_ in rows] == ALIGNED_SCHEMA_COLUMNS
+
+
+def test_aligned_1m_exchange_rows_from_binance_spot_match_expected(
+    materialize_binance_spot_data_source_assets,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        SELECT
+            dataset_source,
+            open_time,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            close_time,
+            quote_asset_volume,
+            number_of_trades,
+            taker_buy_base_asset_volume,
+            taker_buy_quote_asset_volume,
+            ignore
+        FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
+        WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
+          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-01')
+        ORDER BY open_time
+        """
+    )
+
+    assert rows == load_expected_aligned_1m_exchange_rows('2024-01-01')
+
+
+def test_same_partition_rerun_is_idempotent_across_single_source_and_aligned(
+    materialize_binance_spot_data_source_assets,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    first = materialize_binance_spot_data_source_assets(partition_key='2024-01-02')
+    second = materialize_binance_spot_data_source_assets(partition_key='2024-01-02')
+
+    assert first.success
+    assert second.success
+
+    kline_rows = query_origo(
+        f"""
+        SELECT
+            open_time,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            close_time,
+            quote_asset_volume,
+            number_of_trades,
+            taker_buy_base_asset_volume,
+            taker_buy_quote_asset_volume,
+            ignore
+        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-02')
+        ORDER BY open_time
+        """
+    )
+    aligned_rows = query_origo(
+        f"""
+        SELECT
+            dataset_source,
+            open_time,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            close_time,
+            quote_asset_volume,
+            number_of_trades,
+            taker_buy_base_asset_volume,
+            taker_buy_quote_asset_volume,
+            ignore
+        FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
+        WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
+          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-02')
+        ORDER BY open_time
+        """
+    )
+
+    assert kline_rows == load_expected_binance_spot_kline_rows('2024-01-02')
+    assert aligned_rows == load_expected_aligned_1m_exchange_rows('2024-01-02')
+    assert len(kline_rows) == 1
+    assert len(aligned_rows) == 1
+
+
+def test_refresh_assets_declare_immediate_dependencies(origo_assets: dict[str, object]) -> None:
+    kline_asset = origo_assets['refresh_binance_spot_klines_origo']
+    aligned_asset = origo_assets['refresh_aligned_1m_exchange_from_binance_spot_origo']
+
+    kline_deps = kline_asset.asset_deps[kline_asset.key]
+    aligned_deps = aligned_asset.asset_deps[aligned_asset.key]
+
+    assert kline_deps == {
+        origo_assets['create_binance_spot_klines_table_origo'].key,
+        origo_assets['insert_daily_binance_spot_trades_to_origo'].key,
+    }
+    assert aligned_deps == {
+        origo_assets['create_aligned_1m_exchange_table_origo'].key,
+        origo_assets['create_binance_spot_klines_table_origo'].key,
+        origo_assets['refresh_binance_spot_klines_origo'].key,
+    }

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from .helpers import (
     ALIGNED_SCHEMA_COLUMNS,
     KLINE_SCHEMA_COLUMNS,
@@ -9,6 +7,21 @@ from .helpers import (
     load_expected_aligned_1m_exchange_rows,
     load_expected_binance_spot_kline_rows,
 )
+
+
+def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
+    rows = query_origo(
+        f"""
+        SELECT engine, partition_key, sorting_key
+        FROM system.tables
+        WHERE database = '{ORIGO_DATABASE}'
+          AND name = '{table_name}'
+        """
+    )
+
+    assert len(rows) == 1
+    engine, partition_key, sorting_key = rows[0]
+    return str(engine), str(partition_key), str(sorting_key)
 
 
 def test_binance_spot_klines_table_name_contract(origo_assets: dict[str, object]) -> None:
@@ -20,18 +33,18 @@ def test_aligned_1m_exchange_table_name_contract(origo_assets: dict[str, object]
 
 
 def test_daily_pipeline_schedule_targets_binance_spot_data_source_job(
+    origo_definitions_module,
 ) -> None:
-    definitions_text = (
-        Path(__file__).resolve().parents[2] / 'tdw_control_plane' / 'definitions.py'
-    ).read_text(encoding='utf-8')
+    schedule_def = origo_definitions_module.daily_pipeline_schedule
+    job_def = origo_definitions_module.defs.get_job_def('refresh_binance_spot_data_source_job')
+    node_names = set(job_def.graph.node_dict.keys())
 
-    assert "name=\"refresh_binance_spot_data_source_job\"" in definitions_text
-    assert 'selection=[' in definitions_text
-    assert '"insert_daily_binance_spot_trades_to_origo"' in definitions_text
-    assert '"refresh_binance_spot_klines_origo"' in definitions_text
-    assert '"refresh_aligned_1m_exchange_from_binance_spot_origo"' in definitions_text
-    assert 'job=refresh_binance_spot_data_source_job' in definitions_text
-    assert 'job=insert_daily_binance_spot_trades_to_origo_job' not in definitions_text
+    assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
+    assert node_names >= {
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_spot_origo',
+    }
 
 
 def test_binance_spot_klines_schema_matches_exchange_contract(
@@ -49,6 +62,11 @@ def test_binance_spot_klines_schema_matches_exchange_contract(
     )
 
     assert [(name, type_name) for name, type_name, *_ in rows] == KLINE_SCHEMA_COLUMNS
+    assert _table_metadata(query_origo, origo_assets['KLINES_TABLE_NAME']) == (
+        'MergeTree',
+        'toYYYYMM(fromUnixTimestamp64Milli(open_time))',
+        'open_time',
+    )
 
 
 def test_binance_spot_klines_exact_rows_match_expected(
@@ -98,6 +116,11 @@ def test_aligned_1m_exchange_schema_adds_dataset_source_column(
     )
 
     assert [(name, type_name) for name, type_name, *_ in rows] == ALIGNED_SCHEMA_COLUMNS
+    assert _table_metadata(query_origo, origo_assets['ALIGNED_TABLE_NAME']) == (
+        'MergeTree',
+        'toYYYYMM(fromUnixTimestamp64Milli(open_time))',
+        'dataset_source, open_time',
+    )
 
 
 def test_aligned_1m_exchange_rows_from_binance_spot_match_expected(


### PR DESCRIPTION
Closes #168

This PR completes the first Binance spot Origo data-source template on top of `binance_daily_spot_trades`.

It adds:
- `binance_spot_klines` as the single-source 1-minute projection
- `aligned_1m_exchange` as the shared multi-source projection table, populated with Binance spot rows
- `refresh_binance_spot_data_source_job` as the daily scheduled job that materializes raw insert plus both projection layers for the same partition
- end-to-end Origo source-native tests for table-name contracts, schema, exact rows, schedule target, and same-partition rerun idempotency

Local proof:
- `/tmp/tdw-168-venv311/bin/python -m pytest tests/origo_source_native -q --maxfail=1`
- `/tmp/tdw-168-venv311/bin/python -m compileall tdw_control_plane tests tools`
- `/tmp/tdw-168-venv311/bin/python tools/version_gate.py --pr-title "feat(origo): complete binance spot new data source template" --base-pyproject <origin/main pyproject> --head-pyproject pyproject.toml --base-changelog <origin/main changelog> --head-changelog CHANGELOG.md`