### PR TITLE
fix(origo): run Binance daily schedules after archive publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.4 on April 28, 2026
+- Move the default-running daily Binance Origo source schedules to `10:00 UTC` so routine automation runs after observed Binance archive publication.
+- Add bounded hourly Dagster retries to the spot and futures daily archive ingest assets for late archive publication.
+
 # v1.6.3 on April 25, 2026
 - Replace the two daily Binance Origo source-template schedules with Dagster partitioned-job schedules that request the latest daily partition instead of launching non-partitioned empty-config runs.
 - Start the daily spot and futures schedules enabled so Dagster owns routine daily automation while partition backfills stay on Dagster's built-in backfill path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.3"
+version = "1.6.4"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/daily_futures_trades_to_origo.py
+++ b/tdw_control_plane/assets/daily_futures_trades_to_origo.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 import requests
 from clickhouse_driver import Client as ClickhouseClient
-from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, RetryPolicy, asset
 
 from .create_binance_futures_trades_table_origo import (
     LEDGER_TABLE_NAME,
@@ -296,6 +296,7 @@ def _process_day(
     deps=[create_binance_daily_futures_trades_table_origo],
     group_name='binance_futures_data',
     description='Downloads, validates, extracts, and loads Binance BTCUSDT futures trade data into Origo',
+    retry_policy=RetryPolicy(max_retries=23, delay=3600),
 )
 def insert_daily_binance_futures_trades_to_origo(
     context: AssetExecutionContext,

--- a/tdw_control_plane/assets/daily_trades_to_origo.py
+++ b/tdw_control_plane/assets/daily_trades_to_origo.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 import requests
 from clickhouse_driver import Client as ClickhouseClient
-from dagster import AssetExecutionContext, DailyPartitionsDefinition, asset
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, RetryPolicy, asset
 
 from .create_binance_trades_table_origo import (
     LEDGER_TABLE_NAME,
@@ -268,6 +268,7 @@ def _process_day(
     deps=[create_binance_daily_spot_trades_table_origo],
     group_name='binance_data',
     description='Downloads, validates, extracts, and loads Binance BTCUSDT spot trade data into Origo',
+    retry_policy=RetryPolicy(max_retries=23, delay=3600),
 )
 def insert_daily_binance_spot_trades_to_origo(
     context: AssetExecutionContext,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -358,7 +358,7 @@ def _scheduled_time(context: ScheduleEvaluationContext) -> datetime:
 daily_binance_spot_pipeline_schedule = build_schedule_from_partitioned_job(
     refresh_binance_spot_data_source_job,
     name='daily_binance_spot_pipeline_schedule',
-    hour_of_day=1,
+    hour_of_day=10,
     default_status=DefaultScheduleStatus.RUNNING,
 )
 
@@ -366,7 +366,7 @@ daily_binance_spot_pipeline_schedule = build_schedule_from_partitioned_job(
 daily_binance_futures_pipeline_schedule = build_schedule_from_partitioned_job(
     refresh_binance_futures_data_source_job,
     name='daily_binance_futures_pipeline_schedule',
-    hour_of_day=1,
+    hour_of_day=10,
     default_status=DefaultScheduleStatus.RUNNING,
 )
 

--- a/tests/origo_source_native/test_origo_binance_futures_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_futures_data_source_template.py
@@ -96,6 +96,7 @@ def test_daily_binance_futures_pipeline_schedule_targets_binance_futures_data_so
 
     assert not hasattr(origo_definitions_module, 'daily_futures_pipeline_schedule')
     assert schedule_def.job.name == 'refresh_binance_futures_data_source_job'
+    assert resolved_schedule_def.cron_schedule == '0 10 * * *'
     assert resolved_schedule_def.execution_timezone == 'UTC'
     assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
     assert node_names >= {
@@ -114,7 +115,7 @@ def test_daily_binance_futures_pipeline_schedule_requests_latest_daily_partition
     result = _evaluate_schedule(
         origo_definitions_module,
         'daily_binance_futures_pipeline_schedule',
-        datetime(2019, 9, 9, 1, tzinfo=timezone.utc),
+        datetime(2019, 9, 9, 10, tzinfo=timezone.utc),
     )
 
     assert isinstance(result, list)
@@ -135,6 +136,16 @@ def test_daily_binance_futures_pipeline_schedule_requests_latest_daily_partition
         """
     )
     assert rows[0][0] > 0
+
+
+def test_daily_binance_futures_ingest_retries_hourly_for_late_binance_archives(
+    origo_assets: dict[str, object],
+) -> None:
+    retry_policy = origo_assets['insert_daily_binance_futures_trades_to_origo'].op.retry_policy
+
+    assert retry_policy is not None
+    assert retry_policy.max_retries == 23
+    assert retry_policy.delay == 3600
 
 
 def test_binance_source_template_schedules_are_registered_in_defs(

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -89,6 +89,7 @@ def test_daily_binance_spot_pipeline_schedule_targets_binance_spot_data_source_j
     assert not hasattr(origo_definitions_module, 'daily_pipeline_schedule')
     assert not hasattr(origo_definitions_module, 'daily_spot_pipeline_schedule')
     assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
+    assert resolved_schedule_def.cron_schedule == '0 10 * * *'
     assert resolved_schedule_def.execution_timezone == 'UTC'
     assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
     assert node_names >= {
@@ -107,7 +108,7 @@ def test_daily_binance_spot_pipeline_schedule_requests_latest_daily_partition(
     result = _evaluate_schedule(
         origo_definitions_module,
         'daily_binance_spot_pipeline_schedule',
-        datetime(2024, 1, 2, 1, tzinfo=timezone.utc),
+        datetime(2024, 1, 2, 10, tzinfo=timezone.utc),
     )
 
     assert isinstance(result, list)
@@ -288,6 +289,16 @@ def test_same_partition_rerun_is_idempotent_across_single_source_and_aligned(
     assert len(second_kline_rows) == 1
     assert len(second_aligned_rows) == 1
     assert second_aligned_rows[0][0] == BINANCE_SPOT_DATASET_SOURCE
+
+
+def test_daily_binance_spot_ingest_retries_hourly_for_late_binance_archives(
+    origo_assets: dict[str, object],
+) -> None:
+    retry_policy = origo_assets['insert_daily_binance_spot_trades_to_origo'].op.retry_policy
+
+    assert retry_policy is not None
+    assert retry_policy.max_retries == 23
+    assert retry_policy.delay == 3600
 
 
 def test_refresh_assets_declare_immediate_dependencies(origo_assets: dict[str, object]) -> None:


### PR DESCRIPTION
Closes #183

## Summary
- Move the daily Binance spot and futures Origo schedules to 10:00 UTC.
- Add bounded hourly Dagster retries to the spot and futures daily archive ingest assets.
- Cover the schedule hour and retry policy in the Origo source native tests.

## Tests
- `python -m pytest tests/origo_source_native -q --maxfail=1`
- `python tools/fail_loud_gate.py --base-budget <origin/main budget>`
- `python tools/version_gate.py --pr-title "fix(origo): run Binance daily schedules after archive publication" --base-pyproject <origin/main pyproject> --head-pyproject pyproject.toml --base-changelog <origin/main changelog> --head-changelog CHANGELOG.md`
- `python -m ruff check tools tests/tools`
- `pyright --outputjson` + `python tools/typing_gate.py --pyright-json <pyright output> --base-budget <origin/main budget>`