### PR TITLE
refactor(origo): rename daily spot and futures schedules to include binance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.2 on April 23, 2026
+- Rename the two Origo source-template schedules to `daily_binance_spot_pipeline_schedule` and `daily_binance_futures_pipeline_schedule` so both surfaces include the source prefix explicitly.
+- Keep the existing spot and futures source-template jobs unchanged; this slice only renames the Dagster schedule definitions and their registration surface.
+
 # v1.6.1 on April 23, 2026
 - Add the repo-root `AGENTS.md` governance file with the operator-specified ten-law workflow contract and `zero-bang` approval authority.
 - Add `tests/tools/test_agents_contract.py` and extend `pr_checks_ruleset` so the checked-in `AGENTS.md` file identity and workflow coverage are mechanically enforced in CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.1"
+version = "1.6.2"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -357,8 +357,7 @@ def _scheduled_time(context: ScheduleEvaluationContext) -> datetime:
     job=refresh_binance_spot_data_source_job,
     cron_schedule="0 1 * * *",
     execution_timezone="UTC")
-
-def daily_spot_pipeline_schedule():
+def daily_binance_spot_pipeline_schedule():
     return {}
 
 
@@ -366,7 +365,7 @@ def daily_spot_pipeline_schedule():
     job=refresh_binance_futures_data_source_job,
     cron_schedule="0 1 * * *",
     execution_timezone="UTC")
-def daily_futures_pipeline_schedule():
+def daily_binance_futures_pipeline_schedule():
     return {}
 
 
@@ -510,8 +509,8 @@ defs = Definitions(
             insert_monthly_binance_futures_agg_trades_to_tdw],
     
     schedules=[
-        daily_spot_pipeline_schedule,
-        daily_futures_pipeline_schedule,
+        daily_binance_spot_pipeline_schedule,
+        daily_binance_futures_pipeline_schedule,
         daily_tdw_pipeline_schedule,
         monthly_tdw_rollforward_schedule,
     ],

--- a/tests/origo_source_native/test_origo_binance_futures_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_futures_data_source_template.py
@@ -67,13 +67,14 @@ def test_binance_futures_klines_table_name_contract(origo_assets: dict[str, obje
     assert origo_assets['FUTURES_KLINES_TABLE_NAME'] == 'binance_futures_klines'
 
 
-def test_daily_futures_pipeline_schedule_targets_binance_futures_data_source_job(
+def test_daily_binance_futures_pipeline_schedule_targets_binance_futures_data_source_job(
     origo_definitions_module,
 ) -> None:
-    schedule_def = origo_definitions_module.daily_futures_pipeline_schedule
+    schedule_def = origo_definitions_module.daily_binance_futures_pipeline_schedule
     job_def = origo_definitions_module.defs.get_job_def('refresh_binance_futures_data_source_job')
     node_names = set(job_def.graph.node_dict.keys())
 
+    assert not hasattr(origo_definitions_module, 'daily_futures_pipeline_schedule')
     assert schedule_def.job.name == 'refresh_binance_futures_data_source_job'
     assert node_names >= {
         'insert_daily_binance_futures_trades_to_origo',
@@ -82,12 +83,16 @@ def test_daily_futures_pipeline_schedule_targets_binance_futures_data_source_job
     }
 
 
-def test_source_template_schedules_are_registered_in_defs(origo_definitions_module) -> None:
+def test_binance_source_template_schedules_are_registered_in_defs(
+    origo_definitions_module,
+) -> None:
     schedule_names = {schedule.name for schedule in origo_definitions_module.defs.schedules}
 
-    assert 'daily_spot_pipeline_schedule' in schedule_names
-    assert 'daily_futures_pipeline_schedule' in schedule_names
+    assert 'daily_binance_spot_pipeline_schedule' in schedule_names
+    assert 'daily_binance_futures_pipeline_schedule' in schedule_names
     assert 'daily_pipeline_schedule' not in schedule_names
+    assert 'daily_spot_pipeline_schedule' not in schedule_names
+    assert 'daily_futures_pipeline_schedule' not in schedule_names
 
 
 def test_insert_daily_binance_futures_trades_to_origo_accepts_headerless_fixture_day(

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -59,14 +59,15 @@ def test_aligned_1m_exchange_table_name_contract(origo_assets: dict[str, object]
     assert origo_assets['ALIGNED_TABLE_NAME'] == 'aligned_1m_exchange'
 
 
-def test_daily_spot_pipeline_schedule_targets_binance_spot_data_source_job(
+def test_daily_binance_spot_pipeline_schedule_targets_binance_spot_data_source_job(
     origo_definitions_module,
 ) -> None:
-    schedule_def = origo_definitions_module.daily_spot_pipeline_schedule
+    schedule_def = origo_definitions_module.daily_binance_spot_pipeline_schedule
     job_def = origo_definitions_module.defs.get_job_def('refresh_binance_spot_data_source_job')
     node_names = set(job_def.graph.node_dict.keys())
 
     assert not hasattr(origo_definitions_module, 'daily_pipeline_schedule')
+    assert not hasattr(origo_definitions_module, 'daily_spot_pipeline_schedule')
     assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
     assert node_names >= {
         'insert_daily_binance_spot_trades_to_origo',


### PR DESCRIPTION
Closes #176

## Summary
- rename the two Origo source-template schedules to include `binance`
- update the spot and futures Origo schedule proofs to require the old names to be absent
- bump the governed version trail to `1.6.2`