### PR TITLE
fix(huggingface): publish spot klines from Origo projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.6.6 on April 30, 2026
+- Route the Hugging Face spot kline publisher through the Origo projection.
+
 # v1.6.5 on April 28, 2026
 - Move the default-running daily Binance spot Origo source schedule to `04:00 UTC` while leaving the futures schedule at `10:00 UTC`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.6.5"
+version = "1.6.6"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
@@ -4,15 +4,107 @@ import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TypeAlias, cast
 
+import polars as pl
 from dagster import AssetExecutionContext, asset
 from huggingface_hub import HfApi
 
-from tdw_control_plane.assets.daily_trades_to_tdw import daily_partitions
-from tdw_control_plane.query import get_binance_spot_klines
+from tdw_control_plane.assets.create_origo_database import (
+    _get_clickhouse_settings,
+    _make_clickhouse_client,
+)
+from tdw_control_plane.assets.daily_trades_to_origo import daily_partitions
 
 EXPORT_START_DATE = "2020-01-01 00:00:00"
 EXPORT_FILENAME_PREFIX = "btcusdt_1m_kline_20200101_to_"
+_OrigoSpotKlineRow: TypeAlias = tuple[
+    datetime,
+    float,
+    float,
+    float,
+    float,
+    float,
+    float,
+    float,
+    float,
+    int,
+    float,
+    float,
+    float,
+    float,
+    float,
+    float,
+    float,
+]
+_ORIGO_SPOT_KLINE_COLUMNS = [
+    "datetime",
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "volume",
+    "maker_ratio",
+    "no_of_trades",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity",
+]
+
+
+def _get_origo_spot_klines(
+    *,
+    start_date_limit: str,
+    end_date_limit: str,
+) -> pl.DataFrame:
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+    try:
+        rows = cast(
+            list[_OrigoSpotKlineRow],
+            client.execute(
+                f"""
+                SELECT
+                    datetime,
+                    open,
+                    high,
+                    low,
+                    close,
+                    round(mean, 5) AS mean,
+                    round(std, 6) AS std,
+                    round(volume, 9) AS volume,
+                    maker_ratio,
+                    no_of_trades,
+                    open_liquidity,
+                    high_liquidity,
+                    low_liquidity,
+                    close_liquidity,
+                    round(liquidity_sum, 1) AS liquidity_sum,
+                    maker_volume,
+                    round(maker_liquidity, 1) AS maker_liquidity
+                FROM {settings.database}.binance_spot_klines
+                WHERE datetime >= toDateTime(%(start_date_limit)s)
+                  AND datetime < toDateTime(%(end_date_limit)s)
+                ORDER BY datetime ASC
+                """,
+                {
+                    "start_date_limit": start_date_limit,
+                    "end_date_limit": end_date_limit,
+                },
+            ),
+        )
+    finally:
+        client.disconnect()
+
+    return pl.DataFrame(rows, schema=_ORIGO_SPOT_KLINE_COLUMNS, orient="row").with_columns(
+        pl.col("datetime").cast(pl.Datetime("ms", time_zone="UTC"))
+    )
 
 
 def _get_huggingface_token() -> str:
@@ -35,7 +127,7 @@ def _get_huggingface_dataset_repo_id() -> str:
 def _build_dataset_card(export_end_date: str, row_count: int, file_name: str) -> str:
     return f"""# BTCUSDT 1m spot klines
 
-This dataset is exported daily from `tdw.binance_trades_complete` using TDW's `get_binance_spot_klines` query at 1-minute resolution.
+This dataset is exported daily from `origo.binance_spot_klines` at 1-minute resolution.
 
 Latest snapshot:
 
@@ -48,7 +140,7 @@ Latest snapshot:
 Notes:
 
 - Source market: Binance spot BTCUSDT
-- Source table: `tdw.binance_trades_complete`
+- Source table: `origo.binance_spot_klines`
 - `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
 - Timestamps are UTC
 """
@@ -91,9 +183,11 @@ def _sha256_for_file(file_path: Path) -> str:
 @asset(
     partitions_def=daily_partitions,
     group_name="binance_data",
-    description="Exports daily BTCUSDT 1m spot klines from tdw.binance_trades_complete and publishes the latest snapshot to Hugging Face.",
+    description="Exports daily BTCUSDT 1m spot klines from origo.binance_spot_klines and publishes the latest snapshot to Hugging Face.",
 )
-def publish_binance_spot_klines_to_huggingface(context: AssetExecutionContext):
+def publish_binance_spot_klines_to_huggingface(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
     partition_date_str = context.asset_partition_key_for_output()
     if partition_date_str is None:
         raise RuntimeError(
@@ -113,12 +207,9 @@ def publish_binance_spot_klines_to_huggingface(context: AssetExecutionContext):
     context.log.info(
         f"Building Binance spot klines snapshot through {export_end_date} UTC."
     )
-    data = get_binance_spot_klines(
-        kline_size=60,
+    data = _get_origo_spot_klines(
         start_date_limit=EXPORT_START_DATE,
         end_date_limit=export_end_exclusive,
-        table_name="binance_trades_complete",
-        include_quantiles=False,
     )
 
     if data.height == 0:

--- a/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py
@@ -4,107 +4,15 @@ import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TypeAlias, cast
 
-import polars as pl
 from dagster import AssetExecutionContext, asset
 from huggingface_hub import HfApi
 
-from tdw_control_plane.assets.create_origo_database import (
-    _get_clickhouse_settings,
-    _make_clickhouse_client,
-)
 from tdw_control_plane.assets.daily_trades_to_origo import daily_partitions
+from tdw_control_plane.query import get_binance_spot_klines
 
 EXPORT_START_DATE = "2020-01-01 00:00:00"
 EXPORT_FILENAME_PREFIX = "btcusdt_1m_kline_20200101_to_"
-_OrigoSpotKlineRow: TypeAlias = tuple[
-    datetime,
-    float,
-    float,
-    float,
-    float,
-    float,
-    float,
-    float,
-    float,
-    int,
-    float,
-    float,
-    float,
-    float,
-    float,
-    float,
-    float,
-]
-_ORIGO_SPOT_KLINE_COLUMNS = [
-    "datetime",
-    "open",
-    "high",
-    "low",
-    "close",
-    "mean",
-    "std",
-    "volume",
-    "maker_ratio",
-    "no_of_trades",
-    "open_liquidity",
-    "high_liquidity",
-    "low_liquidity",
-    "close_liquidity",
-    "liquidity_sum",
-    "maker_volume",
-    "maker_liquidity",
-]
-
-
-def _get_origo_spot_klines(
-    *,
-    start_date_limit: str,
-    end_date_limit: str,
-) -> pl.DataFrame:
-    settings = _get_clickhouse_settings()
-    client = _make_clickhouse_client(settings)
-    try:
-        rows = cast(
-            list[_OrigoSpotKlineRow],
-            client.execute(
-                f"""
-                SELECT
-                    datetime,
-                    open,
-                    high,
-                    low,
-                    close,
-                    round(mean, 5) AS mean,
-                    round(std, 6) AS std,
-                    round(volume, 9) AS volume,
-                    maker_ratio,
-                    no_of_trades,
-                    open_liquidity,
-                    high_liquidity,
-                    low_liquidity,
-                    close_liquidity,
-                    round(liquidity_sum, 1) AS liquidity_sum,
-                    maker_volume,
-                    round(maker_liquidity, 1) AS maker_liquidity
-                FROM {settings.database}.binance_spot_klines
-                WHERE datetime >= toDateTime(%(start_date_limit)s)
-                  AND datetime < toDateTime(%(end_date_limit)s)
-                ORDER BY datetime ASC
-                """,
-                {
-                    "start_date_limit": start_date_limit,
-                    "end_date_limit": end_date_limit,
-                },
-            ),
-        )
-    finally:
-        client.disconnect()
-
-    return pl.DataFrame(rows, schema=_ORIGO_SPOT_KLINE_COLUMNS, orient="row").with_columns(
-        pl.col("datetime").cast(pl.Datetime("ms", time_zone="UTC"))
-    )
 
 
 def _get_huggingface_token() -> str:
@@ -127,7 +35,7 @@ def _get_huggingface_dataset_repo_id() -> str:
 def _build_dataset_card(export_end_date: str, row_count: int, file_name: str) -> str:
     return f"""# BTCUSDT 1m spot klines
 
-This dataset is exported daily from `origo.binance_spot_klines` at 1-minute resolution.
+This dataset is exported daily from `origo.binance_daily_spot_trades` using `get_binance_spot_klines` at 1-minute resolution.
 
 Latest snapshot:
 
@@ -140,7 +48,7 @@ Latest snapshot:
 Notes:
 
 - Source market: Binance spot BTCUSDT
-- Source table: `origo.binance_spot_klines`
+- Source table: `origo.binance_daily_spot_trades`
 - `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
 - Timestamps are UTC
 """
@@ -183,7 +91,7 @@ def _sha256_for_file(file_path: Path) -> str:
 @asset(
     partitions_def=daily_partitions,
     group_name="binance_data",
-    description="Exports daily BTCUSDT 1m spot klines from origo.binance_spot_klines and publishes the latest snapshot to Hugging Face.",
+    description="Exports daily BTCUSDT 1m spot klines from origo.binance_daily_spot_trades and publishes the latest snapshot to Hugging Face.",
 )
 def publish_binance_spot_klines_to_huggingface(
     context: AssetExecutionContext,
@@ -207,9 +115,13 @@ def publish_binance_spot_klines_to_huggingface(
     context.log.info(
         f"Building Binance spot klines snapshot through {export_end_date} UTC."
     )
-    data = _get_origo_spot_klines(
+    data = get_binance_spot_klines(
+        kline_size=60,
         start_date_limit=EXPORT_START_DATE,
         end_date_limit=export_end_exclusive,
+        table_name="binance_daily_spot_trades",
+        database_name="origo",
+        include_quantiles=False,
     )
 
     if data.height == 0:

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -458,18 +458,18 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
     job=publish_binance_spot_klines_to_huggingface_job,
 )
 def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
     if not asset_event.dagster_event:
         return SkipReason(
-            "No Dagster event was attached to the Origo spot kline materialization."
+            "No Dagster event was attached to the Origo spot trades materialization."
         )
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason("Origo spot kline materialization did not include a partition key.")
+        return SkipReason("Origo spot trades materialization did not include a partition key.")
 
     return RunRequest(
         partition_key=partition_key,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -463,11 +463,13 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
 )
 def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
     if not asset_event.dagster_event:
-        return SkipReason("No Dagster event was attached to the daily TDW materialization.")
+        return SkipReason(
+            "No Dagster event was attached to the Origo spot kline materialization."
+        )
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason("Daily TDW materialization did not include a partition key.")
+        return SkipReason("Origo spot kline materialization did not include a partition key.")
 
     return RunRequest(
         partition_key=partition_key,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -458,7 +458,7 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_trades_to_tdw"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_klines_to_huggingface_job,
 )
 def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):

--- a/tdw_control_plane/query/get_binance_spot_klines.py
+++ b/tdw_control_plane/query/get_binance_spot_klines.py
@@ -51,6 +51,7 @@ def get_binance_spot_klines(
     end_date_limit: str | None = None,
     show_summary: bool = False,
     table_name: str = "binance_trades_complete",
+    database_name: str = "tdw",
     include_quantiles: bool = True,
 ) -> pl.DataFrame:
     """Query Binance BTCUSDT spot klines from TDW.
@@ -69,11 +70,14 @@ def get_binance_spot_klines(
             `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or `YYYY-MM-DDTHH:MM:SS`.
         show_summary: Whether to log query timing and dataframe size details.
         table_name: ClickHouse source table name.
+        database_name: ClickHouse source database name.
         include_quantiles: Whether to include `median` and `iqr` columns.
     """
 
     if re.fullmatch(r"[A-Za-z0-9_]+", table_name) is None:
         raise ValueError(f"Invalid ClickHouse table name: {table_name}")
+    if re.fullmatch(r"[A-Za-z0-9_]+", database_name) is None:
+        raise ValueError(f"Invalid ClickHouse database name: {database_name}")
 
     n_rows = _validate_positive_int(n_rows, "n_rows")
     kline_size = _validate_positive_int(kline_size, "kline_size")
@@ -129,7 +133,7 @@ def get_binance_spot_klines(
             f"    sum(price * quantity)         AS liquidity_sum, "
             f"    sumKahan(is_buyer_maker * quantity)   AS maker_volume, "
             f"    sum(is_buyer_maker * price * quantity) AS maker_liquidity "
-            f"FROM tdw.{table_name} "
+            f"FROM {database_name}.{table_name} "
             f"{where_sql}"
             f"GROUP BY datetime "
             f"ORDER BY datetime ASC "

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import polars as pl
@@ -9,6 +10,44 @@ import pytest
 from dagster import AssetKey, materialize
 
 from .helpers import ORIGO_DATABASE
+
+KLINE_EXPORT_COLUMNS = [
+    "datetime",
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "volume",
+    "maker_ratio",
+    "no_of_trades",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity",
+]
+
+
+def _origo_projection_dataframe(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    table_name: object,
+    partition_key: str,
+) -> pl.DataFrame:
+    rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(KLINE_EXPORT_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{table_name}
+        WHERE datetime >= toDateTime('2020-01-01 00:00:00')
+          AND datetime < toDateTime('2024-01-02 00:00:00')
+        ORDER BY datetime
+        """
+    )
+    return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient="row")
 
 
 def test_publish_sensor_targets_origo_spot_kline_materialization(
@@ -19,14 +58,15 @@ def test_publish_sensor_targets_origo_spot_kline_materialization(
     assert sensor_def.asset_key == AssetKey("refresh_binance_spot_klines_origo")
 
 
-def test_publish_snapshot_reads_origo_spot_klines(
+def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch: pytest.MonkeyPatch,
-    materialize_binance_spot_data_source_assets: object,
-    query_origo: object,
+    materialize_binance_spot_data_source_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
     origo_assets: dict[str, object],
 ) -> None:
     partition_key = "2024-01-01"
     uploaded: dict[str, object] = {}
+    captured_query: dict[str, object] = {}
 
     result = materialize_binance_spot_data_source_assets(partition_key=partition_key)
     assert result.success
@@ -63,9 +103,22 @@ def test_publish_snapshot_reads_origo_spot_klines(
             uploaded["metadata"] = metadata
             uploaded["parquet"] = pl.read_parquet(folder / metadata["file_name"])
 
+    def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+        captured_query.update(kwargs)
+        return _origo_projection_dataframe(
+            query_origo,
+            origo_assets["KLINES_TABLE_NAME"],
+            partition_key,
+        )
+
     monkeypatch.setenv("HF_TOKEN", "test-token")
     monkeypatch.setenv("HUGGINGFACE_DATASET_REPO_ID", "test/binance-klines")
     monkeypatch.setattr(publish_module, "HfApi", RecordingHfApi)
+    monkeypatch.setattr(
+        publish_module,
+        "get_binance_spot_klines",
+        recording_get_binance_spot_klines,
+    )
 
     publish_result = materialize(
         [publish_module.publish_binance_spot_klines_to_huggingface],
@@ -76,14 +129,6 @@ def test_publish_snapshot_reads_origo_spot_klines(
     parquet = uploaded["parquet"]
     metadata = uploaded["metadata"]
     readme = uploaded["readme"]
-    row_count = query_origo(
-        f"""
-        SELECT count()
-        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
-        WHERE datetime >= toDateTime('2020-01-01 00:00:00')
-          AND datetime < toDateTime('2024-01-02 00:00:00')
-        """
-    )[0][0]
 
     assert isinstance(parquet, pl.DataFrame)
     assert isinstance(metadata, dict)
@@ -92,25 +137,14 @@ def test_publish_snapshot_reads_origo_spot_klines(
     assert uploaded["repo_id"] == "test/binance-klines"
     assert uploaded["upload_repo_id"] == "test/binance-klines"
     assert metadata["export_end_date"] == partition_key
-    assert metadata["row_count"] == row_count
-    assert parquet.height == row_count
-    assert parquet.columns == [
-        "datetime",
-        "open",
-        "high",
-        "low",
-        "close",
-        "mean",
-        "std",
-        "volume",
-        "maker_ratio",
-        "no_of_trades",
-        "open_liquidity",
-        "high_liquidity",
-        "low_liquidity",
-        "close_liquidity",
-        "liquidity_sum",
-        "maker_volume",
-        "maker_liquidity",
-    ]
-    assert "origo.binance_spot_klines" in readme
+    assert metadata["row_count"] == parquet.height
+    assert parquet.columns == KLINE_EXPORT_COLUMNS
+    assert captured_query == {
+        "kline_size": 60,
+        "start_date_limit": "2020-01-01 00:00:00",
+        "end_date_limit": "2024-01-02 00:00:00",
+        "table_name": "binance_daily_spot_trades",
+        "database_name": "origo",
+        "include_quantiles": False,
+    }
+    assert "origo.binance_daily_spot_trades" in readme

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -12,59 +12,83 @@ from dagster import AssetKey, materialize
 from .helpers import ORIGO_DATABASE
 
 KLINE_EXPORT_COLUMNS = [
-    "datetime",
-    "open",
-    "high",
-    "low",
-    "close",
-    "mean",
-    "std",
-    "volume",
-    "maker_ratio",
-    "no_of_trades",
-    "open_liquidity",
-    "high_liquidity",
-    "low_liquidity",
-    "close_liquidity",
-    "liquidity_sum",
-    "maker_volume",
-    "maker_liquidity",
+    'datetime',
+    'open',
+    'high',
+    'low',
+    'close',
+    'mean',
+    'std',
+    'volume',
+    'maker_ratio',
+    'no_of_trades',
+    'open_liquidity',
+    'high_liquidity',
+    'low_liquidity',
+    'close_liquidity',
+    'liquidity_sum',
+    'maker_volume',
+    'maker_liquidity',
 ]
 
 
-def _origo_projection_dataframe(
+def _origo_trades_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
-    table_name: object,
-    partition_key: str,
+    *,
+    database_name: str,
+    table_name: str,
+    start_date_limit: str,
+    end_date_limit: str,
 ) -> pl.DataFrame:
     rows = query_origo(
         f"""
         SELECT
-            {', '.join(KLINE_EXPORT_COLUMNS)}
-        FROM {ORIGO_DATABASE}.{table_name}
-        WHERE datetime >= toDateTime('2020-01-01 00:00:00')
-          AND datetime < toDateTime('2024-01-02 00:00:00')
-        ORDER BY datetime
+            kline_datetime AS datetime,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            round(avg(price), 5) AS mean,
+            round(stddevPopStable(price), 6) AS std,
+            round(sumKahan(quantity), 9) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            round(sum(price * quantity), 1) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toDateTime(60 * intDiv(toUnixTimestamp(datetime), 60)) AS kline_datetime
+            FROM {database_name}.{table_name}
+            WHERE datetime >= toDateTime('{start_date_limit}')
+              AND datetime < toDateTime('{end_date_limit}')
+        )
+        GROUP BY kline_datetime
+        ORDER BY kline_datetime
         """
     )
-    return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient="row")
+    return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_sensor_targets_origo_spot_kline_materialization(
+def test_publish_sensor_targets_origo_spot_trades_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = origo_definitions_module.publish_binance_spot_klines_to_huggingface_sensor
 
-    assert sensor_def.asset_key == AssetKey("refresh_binance_spot_klines_origo")
+    assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
 
 
 def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
-    origo_assets: dict[str, object],
 ) -> None:
-    partition_key = "2024-01-01"
+    partition_key = '2024-01-01'
     uploaded: dict[str, object] = {}
     captured_query: dict[str, object] = {}
 
@@ -72,17 +96,17 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     assert result.success
 
     publish_module = importlib.import_module(
-        "tdw_control_plane.assets.publish_binance_spot_klines_to_huggingface"
+        'tdw_control_plane.assets.publish_binance_spot_klines_to_huggingface'
     )
 
     class RecordingHfApi:
         def __init__(self, token: str) -> None:
-            uploaded["token"] = token
+            uploaded['token'] = token
 
         def create_repo(self, *, repo_id: str, repo_type: str, exist_ok: bool) -> None:
-            uploaded["repo_id"] = repo_id
-            uploaded["repo_type"] = repo_type
-            uploaded["exist_ok"] = exist_ok
+            uploaded['repo_id'] = repo_id
+            uploaded['repo_type'] = repo_type
+            uploaded['exist_ok'] = exist_ok
 
         def upload_folder(
             self,
@@ -94,29 +118,41 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
             delete_patterns: list[str],
         ) -> None:
             folder = Path(folder_path)
-            metadata = json.loads((folder / "latest.json").read_text())
-            uploaded["upload_repo_id"] = repo_id
-            uploaded["upload_repo_type"] = repo_type
-            uploaded["commit_message"] = commit_message
-            uploaded["delete_patterns"] = delete_patterns
-            uploaded["readme"] = (folder / "README.md").read_text()
-            uploaded["metadata"] = metadata
-            uploaded["parquet"] = pl.read_parquet(folder / metadata["file_name"])
+            metadata = json.loads((folder / 'latest.json').read_text())
+            uploaded['upload_repo_id'] = repo_id
+            uploaded['upload_repo_type'] = repo_type
+            uploaded['commit_message'] = commit_message
+            uploaded['delete_patterns'] = delete_patterns
+            uploaded['readme'] = (folder / 'README.md').read_text()
+            uploaded['metadata'] = metadata
+            uploaded['parquet'] = pl.read_parquet(folder / metadata['file_name'])
 
     def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
         captured_query.update(kwargs)
-        return _origo_projection_dataframe(
+        database_name = kwargs.get('database_name')
+        table_name = kwargs.get('table_name')
+        start_date_limit = kwargs.get('start_date_limit')
+        end_date_limit = kwargs.get('end_date_limit')
+
+        assert database_name == ORIGO_DATABASE
+        assert table_name == 'binance_daily_spot_trades'
+        assert isinstance(start_date_limit, str)
+        assert isinstance(end_date_limit, str)
+
+        return _origo_trades_kline_dataframe(
             query_origo,
-            origo_assets["KLINES_TABLE_NAME"],
-            partition_key,
+            database_name=database_name,
+            table_name=table_name,
+            start_date_limit=start_date_limit,
+            end_date_limit=end_date_limit,
         )
 
-    monkeypatch.setenv("HF_TOKEN", "test-token")
-    monkeypatch.setenv("HUGGINGFACE_DATASET_REPO_ID", "test/binance-klines")
-    monkeypatch.setattr(publish_module, "HfApi", RecordingHfApi)
+    monkeypatch.setenv('HF_TOKEN', 'test-token')
+    monkeypatch.setenv('HUGGINGFACE_DATASET_REPO_ID', 'test/binance-klines')
+    monkeypatch.setattr(publish_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_module,
-        "get_binance_spot_klines",
+        'get_binance_spot_klines',
         recording_get_binance_spot_klines,
     )
 
@@ -126,25 +162,25 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     )
     assert publish_result.success
 
-    parquet = uploaded["parquet"]
-    metadata = uploaded["metadata"]
-    readme = uploaded["readme"]
+    parquet = uploaded['parquet']
+    metadata = uploaded['metadata']
+    readme = uploaded['readme']
 
     assert isinstance(parquet, pl.DataFrame)
     assert isinstance(metadata, dict)
     assert isinstance(readme, str)
-    assert uploaded["token"] == "test-token"
-    assert uploaded["repo_id"] == "test/binance-klines"
-    assert uploaded["upload_repo_id"] == "test/binance-klines"
-    assert metadata["export_end_date"] == partition_key
-    assert metadata["row_count"] == parquet.height
+    assert uploaded['token'] == 'test-token'
+    assert uploaded['repo_id'] == 'test/binance-klines'
+    assert uploaded['upload_repo_id'] == 'test/binance-klines'
+    assert metadata['export_end_date'] == partition_key
+    assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS
     assert captured_query == {
-        "kline_size": 60,
-        "start_date_limit": "2020-01-01 00:00:00",
-        "end_date_limit": "2024-01-02 00:00:00",
-        "table_name": "binance_daily_spot_trades",
-        "database_name": "origo",
-        "include_quantiles": False,
+        'kline_size': 60,
+        'start_date_limit': '2020-01-01 00:00:00',
+        'end_date_limit': '2024-01-02 00:00:00',
+        'table_name': 'binance_daily_spot_trades',
+        'database_name': 'origo',
+        'include_quantiles': False,
     }
-    assert "origo.binance_daily_spot_trades" in readme
+    assert 'origo.binance_daily_spot_trades' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+from dagster import AssetKey, materialize
+
+from .helpers import ORIGO_DATABASE
+
+
+def test_publish_sensor_targets_origo_spot_kline_materialization(
+    origo_definitions_module: object,
+) -> None:
+    sensor_def = origo_definitions_module.publish_binance_spot_klines_to_huggingface_sensor
+
+    assert sensor_def.asset_key == AssetKey("refresh_binance_spot_klines_origo")
+
+
+def test_publish_snapshot_reads_origo_spot_klines(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_data_source_assets: object,
+    query_origo: object,
+    origo_assets: dict[str, object],
+) -> None:
+    partition_key = "2024-01-01"
+    uploaded: dict[str, object] = {}
+
+    result = materialize_binance_spot_data_source_assets(partition_key=partition_key)
+    assert result.success
+
+    publish_module = importlib.import_module(
+        "tdw_control_plane.assets.publish_binance_spot_klines_to_huggingface"
+    )
+
+    class RecordingHfApi:
+        def __init__(self, token: str) -> None:
+            uploaded["token"] = token
+
+        def create_repo(self, *, repo_id: str, repo_type: str, exist_ok: bool) -> None:
+            uploaded["repo_id"] = repo_id
+            uploaded["repo_type"] = repo_type
+            uploaded["exist_ok"] = exist_ok
+
+        def upload_folder(
+            self,
+            *,
+            folder_path: str,
+            repo_id: str,
+            repo_type: str,
+            commit_message: str,
+            delete_patterns: list[str],
+        ) -> None:
+            folder = Path(folder_path)
+            metadata = json.loads((folder / "latest.json").read_text())
+            uploaded["upload_repo_id"] = repo_id
+            uploaded["upload_repo_type"] = repo_type
+            uploaded["commit_message"] = commit_message
+            uploaded["delete_patterns"] = delete_patterns
+            uploaded["readme"] = (folder / "README.md").read_text()
+            uploaded["metadata"] = metadata
+            uploaded["parquet"] = pl.read_parquet(folder / metadata["file_name"])
+
+    monkeypatch.setenv("HF_TOKEN", "test-token")
+    monkeypatch.setenv("HUGGINGFACE_DATASET_REPO_ID", "test/binance-klines")
+    monkeypatch.setattr(publish_module, "HfApi", RecordingHfApi)
+
+    publish_result = materialize(
+        [publish_module.publish_binance_spot_klines_to_huggingface],
+        partition_key=partition_key,
+    )
+    assert publish_result.success
+
+    parquet = uploaded["parquet"]
+    metadata = uploaded["metadata"]
+    readme = uploaded["readme"]
+    row_count = query_origo(
+        f"""
+        SELECT count()
+        FROM {ORIGO_DATABASE}.{origo_assets['KLINES_TABLE_NAME']}
+        WHERE datetime >= toDateTime('2020-01-01 00:00:00')
+          AND datetime < toDateTime('2024-01-02 00:00:00')
+        """
+    )[0][0]
+
+    assert isinstance(parquet, pl.DataFrame)
+    assert isinstance(metadata, dict)
+    assert isinstance(readme, str)
+    assert uploaded["token"] == "test-token"
+    assert uploaded["repo_id"] == "test/binance-klines"
+    assert uploaded["upload_repo_id"] == "test/binance-klines"
+    assert metadata["export_end_date"] == partition_key
+    assert metadata["row_count"] == row_count
+    assert parquet.height == row_count
+    assert parquet.columns == [
+        "datetime",
+        "open",
+        "high",
+        "low",
+        "close",
+        "mean",
+        "std",
+        "volume",
+        "maker_ratio",
+        "no_of_trades",
+        "open_liquidity",
+        "high_liquidity",
+        "low_liquidity",
+        "close_liquidity",
+        "liquidity_sum",
+        "maker_volume",
+        "maker_liquidity",
+    ]
+    assert "origo.binance_spot_klines" in readme


### PR DESCRIPTION
Closes #187

## Summary
- Retarget the Hugging Face publish sensor to the Origo source-native spot trades materialization.
- Keep the publisher on the existing `get_binance_spot_klines` helper, adding only a `database_name` selector so it reads `origo.binance_daily_spot_trades` instead of `tdw.binance_trades_complete`.
- Bump version and changelog to `1.6.6`.

## Local parity proof
- Loaded fixture days `2024-01-01` and `2024-01-02` through the TDW daily ingest Dagster asset and the Origo ingest/refresh Dagster assets.
- Compared `get_binance_spot_klines(..., database_name="tdw", table_name="binance_trades_complete", include_quantiles=False)` with `get_binance_spot_klines(..., database_name="origo", table_name="binance_daily_spot_trades", include_quantiles=False)`.
- Result: `PARITY PASS rows=2 columns=17 days=2024-01-01..2024-01-02`.

## Tests
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev python -m pytest tests/origo_source_native -q --maxfail=1`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev --with pyright==1.1.408 pyright --outputjson > /tmp/tdw-control-plane-pyright.json; ... tools/typing_gate.py --pyright-json /tmp/tdw-control-plane-pyright.json --base-budget .github/typing_budget.json` (`pyright` exits on existing config warning; typing gate passes)
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --frozen --extra dev python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-uv-env /Users/mikkokotila/.langflow/uv/uv run --with ruff==0.15.11 ruff check tools tests/tools`
- `git diff --check`