### PR TITLE
fix(origo): add depth20 table creation jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.7.1 on May 14, 2026
+- Add Dagster table-creation jobs for the Binance spot depth20 source-native snapshots and 1-minute projection tables.
+
 # v1.7.0 on May 14, 2026
 - Add the Binance spot depth20 history service as an Origo source with source-native snapshots and a 1-minute source projection.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.7.0"
+version = "1.7.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -139,6 +139,16 @@ create_binance_futures_klines_table_origo_job = define_asset_job(
     selection=["create_binance_futures_klines_table_origo"]
 )
 
+create_binance_spot_depth20_snapshots_table_origo_job = define_asset_job(
+    name="create_binance_spot_depth20_snapshots_table_origo_job",
+    selection=["create_binance_spot_depth20_snapshots_table_origo"]
+)
+
+create_binance_spot_depth20_1m_table_origo_job = define_asset_job(
+    name="create_binance_spot_depth20_1m_table_origo_job",
+    selection=["create_binance_spot_depth20_1m_table_origo"]
+)
+
 create_aligned_1m_exchange_table_origo_job = define_asset_job(
     name="create_aligned_1m_exchange_table_origo_job",
     selection=["create_aligned_1m_exchange_table_origo"]
@@ -593,6 +603,8 @@ defs = Definitions(
           create_binance_daily_futures_trades_table_origo_job,
           create_binance_spot_klines_table_origo_job,
           create_binance_futures_klines_table_origo_job,
+          create_binance_spot_depth20_snapshots_table_origo_job,
+          create_binance_spot_depth20_1m_table_origo_job,
           create_aligned_1m_exchange_table_origo_job,
           create_binance_trades_complete_view_job,
           insert_monthly_binance_trades_job,

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -122,6 +122,25 @@ def test_binance_spot_depth20_1m_schema_contains_bookkeeping_and_five_scalar_boo
     )
 
 
+def test_binance_spot_depth20_table_creation_jobs_are_registered(
+    origo_definitions_module,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    snapshots_job_def = repository_def.get_job_def(
+        'create_binance_spot_depth20_snapshots_table_origo_job'
+    )
+    projection_job_def = repository_def.get_job_def(
+        'create_binance_spot_depth20_1m_table_origo_job'
+    )
+
+    assert set(snapshots_job_def.graph.node_dict.keys()) == {
+        'create_binance_spot_depth20_snapshots_table_origo'
+    }
+    assert set(projection_job_def.graph.node_dict.keys()) == {
+        'create_binance_spot_depth20_1m_table_origo'
+    }
+
+
 def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
     origo_definitions_module,
 ) -> None:

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -125,11 +125,10 @@ def test_binance_spot_depth20_1m_schema_contains_bookkeeping_and_five_scalar_boo
 def test_binance_spot_depth20_table_creation_jobs_are_registered(
     origo_definitions_module,
 ) -> None:
-    repository_def = origo_definitions_module.defs.get_repository_def()
-    snapshots_job_def = repository_def.get_job_def(
+    snapshots_job_def = origo_definitions_module.defs.get_job_def(
         'create_binance_spot_depth20_snapshots_table_origo_job'
     )
-    projection_job_def = repository_def.get_job_def(
+    projection_job_def = origo_definitions_module.defs.get_job_def(
         'create_binance_spot_depth20_1m_table_origo_job'
     )
 


### PR DESCRIPTION
Closes #193.

## Summary
- Add the two missing Dagster create-table jobs for `binance_spot_depth20_snapshots` and `binance_spot_depth20_1m`.
- Register both jobs in `Definitions.jobs`.
- Add the focused job-registration test, plus required patch version and changelog entry.

## Checks
- PASS: compileall tdw_control_plane
- PASS: typing_gate with pyright summary 1193 errors <= budget 1213
- PASS: fail_loud_gate
- PASS: ruff check tools tests/tools
- PASS: docker compose -f docker-compose.deploy.yml config --quiet
- PASS: git diff --check
- BLOCKED locally: focused pytest and tests/origo_source_native need Docker; daemon socket is unavailable on this machine.