### PR TITLE
docs: add repo-root AGENTS.md

### DIFF
--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -29,7 +29,7 @@ jobs:
         run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
-        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py -q
+        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py -q
 
       - name: Compare live ruleset to checked-in snapshot
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+## The laws
+
+Ten laws. Nine are workflow gates on every PR; the tenth is branch protection on `main`. Any failure blocks merge. No bypass.
+
+1. **Every PR closes exactly one OPEN slice-labelled issue.** PR title byte-equals the issue title. Diff stays within the issue's `## Surfaces` globs. Diff touches no path in `## Out of Scope`. Issue body preserves every `> **Significance.**` blockquote from the slice template verbatim. *(pr_checks_slice)*
+
+2. **PR title, every non-merge commit, and the linked issue title match Conventional Commits v1.0.0.** Allowed types: `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert`. *(pr_checks_cc)*
+
+3. **Typing discipline never weakens.** No new `Any`, `cast(..., Any)`, `# type: ignore`, `# pyright: ignore`, or `# noqa`. Pyright error count cannot rise. `.github/typing_budget.json` cannot be raised by the PR it gates. *(pr_checks_typing)*
+
+4. **Silent-fallback patterns never grow.** No new bare `except:`, empty handler (`pass`, `...`, `return`, `return None`, `continue`, `break`), `contextlib.suppress` (or any alias chain thereof), or `errors='ignore'`. `.github/fail_loud_budget.json` cannot be raised by the PR it gates. *(pr_checks_fail_loud)*
+
+5. **Every PR bumps the version and leaves a CHANGELOG trail.** `[project].version` advances strictly forward by `MAJOR.MINOR.PATCH`. `CHANGELOG.md`'s first `# v<X.Y.Z>` header equals the new version and carries at least one content line. Bump level meets the Conventional Commits type minimum: `type!` → major, `feat` → minor, else patch. *(pr_checks_version)*
+
+6. **Ruff 0.15.11 is clean on `tools/` and `tests/tools/`.** *(pr_checks_lint)*
+
+7. **`pytest tests/origo_source_native` passes.** *(pr_checks_tests)*
+
+8. **CodeQL reports no new Python security anti-patterns.** *(PR Checks CodeQL)*
+
+9. **Live branch protection on `main` matches `.github/rulesets/main.json`.** Changing branch protection out-of-band (in the GitHub UI) blocks the next PR until the snapshot is updated in a PR of its own. *(pr_checks_ruleset)*
+
+10. **No direct push to `main`. No force-push. No branch deletion.** Branch must be up-to-date with `main` before merge. One Copilot review required; all review threads resolved. *(branch protection, server-side)*
+
+## Workflow
+
+Branch off `main`. Push to a remote branch of the same name. **Open the PR the moment the change is ready for CI to run on it — not when it feels finished.** The gates run on GitHub while you keep working locally. Don't wait for CI in the foreground.
+
+**`zero-bang` is the approving authority.** Request their review the moment the PR is open. Once every requested change is addressed, re-request `zero-bang`'s review.
+
+Each push re-runs every gate. Prefer new commits to amends — amends don't give you anything and they muddle the PR history.
+
+Merge unlocks when every required gate is green **and** the branch is up-to-date with `main`. Up-to-date is enforced server-side; rebase when main advances.
+
+When a gate fails, the gate's own output names the reason. Read the output, fix the code or the slice issue, push again. If the failure is the gate being wrong rather than the PR being wrong, fix the gate in its own PR — the ruleset drift gate (law 9) will force the matching ruleset-snapshot update so no gate relaxation side-enters.
+
+## Review work
+
+When reviewing a PR, post each comment inline as a review comment. Do not confirm with the operator first.
+
+When reviewing an issue, post comments as a new comment in the thread. Do not confirm with the operator first.
+
+When reviewing comments left on an issue you are working on, always address the issues by editing the original body or by adding a new comment that clearly explains why something is not addressed. Do not confirm with the operator first
+
+The opinion is the deliverable. Confirming before posting adds a round-trip and slows collaboration.
+
+## Beyond the laws
+
+The gates check shape, scope, format, ratchets, and named test suites. They do not check whether the slice's capability actually works. The operator judges that at review time, against the following stance:
+
+**Radical simplicity.** The simplest code that meets the requirement wins. Complexity earns its place by naming the specific concern it addresses — not "robustness" or "future-proofing" in general.
+
+**No defensive fog.** Agents are primed to produce defensible-looking code: `try/except` that swallows everything, fallbacks for cases that don't happen, docstrings that restate the signature, comments that narrate the line, parameters that might be useful someday. None of it belongs here. The fail-loud gate (law 4) catches the AST-detectable forms mechanically; the rest is operator-caught at review.
+
+**Minimal scope.** Touch only the files the task demands. Drive-by cleanups go in a separate slice.
+
+**No synthetic data.** Ever. Inventing data is not a shortcut — it corrupts everything downstream. If the real data isn't there, stop and ask.
+
+**Validate against the stated expectation.** The question is never "did it run" — it's "did it return what the slice promised."
+
+**The smallest possible honest way always.** Slice spec, code, communication, everything, let it be the smallest possible unit size that honestly delivers what is required.
+
+## When in doubt, stop
+
+This is collaboration. If the requirement is unclear, if the scope is ambiguous, if a gate's meaning is unobvious, if the fix would require touching something that wasn't asked for — stop and ask the operator. Proceeding through doubt is where harm accumulates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.1 on April 23, 2026
+- Add the repo-root `AGENTS.md` governance file with the operator-specified ten-law workflow contract and `zero-bang` approval authority.
+- Add `tests/tools/test_agents_contract.py` and extend `pr_checks_ruleset` so the checked-in `AGENTS.md` file identity and workflow coverage are mechanically enforced in CI.
+
 # v1.6.0 on April 23, 2026
 - Complete the Binance futures Origo data-source template on top of `binance_daily_futures_trades` by adding the single-source `binance_futures_klines` projection and the shared `aligned_1m_exchange` futures path.
 - Rename the generic spot schedule to `daily_spot_pipeline_schedule`, add `daily_futures_pipeline_schedule`, and wire `refresh_binance_futures_data_source_job` so spot and futures source-template automation follow the same naming law.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.0"
+version = "1.6.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/tools/test_agents_contract.py
+++ b/tests/tools/test_agents_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_FILE = REPO_ROOT / 'AGENTS.md'
+RULESET_WORKFLOW = REPO_ROOT / '.github/workflows/pr_checks_ruleset.yml'
+EXPECTED_SHA256 = '9be3ef4419eedce0b403181a0bd1d77c38072e4475312cd479a572328929e19a'
+
+
+def test_repo_agents_file_exists_and_has_expected_sha256() -> None:
+    assert AGENTS_FILE.exists()
+    assert hashlib.sha256(AGENTS_FILE.read_bytes()).hexdigest() == EXPECTED_SHA256
+
+
+def test_repo_agents_file_contains_zero_bang_authority_and_ten_laws() -> None:
+    agents = AGENTS_FILE.read_text(encoding='utf-8')
+
+    assert '# AGENTS.md' in agents
+    assert '## The laws' in agents
+    assert '**`zero-bang` is the approving authority.**' in agents
+
+    law_numbers = re.findall(r'^\d+\.\s', agents, flags=re.MULTILINE)
+    assert law_numbers == [f'{n}. ' for n in range(1, 11)]
+
+
+def test_pr_checks_ruleset_runs_agents_contract() -> None:
+    workflow = RULESET_WORKFLOW.read_text(encoding='utf-8')
+
+    assert 'tests/tools/test_agents_contract.py' in workflow
+    assert 'continue-on-error' not in workflow


### PR DESCRIPTION
Closes #171\n\n## Summary\n- add the repo-root AGENTS.md file from the slice contract\n- add tests/tools/test_agents_contract.py to pin file identity and zero-bang authority\n- extend pr_checks_ruleset to run the new agents contract test and bump version/changelog to 1.6.1\n