### PR TITLE
ci: add post-merge privileged ruleset parity audit for bypass_actors on main

### DIFF
--- a/.github/workflows/audit_main_ruleset.yml
+++ b/.github/workflows/audit_main_ruleset.yml
@@ -26,7 +26,7 @@ jobs:
         run: python -m venv .venv-ruleset-audit
 
       - name: Install audit dependencies
-        run: .venv-ruleset-audit/bin/python -m pip install --upgrade pip pytest
+        run: .venv-ruleset-audit/bin/python -m pip install --upgrade pip
 
       - name: Audit live main ruleset with privileged token
         env:

--- a/.github/workflows/audit_main_ruleset.yml
+++ b/.github/workflows/audit_main_ruleset.yml
@@ -1,0 +1,46 @@
+name: audit_main_ruleset
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit_main_ruleset:
+    name: audit_main_ruleset
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up audit venv
+        run: python -m venv .venv-ruleset-audit
+
+      - name: Install audit dependencies
+        run: .venv-ruleset-audit/bin/python -m pip install --upgrade pip pytest
+
+      - name: Audit live main ruleset with privileged token
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_AUDIT_TOKEN }}
+        run: >-
+          .venv-ruleset-audit/bin/python tools/privileged_ruleset_audit.py
+          --ruleset-file .github/rulesets/main.json
+          --repo "${{ github.repository }}"
+          --ruleset-id 5406599
+          --output-dir .ruleset-audit
+
+      - name: Upload compared live payload on failure
+        if: ${{ failure() && hashFiles('.ruleset-audit/*') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-main-ruleset-live-payload
+          path: .ruleset-audit

--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -29,7 +29,7 @@ jobs:
         run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
-        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py -q
+        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py -q
 
       - name: Compare live ruleset to checked-in snapshot
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.6.3 on April 23, 2026
+- Add `audit_main_ruleset`, a privileged post-merge `main` workflow that audits full live parity of ruleset `5406599`, including `bypass_actors`, against `.github/rulesets/main.json`.
+- Add `tools/privileged_ruleset_audit.py` and `tests/tools/test_privileged_ruleset_audit.py`, including the fail-loud contract for missing or underscoped visibility of `bypass_actors` and the live-payload snapshot on failure.
+- Extend `pr_checks_ruleset` so the privileged-audit workflow and tool contract are mechanically protected by required CI before rollout.
+
 # v1.6.2 on April 23, 2026
 - Rename the two Origo source-template schedules to `daily_binance_spot_pipeline_schedule` and `daily_binance_futures_pipeline_schedule` so both surfaces include the source prefix explicitly.
 - Keep the existing spot and futures source-template jobs unchanged; this slice only renames the Dagster schedule definitions and their registration surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.2"
+version = "1.6.3"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/tools/test_privileged_ruleset_audit.py
+++ b/tests/tools/test_privileged_ruleset_audit.py
@@ -24,6 +24,15 @@ def _load_audit_module() -> types.ModuleType:
     return module
 
 
+def _load_ruleset_gate_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location('ruleset_gate_independent', REPO_ROOT / 'tools/ruleset_gate.py')
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _run_audit_fixture(live_fixture: str, tmp_path: Path) -> tuple[int, str, str]:
     module = _load_audit_module()
     stdout = io.StringIO()
@@ -33,7 +42,7 @@ def _run_audit_fixture(live_fixture: str, tmp_path: Path) -> tuple[int, str, str
             code = module.run_audit(
                 ruleset_file=str(SNAPSHOT),
                 repo=None,
-                ruleset_id='5406599',
+                ruleset_id=5406599,
                 output_dir=str(tmp_path),
                 live_json=str(FIXTURES / live_fixture),
             )
@@ -98,17 +107,18 @@ def test_privileged_ruleset_audit_fails_loud_when_live_payload_omits_bypass_acto
 
 def test_privileged_ruleset_audit_shares_ruleset_gate_semantics() -> None:
     module = _load_audit_module()
+    ruleset_gate = _load_ruleset_gate_module()
 
     assert (
         module.shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
-        == module.shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
+        == ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
     )
     assert (
         module.shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS
-        == frozenset({'bypass_actors'})
+        == ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS
     )
-    assert 'bypass_actors' in module.shared_ruleset_gate.SNAPSHOT_TOP_LEVEL_FIELDS
-    assert 'bypass_actors' not in module.shared_ruleset_gate.IGNORED_LIVE_FIELDS
+    assert module.shared_ruleset_gate.SNAPSHOT_TOP_LEVEL_FIELDS == ruleset_gate.SNAPSHOT_TOP_LEVEL_FIELDS
+    assert module.shared_ruleset_gate.IGNORED_LIVE_FIELDS == ruleset_gate.IGNORED_LIVE_FIELDS
 
 
 def test_audit_main_ruleset_workflow_contract() -> None:

--- a/tests/tools/test_privileged_ruleset_audit.py
+++ b/tests/tools/test_privileged_ruleset_audit.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_TOOL = REPO_ROOT / 'tools/privileged_ruleset_audit.py'
+RULESET_WORKFLOW = REPO_ROOT / '.github/workflows/pr_checks_ruleset.yml'
+AUDIT_WORKFLOW = REPO_ROOT / '.github/workflows/audit_main_ruleset.yml'
+SNAPSHOT = REPO_ROOT / '.github/rulesets/main.json'
+FIXTURES = REPO_ROOT / 'tests/fixtures/github'
+
+
+def _load_audit_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location('privileged_ruleset_audit', AUDIT_TOOL)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_audit_fixture(live_fixture: str, tmp_path: Path) -> tuple[int, str, str]:
+    module = _load_audit_module()
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            code = module.run_audit(
+                ruleset_file=str(SNAPSHOT),
+                repo=None,
+                ruleset_id='5406599',
+                output_dir=str(tmp_path),
+                live_json=str(FIXTURES / live_fixture),
+            )
+        except SystemExit as exc:
+            code = int(exc.code)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_privileged_ruleset_audit_accepts_matching_live_payload_with_bypass_actors(
+    tmp_path: Path,
+) -> None:
+    code, stdout, stderr = _run_audit_fixture('ruleset_live_target.json', tmp_path)
+
+    assert code == 0
+    assert 'PRIVILEGED RULESET AUDIT -- PASS' in stdout
+    assert stderr == ''
+    assert not (tmp_path / 'live_ruleset.json').exists()
+
+
+def test_privileged_ruleset_audit_fails_on_bypass_actor_drift(tmp_path: Path) -> None:
+    code, _, stderr = _run_audit_fixture('ruleset_live_with_bypass_actor.json', tmp_path)
+
+    assert code == 1
+    assert 'privileged_ruleset_audit: ruleset drift detected' in stderr
+
+
+def test_privileged_ruleset_audit_writes_live_payload_snapshot_on_failure(
+    tmp_path: Path,
+) -> None:
+    code, _, stderr = _run_audit_fixture('ruleset_live_with_bypass_actor.json', tmp_path)
+    snapshot = tmp_path / 'live_ruleset.json'
+
+    assert code == 1
+    assert snapshot.exists()
+    assert json.loads(snapshot.read_text(encoding='utf-8')) == json.loads(
+        (FIXTURES / 'ruleset_live_with_bypass_actor.json').read_text(encoding='utf-8')
+    )
+    assert str(snapshot) in stderr
+
+
+def test_privileged_ruleset_audit_fails_loud_when_live_payload_omits_bypass_actors(
+    tmp_path: Path,
+) -> None:
+    code, _, stderr = _run_audit_fixture(
+        'ruleset_live_target_without_bypass_actors.json',
+        tmp_path,
+    )
+    snapshot = tmp_path / 'live_ruleset.json'
+
+    assert code == 2
+    assert (
+        "privileged live ruleset missing required observable field(s): ['bypass_actors']"
+        in stderr
+    )
+    assert snapshot.exists()
+    assert json.loads(snapshot.read_text(encoding='utf-8')) == json.loads(
+        (FIXTURES / 'ruleset_live_target_without_bypass_actors.json').read_text(
+            encoding='utf-8'
+        )
+    )
+
+
+def test_privileged_ruleset_audit_shares_ruleset_gate_semantics() -> None:
+    module = _load_audit_module()
+
+    assert (
+        module.shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
+        == module.shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
+    )
+    assert (
+        module.shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS
+        == frozenset({'bypass_actors'})
+    )
+    assert 'bypass_actors' in module.shared_ruleset_gate.SNAPSHOT_TOP_LEVEL_FIELDS
+    assert 'bypass_actors' not in module.shared_ruleset_gate.IGNORED_LIVE_FIELDS
+
+
+def test_audit_main_ruleset_workflow_contract() -> None:
+    workflow = AUDIT_WORKFLOW.read_text(encoding='utf-8')
+
+    assert 'name: audit_main_ruleset' in workflow
+    assert 'push:' in workflow
+    assert 'branches: [main]' in workflow
+    assert 'workflow_dispatch:' in workflow
+    assert 'pull_request:' not in workflow
+    assert 'RULESET_AUDIT_TOKEN' in workflow
+    assert 'tools/privileged_ruleset_audit.py' in workflow
+    assert '--ruleset-file .github/rulesets/main.json' in workflow
+    assert '--repo "${{ github.repository }}"' in workflow
+    assert '--ruleset-id 5406599' in workflow
+    assert '--output-dir .ruleset-audit' in workflow
+    assert 'actions/upload-artifact@v4' in workflow
+    assert "failure()" in workflow
+    assert '.ruleset-audit' in workflow
+
+
+def test_pr_checks_ruleset_runs_privileged_audit_contract() -> None:
+    workflow = RULESET_WORKFLOW.read_text(encoding='utf-8')
+
+    assert 'tests/tools/test_privileged_ruleset_audit.py' in workflow
+    assert 'continue-on-error' not in workflow

--- a/tools/privileged_ruleset_audit.py
+++ b/tools/privileged_ruleset_audit.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Privileged post-merge ruleset audit for full live parity on main."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+TOOLS_DIR = Path(__file__).resolve().parent
+
+LIVE_PAYLOAD_SNAPSHOT = 'live_ruleset.json'
+
+
+def _load_shared_ruleset_gate_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location('ruleset_gate', TOOLS_DIR / 'ruleset_gate.py')
+    if spec is None or spec.loader is None:
+        raise SystemExit('privileged_ruleset_audit: cannot load tools/ruleset_gate.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+shared_ruleset_gate = _load_shared_ruleset_gate_module()
+
+
+def _write_live_payload_snapshot(output_dir: Path, payload: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / LIVE_PAYLOAD_SNAPSHOT
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + '\n',
+        encoding='utf-8',
+    )
+    return path
+
+
+def normalize_privileged_live_ruleset(payload: dict[str, Any]) -> dict[str, Any]:
+    live_fields = set(payload)
+    unexpected = (
+        live_fields
+        - shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
+        - shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS
+        - shared_ruleset_gate.IGNORED_LIVE_FIELDS
+    )
+    if unexpected:
+        raise SystemExit(
+            shared_ruleset_gate.fail(
+                f'unexpected live ruleset field(s): {sorted(unexpected)}',
+                code=1,
+            )
+        )
+
+    missing_required = shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS - live_fields
+    if missing_required:
+        raise SystemExit(
+            shared_ruleset_gate.fail(
+                f'expected live ruleset field(s) missing: {sorted(missing_required)}',
+                code=1,
+            )
+        )
+
+    missing_optional = shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS - live_fields
+    if missing_optional:
+        raise SystemExit(
+            shared_ruleset_gate.fail(
+                'privileged live ruleset missing required observable field(s): '
+                f'{sorted(missing_optional)}',
+                code=2,
+            )
+        )
+
+    comparable_fields = (
+        shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS
+        | shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS
+    )
+    return {key: payload[key] for key in sorted(comparable_fields)}
+
+
+def run_audit(
+    *,
+    ruleset_file: str,
+    repo: str | None,
+    ruleset_id: str,
+    output_dir: str,
+    live_json: str | None = None,
+) -> int:
+    expected_ruleset = shared_ruleset_gate.normalize_snapshot_ruleset(
+        shared_ruleset_gate.load_json_file(Path(ruleset_file))
+    )
+    live_payload = shared_ruleset_gate.load_live_ruleset(
+        repo=repo,
+        ruleset_id=ruleset_id,
+        live_json=live_json,
+    )
+    snapshot_dir = Path(output_dir)
+
+    try:
+        live_ruleset = normalize_privileged_live_ruleset(live_payload)
+    except SystemExit:
+        _write_live_payload_snapshot(snapshot_dir, live_payload)
+        raise
+
+    expected_comparable = {
+        key: expected_ruleset[key]
+        for key in sorted(live_ruleset)
+    }
+
+    if live_ruleset != expected_comparable:
+        snapshot_path = _write_live_payload_snapshot(snapshot_dir, live_payload)
+        print('privileged_ruleset_audit: ruleset drift detected', file=sys.stderr)
+        print('expected:', file=sys.stderr)
+        print(
+            json.dumps(expected_comparable, indent=2, sort_keys=True),
+            file=sys.stderr,
+        )
+        print('live:', file=sys.stderr)
+        print(
+            json.dumps(live_ruleset, indent=2, sort_keys=True),
+            file=sys.stderr,
+        )
+        print(
+            'privileged_ruleset_audit: wrote compared live payload to '
+            f'{snapshot_path}',
+            file=sys.stderr,
+        )
+        return 1
+
+    print('PRIVILEGED RULESET AUDIT -- PASS')
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Privileged ruleset audit')
+    parser.add_argument('--ruleset-file', required=True)
+    parser.add_argument('--repo', required=True)
+    parser.add_argument('--ruleset-id', required=True, type=int)
+    parser.add_argument('--output-dir', required=True)
+    args = parser.parse_args()
+
+    return run_audit(
+        ruleset_file=args.ruleset_file,
+        repo=args.repo,
+        ruleset_id=str(args.ruleset_id),
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/privileged_ruleset_audit.py
+++ b/tools/privileged_ruleset_audit.py
@@ -28,6 +28,11 @@ def _load_shared_ruleset_gate_module() -> types.ModuleType:
 shared_ruleset_gate = _load_shared_ruleset_gate_module()
 
 
+def fail(message: str, *, code: int) -> int:
+    print(f'privileged_ruleset_audit: {message}', file=sys.stderr)
+    return code
+
+
 def _write_live_payload_snapshot(output_dir: Path, payload: dict[str, Any]) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / LIVE_PAYLOAD_SNAPSHOT
@@ -48,7 +53,7 @@ def normalize_privileged_live_ruleset(payload: dict[str, Any]) -> dict[str, Any]
     )
     if unexpected:
         raise SystemExit(
-            shared_ruleset_gate.fail(
+            fail(
                 f'unexpected live ruleset field(s): {sorted(unexpected)}',
                 code=1,
             )
@@ -57,7 +62,7 @@ def normalize_privileged_live_ruleset(payload: dict[str, Any]) -> dict[str, Any]
     missing_required = shared_ruleset_gate.REQUIRED_TOP_LEVEL_FIELDS - live_fields
     if missing_required:
         raise SystemExit(
-            shared_ruleset_gate.fail(
+            fail(
                 f'expected live ruleset field(s) missing: {sorted(missing_required)}',
                 code=1,
             )
@@ -66,7 +71,7 @@ def normalize_privileged_live_ruleset(payload: dict[str, Any]) -> dict[str, Any]
     missing_optional = shared_ruleset_gate.OPTIONAL_LIVE_TOP_LEVEL_FIELDS - live_fields
     if missing_optional:
         raise SystemExit(
-            shared_ruleset_gate.fail(
+            fail(
                 'privileged live ruleset missing required observable field(s): '
                 f'{sorted(missing_optional)}',
                 code=2,
@@ -84,7 +89,7 @@ def run_audit(
     *,
     ruleset_file: str,
     repo: str | None,
-    ruleset_id: str,
+    ruleset_id: int,
     output_dir: str,
     live_json: str | None = None,
 ) -> int:
@@ -93,7 +98,7 @@ def run_audit(
     )
     live_payload = shared_ruleset_gate.load_live_ruleset(
         repo=repo,
-        ruleset_id=ruleset_id,
+        ruleset_id=str(ruleset_id),
         live_json=live_json,
     )
     snapshot_dir = Path(output_dir)
@@ -144,7 +149,7 @@ def main() -> int:
     return run_audit(
         ruleset_file=args.ruleset_file,
         repo=args.repo,
-        ruleset_id=str(args.ruleset_id),
+        ruleset_id=args.ruleset_id,
         output_dir=args.output_dir,
     )
 


### PR DESCRIPTION
Closes #163

## Summary
- Add a main-only privileged ruleset audit workflow using `RULESET_AUDIT_TOKEN`, with a job-level `github.ref == 'refs/heads/main'` guard for manual dispatch.
- Add the audit tool and contract tests, including fail-loud behavior when `bypass_actors` is not visible.
- Extend `pr_checks_ruleset` so the new workflow/tool contract is protected before rollout.
- Rebase-by-merge onto current `main` and bump version/changelog to `1.6.7`.

## Local checks
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev --with ruff==0.15.11 python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev python -m pytest tests/origo_source_native -q --maxfail=1`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --with ruff==0.15.11 ruff check tools tests/tools`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev --with pyright==1.1.408 pyright --outputjson > /tmp/tdw-control-plane-pyright.json; ... tools/typing_gate.py --pyright-json /tmp/tdw-control-plane-pyright.json --base-budget .github/typing_budget.json` (`pyright` exits on existing config warning; typing gate passes)
- `tools/version_gate.py` against `origin/main` (`1.6.6 -> 1.6.7`)