### PR TITLE
fix(origo): make Binance spot projection schema and refresh SQL match TDW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.1 on April 23, 2026
+- Correct the Origo Binance spot projection contract so `binance_spot_klines` and `aligned_1m_exchange` match the TDW 1-minute kline schema instead of the exchange-native 12-column shape.
+- Replace the single-source and aligned refresh SQL so both tables materialize the TDW analytics columns (`mean`, `std`, `median`, `iqr`, maker/liquidity fields) from raw spot trades.
+- Add a checked-in TDW contract fixture and replace the old exchange-native row tests with fixture-backed schema and row-parity tests for both projection tables.
+
 # v1.5.0 on April 23, 2026
 - Complete the first Binance spot Origo data-source template on top of `binance_daily_spot_trades` by adding the single-source `binance_spot_klines` projection and the shared `aligned_1m_exchange` projection layer.
 - Replace the old raw-only daily Origo schedule target with `refresh_binance_spot_data_source_job`, which materializes the raw daily insert plus both projection layers for the same partition.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.5.0"
+version = "1.5.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
+++ b/tdw_control_plane/assets/create_aligned_1m_exchange_table_origo.py
@@ -17,22 +17,29 @@ def _create_aligned_table(client: ClickhouseClient, settings: ClickHouseSettings
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{ALIGNED_TABLE_NAME} (
             dataset_source LowCardinality(String),
-            open_time UInt64,
+            datetime DateTime,
             open Float64,
             high Float64,
             low Float64,
             close Float64,
+            mean Float64,
+            std Float64,
+            median Float64,
+            iqr Float64,
             volume Float64,
-            close_time UInt64,
-            quote_asset_volume Float64,
-            number_of_trades UInt64,
-            taker_buy_base_asset_volume Float64,
-            taker_buy_quote_asset_volume Float64,
-            ignore Float64
+            maker_ratio Float64,
+            no_of_trades UInt64,
+            open_liquidity Float64,
+            high_liquidity Float64,
+            low_liquidity Float64,
+            close_liquidity Float64,
+            liquidity_sum Float64,
+            maker_volume Float64,
+            maker_liquidity Float64
         )
         ENGINE = MergeTree()
-        PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time))
-        ORDER BY (dataset_source, open_time)
+        PARTITION BY toYYYYMM(datetime)
+        ORDER BY (dataset_source, datetime)
         """
     )
 

--- a/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_klines_table_origo.py
@@ -16,22 +16,29 @@ def _create_klines_table(client: ClickhouseClient, settings: ClickHouseSettings)
     client.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{KLINES_TABLE_NAME} (
-            open_time UInt64,
+            datetime DateTime,
             open Float64,
             high Float64,
             low Float64,
             close Float64,
+            mean Float64,
+            std Float64,
+            median Float64,
+            iqr Float64,
             volume Float64,
-            close_time UInt64,
-            quote_asset_volume Float64,
-            number_of_trades UInt64,
-            taker_buy_base_asset_volume Float64,
-            taker_buy_quote_asset_volume Float64,
-            ignore Float64
+            maker_ratio Float64,
+            no_of_trades UInt64,
+            open_liquidity Float64,
+            high_liquidity Float64,
+            low_liquidity Float64,
+            close_liquidity Float64,
+            liquidity_sum Float64,
+            maker_volume Float64,
+            maker_liquidity Float64
         )
         ENGINE = MergeTree()
-        PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time))
-        ORDER BY open_time
+        PARTITION BY toYYYYMM(datetime)
+        ORDER BY datetime
         """
     )
 

--- a/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
+++ b/tdw_control_plane/assets/refresh_aligned_1m_exchange_from_binance_spot_origo.py
@@ -28,7 +28,7 @@ def _delete_partition_rows(
         f"""
         ALTER TABLE {database}.{ALIGNED_TABLE_NAME}
         DELETE WHERE dataset_source = '{BINANCE_SPOT_DATASET_SOURCE}'
-          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+          AND toDate(datetime) = toDate('{partition_date}')
         """,
         settings={'mutations_sync': 2},
     )
@@ -44,7 +44,7 @@ def _count_partition_rows(
         SELECT count()
         FROM {database}.{ALIGNED_TABLE_NAME}
         WHERE dataset_source = '{BINANCE_SPOT_DATASET_SOURCE}'
-          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+          AND toDate(datetime) = toDate('{partition_date}')
         """
     )
     return int(result[0][0])
@@ -60,21 +60,28 @@ def _insert_partition_rows(
         INSERT INTO {database}.{ALIGNED_TABLE_NAME}
         SELECT
             '{BINANCE_SPOT_DATASET_SOURCE}' AS dataset_source,
-            open_time,
+            datetime,
             open,
             high,
             low,
             close,
+            mean,
+            std,
+            median,
+            iqr,
             volume,
-            close_time,
-            quote_asset_volume,
-            number_of_trades,
-            taker_buy_base_asset_volume,
-            taker_buy_quote_asset_volume,
-            ignore
+            maker_ratio,
+            no_of_trades,
+            open_liquidity,
+            high_liquidity,
+            low_liquidity,
+            close_liquidity,
+            liquidity_sum,
+            maker_volume,
+            maker_liquidity
         FROM {database}.{KLINES_TABLE_NAME}
-        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
-        ORDER BY open_time
+        WHERE toDate(datetime) = toDate('{partition_date}')
+        ORDER BY datetime
         """
     )
 

--- a/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
@@ -29,7 +29,7 @@ def _delete_partition_rows(
     client.execute(
         f"""
         ALTER TABLE {database}.{KLINES_TABLE_NAME}
-        DELETE WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        DELETE WHERE toDate(datetime) = toDate('{partition_date}')
         """,
         settings={'mutations_sync': 2},
     )
@@ -44,7 +44,7 @@ def _count_partition_rows(
         f"""
         SELECT count()
         FROM {database}.{KLINES_TABLE_NAME}
-        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('{partition_date}')
+        WHERE toDate(datetime) = toDate('{partition_date}')
         """
     )
     return int(result[0][0])
@@ -59,22 +59,29 @@ def _insert_partition_rows(
         f"""
         INSERT INTO {database}.{KLINES_TABLE_NAME}
         SELECT
-            toUnixTimestamp(toStartOfMinute(datetime)) * 1000 AS open_time,
+            toDateTime(60 * intDiv(toUnixTimestamp(datetime), 60)) AS datetime,
             argMin(price, trade_id) AS open,
             max(price) AS high,
             min(price) AS low,
             argMax(price, trade_id) AS close,
-            sum(quantity) AS volume,
-            ((toUnixTimestamp(toStartOfMinute(datetime)) + 60) * 1000) - 1 AS close_time,
-            sum(quote_quantity) AS quote_asset_volume,
-            count() AS number_of_trades,
-            sumIf(quantity, is_buyer_maker = 0) AS taker_buy_base_asset_volume,
-            sumIf(quote_quantity, is_buyer_maker = 0) AS taker_buy_quote_asset_volume,
-            toFloat64(0) AS ignore
+            avg(price) AS mean,
+            stddevPopStable(price) AS std,
+            quantileExact(0.5)(price) AS median,
+            quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr,
+            sumKahan(quantity) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            sum(price * quantity) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            sum(is_buyer_maker * price * quantity) AS maker_liquidity
         FROM {database}.{RAW_TABLE_NAME}
         WHERE toDate(datetime) = toDate('{partition_date}')
-        GROUP BY toStartOfMinute(datetime)
-        ORDER BY open_time
+        GROUP BY datetime
+        ORDER BY datetime
         """
     )
 

--- a/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_klines_origo.py
@@ -59,7 +59,7 @@ def _insert_partition_rows(
         f"""
         INSERT INTO {database}.{KLINES_TABLE_NAME}
         SELECT
-            toDateTime(60 * intDiv(toUnixTimestamp(datetime), 60)) AS datetime,
+            kline_datetime AS datetime,
             argMin(price, trade_id) AS open,
             max(price) AS high,
             min(price) AS low,
@@ -78,10 +78,15 @@ def _insert_partition_rows(
             sum(price * quantity) AS liquidity_sum,
             sumKahan(is_buyer_maker * quantity) AS maker_volume,
             sum(is_buyer_maker * price * quantity) AS maker_liquidity
-        FROM {database}.{RAW_TABLE_NAME}
-        WHERE toDate(datetime) = toDate('{partition_date}')
-        GROUP BY datetime
-        ORDER BY datetime
+        FROM (
+            SELECT
+                *,
+                toDateTime(60 * intDiv(toUnixTimestamp(datetime), 60)) AS kline_datetime
+            FROM {database}.{RAW_TABLE_NAME}
+            WHERE toDate(datetime) = toDate('{partition_date}')
+        )
+        GROUP BY kline_datetime
+        ORDER BY kline_datetime
         """
     )
 

--- a/tests/fixtures/tdw/binance_spot_1m_contract.json
+++ b/tests/fixtures/tdw/binance_spot_1m_contract.json
@@ -1,0 +1,71 @@
+{
+  "columns": [
+    "datetime",
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "median",
+    "iqr",
+    "volume",
+    "maker_ratio",
+    "no_of_trades",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity"
+  ],
+  "fixture_day": "2024-01-01",
+  "binance_spot_klines_rows": [
+    {
+      "datetime": "2024-01-01 00:00:00",
+      "open": 42000.1,
+      "high": 42010.0,
+      "low": 42000.1,
+      "close": 42005.5,
+      "mean": 42005.200000000004,
+      "std": 4.047221268968605,
+      "median": 42005.5,
+      "iqr": 9.900000000001455,
+      "volume": 0.0045000000000000005,
+      "maker_ratio": 0.6666666666666666,
+      "no_of_trades": 3,
+      "open_liquidity": 42.000099999999996,
+      "high_liquidity": 84.02,
+      "low_liquidity": 42.000099999999996,
+      "close_liquidity": 63.008250000000004,
+      "liquidity_sum": 189.02835,
+      "maker_volume": 0.0025,
+      "maker_liquidity": 105.00835000000001
+    }
+  ],
+  "aligned_1m_exchange_rows": [
+    {
+      "dataset_source": "binance_spot",
+      "datetime": "2024-01-01 00:00:00",
+      "open": 42000.1,
+      "high": 42010.0,
+      "low": 42000.1,
+      "close": 42005.5,
+      "mean": 42005.200000000004,
+      "std": 4.047221268968605,
+      "median": 42005.5,
+      "iqr": 9.900000000001455,
+      "volume": 0.0045000000000000005,
+      "maker_ratio": 0.6666666666666666,
+      "no_of_trades": 3,
+      "open_liquidity": 42.000099999999996,
+      "high_liquidity": 84.02,
+      "low_liquidity": 42.000099999999996,
+      "close_liquidity": 63.008250000000004,
+      "liquidity_sum": 189.02835,
+      "maker_volume": 0.0025,
+      "maker_liquidity": 105.00835000000001
+    }
+  ]
+}

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -12,24 +12,9 @@ TDW_CONTRACT_FIXTURE_PATH = (
 )
 TDW_KLINE_COLUMN_TYPES = [
     'DateTime',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
+    *(['Float64'] * 10),
     'UInt64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
-    'Float64',
+    *(['Float64'] * 7),
 ]
 TDW_ALIGNED_COLUMN_TYPES = ['LowCardinality(String)', *TDW_KLINE_COLUMN_TYPES]
 

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -1,12 +1,37 @@
 from __future__ import annotations
 
-from .helpers import (
-    ALIGNED_SCHEMA_COLUMNS,
-    KLINE_SCHEMA_COLUMNS,
-    ORIGO_DATABASE,
-    load_expected_aligned_1m_exchange_rows,
-    load_expected_binance_spot_kline_rows,
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .helpers import BINANCE_SPOT_DATASET_SOURCE, ORIGO_DATABASE
+
+TDW_CONTRACT_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1] / 'fixtures' / 'tdw' / 'binance_spot_1m_contract.json'
 )
+TDW_KLINE_COLUMN_TYPES = [
+    'DateTime',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'UInt64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+    'Float64',
+]
+TDW_ALIGNED_COLUMN_TYPES = ['LowCardinality(String)', *TDW_KLINE_COLUMN_TYPES]
 
 
 def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
@@ -22,6 +47,23 @@ def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
     assert len(rows) == 1
     engine, partition_key, sorting_key = rows[0]
     return str(engine), str(partition_key), str(sorting_key)
+
+
+def _load_tdw_contract_fixture() -> dict[str, Any]:
+    return json.loads(TDW_CONTRACT_FIXTURE_PATH.read_text())
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    return value
+
+
+def _rows_to_dicts(columns: list[str], rows: list[tuple[Any, ...]]) -> list[dict[str, Any]]:
+    return [
+        {column: _normalize_value(value) for column, value in zip(columns, row, strict=True)}
+        for row in rows
+    ]
 
 
 def test_binance_spot_klines_table_name_contract(origo_assets: dict[str, object]) -> None:
@@ -47,12 +89,14 @@ def test_daily_pipeline_schedule_targets_binance_spot_data_source_job(
     }
 
 
-def test_binance_spot_klines_schema_matches_exchange_contract(
+def test_binance_spot_klines_schema_matches_tdw_contract_fixture(
     materialize_binance_spot_data_source_assets,
     query_origo,
     origo_assets: dict[str, object],
 ) -> None:
-    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    fixture = _load_tdw_contract_fixture()
+
+    result = materialize_binance_spot_data_source_assets(partition_key=fixture['fixture_day'])
     assert result.success
 
     rows = query_origo(
@@ -61,52 +105,48 @@ def test_binance_spot_klines_schema_matches_exchange_contract(
         """
     )
 
-    assert [(name, type_name) for name, type_name, *_ in rows] == KLINE_SCHEMA_COLUMNS
+    assert [name for name, *_ in rows] == fixture['columns']
+    assert [type_name for _, type_name, *_ in rows] == TDW_KLINE_COLUMN_TYPES
     assert _table_metadata(query_origo, origo_assets['KLINES_TABLE_NAME']) == (
         'MergeTree',
-        'toYYYYMM(fromUnixTimestamp64Milli(open_time))',
-        'open_time',
+        'toYYYYMM(datetime)',
+        'datetime',
     )
 
 
-def test_binance_spot_klines_exact_rows_match_expected(
+def test_binance_spot_klines_rows_match_tdw_contract_fixture_for_fixture_day(
     materialize_binance_spot_data_source_assets,
     query_origo,
     origo_assets: dict[str, object],
 ) -> None:
-    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    fixture = _load_tdw_contract_fixture()
+    fixture_day = fixture['fixture_day']
+    columns = fixture['columns']
+
+    result = materialize_binance_spot_data_source_assets(partition_key=fixture_day)
     assert result.success
 
     rows = query_origo(
         f"""
         SELECT
-            open_time,
-            open,
-            high,
-            low,
-            close,
-            volume,
-            close_time,
-            quote_asset_volume,
-            number_of_trades,
-            taker_buy_base_asset_volume,
-            taker_buy_quote_asset_volume,
-            ignore
+            {', '.join(columns)}
         FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
-        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-01')
-        ORDER BY open_time
+        WHERE toDate(datetime) = toDate('{fixture_day}')
+        ORDER BY datetime
         """
     )
 
-    assert rows == load_expected_binance_spot_kline_rows('2024-01-01')
+    assert _rows_to_dicts(columns, rows) == fixture['binance_spot_klines_rows']
 
 
-def test_aligned_1m_exchange_schema_adds_dataset_source_column(
+def test_aligned_1m_exchange_schema_matches_tdw_contract_fixture_plus_dataset_source(
     materialize_binance_spot_data_source_assets,
     query_origo,
     origo_assets: dict[str, object],
 ) -> None:
-    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    fixture = _load_tdw_contract_fixture()
+
+    result = materialize_binance_spot_data_source_assets(partition_key=fixture['fixture_day'])
     assert result.success
 
     rows = query_origo(
@@ -115,46 +155,39 @@ def test_aligned_1m_exchange_schema_adds_dataset_source_column(
         """
     )
 
-    assert [(name, type_name) for name, type_name, *_ in rows] == ALIGNED_SCHEMA_COLUMNS
+    assert [name for name, *_ in rows] == ['dataset_source', *fixture['columns']]
+    assert [type_name for _, type_name, *_ in rows] == TDW_ALIGNED_COLUMN_TYPES
     assert _table_metadata(query_origo, origo_assets['ALIGNED_TABLE_NAME']) == (
         'MergeTree',
-        'toYYYYMM(fromUnixTimestamp64Milli(open_time))',
-        'dataset_source, open_time',
+        'toYYYYMM(datetime)',
+        'dataset_source, datetime',
     )
 
 
-def test_aligned_1m_exchange_rows_from_binance_spot_match_expected(
+def test_aligned_1m_exchange_rows_match_tdw_contract_fixture_plus_dataset_source(
     materialize_binance_spot_data_source_assets,
     query_origo,
     origo_assets: dict[str, object],
 ) -> None:
-    result = materialize_binance_spot_data_source_assets(partition_key='2024-01-01')
+    fixture = _load_tdw_contract_fixture()
+    fixture_day = fixture['fixture_day']
+    columns = ['dataset_source', *fixture['columns']]
+
+    result = materialize_binance_spot_data_source_assets(partition_key=fixture_day)
     assert result.success
 
     rows = query_origo(
         f"""
         SELECT
-            dataset_source,
-            open_time,
-            open,
-            high,
-            low,
-            close,
-            volume,
-            close_time,
-            quote_asset_volume,
-            number_of_trades,
-            taker_buy_base_asset_volume,
-            taker_buy_quote_asset_volume,
-            ignore
+            {', '.join(columns)}
         FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
         WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
-          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-01')
-        ORDER BY open_time
+          AND toDate(datetime) = toDate('{fixture_day}')
+        ORDER BY datetime
         """
     )
 
-    assert rows == load_expected_aligned_1m_exchange_rows('2024-01-01')
+    assert _rows_to_dicts(columns, rows) == fixture['aligned_1m_exchange_rows']
 
 
 def test_same_partition_rerun_is_idempotent_across_single_source_and_aligned(
@@ -162,59 +195,58 @@ def test_same_partition_rerun_is_idempotent_across_single_source_and_aligned(
     query_origo,
     origo_assets: dict[str, object],
 ) -> None:
+    kline_columns = _load_tdw_contract_fixture()['columns']
+    aligned_columns = ['dataset_source', *kline_columns]
+
     first = materialize_binance_spot_data_source_assets(partition_key='2024-01-02')
+    first_kline_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(kline_columns)}
+        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        WHERE toDate(datetime) = toDate('2024-01-02')
+        ORDER BY datetime
+        """
+    )
+    first_aligned_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(aligned_columns)}
+        FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
+        WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
+          AND toDate(datetime) = toDate('2024-01-02')
+        ORDER BY datetime
+        """
+    )
+
     second = materialize_binance_spot_data_source_assets(partition_key='2024-01-02')
+    second_kline_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(kline_columns)}
+        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        WHERE toDate(datetime) = toDate('2024-01-02')
+        ORDER BY datetime
+        """
+    )
+    second_aligned_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(aligned_columns)}
+        FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
+        WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
+          AND toDate(datetime) = toDate('2024-01-02')
+        ORDER BY datetime
+        """
+    )
 
     assert first.success
     assert second.success
-
-    kline_rows = query_origo(
-        f"""
-        SELECT
-            open_time,
-            open,
-            high,
-            low,
-            close,
-            volume,
-            close_time,
-            quote_asset_volume,
-            number_of_trades,
-            taker_buy_base_asset_volume,
-            taker_buy_quote_asset_volume,
-            ignore
-        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
-        WHERE toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-02')
-        ORDER BY open_time
-        """
-    )
-    aligned_rows = query_origo(
-        f"""
-        SELECT
-            dataset_source,
-            open_time,
-            open,
-            high,
-            low,
-            close,
-            volume,
-            close_time,
-            quote_asset_volume,
-            number_of_trades,
-            taker_buy_base_asset_volume,
-            taker_buy_quote_asset_volume,
-            ignore
-        FROM {ORIGO_DATABASE}.{origo_assets['ALIGNED_TABLE_NAME']}
-        WHERE dataset_source = '{origo_assets["BINANCE_SPOT_DATASET_SOURCE"]}'
-          AND toDate(fromUnixTimestamp64Milli(open_time)) = toDate('2024-01-02')
-        ORDER BY open_time
-        """
-    )
-
-    assert kline_rows == load_expected_binance_spot_kline_rows('2024-01-02')
-    assert aligned_rows == load_expected_aligned_1m_exchange_rows('2024-01-02')
-    assert len(kline_rows) == 1
-    assert len(aligned_rows) == 1
+    assert first_kline_rows == second_kline_rows
+    assert first_aligned_rows == second_aligned_rows
+    assert len(second_kline_rows) == 1
+    assert len(second_aligned_rows) == 1
+    assert second_aligned_rows[0][0] == BINANCE_SPOT_DATASET_SOURCE
 
 
 def test_refresh_assets_declare_immediate_dependencies(origo_assets: dict[str, object]) -> None:


### PR DESCRIPTION
Closes #172

## What changed
- replace the Origo `binance_spot_klines` and `aligned_1m_exchange` table schemas with the TDW 1-minute kline contract
- replace both projection refresh SQL paths so they materialize the TDW analytics columns from Binance spot raw trades
- add a checked-in TDW contract fixture and replace the old exchange-native row tests with fixture-backed schema and row-parity tests
- bump the package version to `1.5.1` and record the corrective slice in `CHANGELOG.md`

## Proof
- `/tmp/tdw-168-venv311/bin/python -m pytest tests/origo_source_native -q --maxfail=1`
- `/tmp/tdw-168-venv311/bin/python -m compileall tdw_control_plane tests tools`
- `/tmp/tdw-168-venv311/bin/python tools/version_gate.py --pr-title 'fix(origo): make Binance spot projection schema and refresh SQL match TDW' --base-pyproject /tmp/tdw-172-base-pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/tdw-172-base-CHANGELOG.md --head-changelog CHANGELOG.md`
