### PR TITLE
fix(origo): run Binance spot daily schedule at 04:00 UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.6.5 on April 28, 2026
+- Move the default-running daily Binance spot Origo source schedule to `04:00 UTC` while leaving the futures schedule at `10:00 UTC`.
+
 # v1.6.4 on April 28, 2026
 - Move the default-running daily Binance Origo source schedules to `10:00 UTC` so routine automation runs after observed Binance archive publication.
 - Add bounded hourly Dagster retries to the spot and futures daily archive ingest assets for late archive publication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.4"
+version = "1.6.5"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -358,7 +358,7 @@ def _scheduled_time(context: ScheduleEvaluationContext) -> datetime:
 daily_binance_spot_pipeline_schedule = build_schedule_from_partitioned_job(
     refresh_binance_spot_data_source_job,
     name='daily_binance_spot_pipeline_schedule',
-    hour_of_day=10,
+    hour_of_day=4,
     default_status=DefaultScheduleStatus.RUNNING,
 )
 

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -89,7 +89,7 @@ def test_daily_binance_spot_pipeline_schedule_targets_binance_spot_data_source_j
     assert not hasattr(origo_definitions_module, 'daily_pipeline_schedule')
     assert not hasattr(origo_definitions_module, 'daily_spot_pipeline_schedule')
     assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
-    assert resolved_schedule_def.cron_schedule == '0 10 * * *'
+    assert resolved_schedule_def.cron_schedule == '0 4 * * *'
     assert resolved_schedule_def.execution_timezone == 'UTC'
     assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
     assert node_names >= {
@@ -108,7 +108,7 @@ def test_daily_binance_spot_pipeline_schedule_requests_latest_daily_partition(
     result = _evaluate_schedule(
         origo_definitions_module,
         'daily_binance_spot_pipeline_schedule',
-        datetime(2024, 1, 2, 10, tzinfo=timezone.utc),
+        datetime(2024, 1, 2, 4, tzinfo=timezone.utc),
     )
 
     assert isinstance(result, list)


### PR DESCRIPTION
Closes #185

## Summary
- Move only the daily Binance spot Origo schedule to 04:00 UTC.
- Leave the futures schedule at 10:00 UTC.
- Update the spot schedule tests and version/changelog trail.

## Tests
- `python -m pytest tests/origo_source_native/test_origo_binance_spot_data_source_template.py::test_daily_binance_spot_pipeline_schedule_targets_binance_spot_data_source_job tests/origo_source_native/test_origo_binance_spot_data_source_template.py::test_daily_binance_spot_pipeline_schedule_requests_latest_daily_partition -q`
- `python -m pytest tests/origo_source_native -q --maxfail=1`
- `python tools/fail_loud_gate.py --base-budget <origin/main budget>`
- `python tools/version_gate.py --pr-title "fix(origo): run Binance spot daily schedule at 04:00 UTC" --base-pyproject <origin/main pyproject> --head-pyproject pyproject.toml --base-changelog <origin/main changelog> --head-changelog CHANGELOG.md`
- `python -m ruff check tools tests/tools`
- `pyright --outputjson` + `python tools/typing_gate.py --pyright-json <pyright output> --base-budget <origin/main budget>`