### PR TITLE
feat(huggingface): publish Binance spot 1h and 4h klines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.8.0 on May 18, 2026
-- Add a Hugging Face publisher for BTCUSDT 1-hour spot kline snapshots from Origo daily spot trades.
+- Add Hugging Face publishers for BTCUSDT 1-hour and 4-hour spot kline snapshots from Origo daily spot trades.
 
 # v1.7.1 on May 14, 2026
 - Add Dagster table-creation jobs for the Binance spot depth20 source-native snapshots and 1-minute projection tables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.8.0 on May 18, 2026
+- Add a Hugging Face publisher for BTCUSDT 1-hour spot kline snapshots from Origo daily spot trades.
+
 # v1.7.1 on May 14, 2026
 - Add Dagster table-creation jobs for the Binance spot depth20 source-native snapshots and 1-minute projection tables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.7.1"
+version = "1.8.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
@@ -19,7 +19,7 @@ def publish_binance_spot_1h_klines_to_huggingface(
         kline_size_seconds=3600,
         file_prefix="btcusdt_1h_kline_20200101_to_",
         default_repo_id="vaquum/binance_btcusdt_1h_klines",
-        repo_id_env="HUGGINGFACE_1H_DATASET_REPO_ID",
+        repo_id_env=None,
         cadence_label="1h",
         resolution_label="1-hour",
     )

--- a/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
@@ -1,91 +1,9 @@
-import hashlib
-import json
-import os
-import tempfile
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
 from dagster import AssetExecutionContext, asset
-from huggingface_hub import HfApi
 
 from tdw_control_plane.assets.daily_trades_to_origo import daily_partitions
-from tdw_control_plane.query import get_binance_spot_klines
-
-EXPORT_START_DATE = "2020-01-01 00:00:00"
-EXPORT_FILENAME_PREFIX = "btcusdt_1h_kline_20200101_to_"
-
-
-def _get_huggingface_token() -> str:
-    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
-    if not token:
-        raise RuntimeError(
-            "HF_TOKEN or HUGGINGFACE_HUB_TOKEN must be set before publishing to Hugging Face."
-        )
-
-    return token
-
-
-def _get_huggingface_dataset_repo_id() -> str:
-    return os.environ.get(
-        "HUGGINGFACE_1H_DATASET_REPO_ID",
-        "vaquum/binance_btcusdt_1h_klines",
-    )
-
-
-def _build_dataset_card(export_end_date: str, row_count: int, file_name: str) -> str:
-    return f"""# BTCUSDT 1h spot klines
-
-This dataset is exported daily from `origo.binance_daily_spot_trades` using `get_binance_spot_klines` at 1-hour resolution.
-
-Latest snapshot:
-
-- file: `{file_name}`
-- start date: `2020-01-01`
-- rows: `{row_count}`
-- end date: `{export_end_date}`
-- columns: `datetime`, `open`, `high`, `low`, `close`, `mean`, `std`, `volume`, `maker_ratio`, `no_of_trades`, `open_liquidity`, `high_liquidity`, `low_liquidity`, `close_liquidity`, `liquidity_sum`, `maker_volume`, `maker_liquidity`
-
-Notes:
-
-- Source market: Binance spot BTCUSDT
-- Source table: `origo.binance_daily_spot_trades`
-- `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
-- Timestamps are UTC
-"""
-
-
-def _build_snapshot_metadata(
-    export_end_date: str,
-    file_name: str,
-    row_count: int,
-    file_sha256: str,
-) -> str:
-    generated_at = datetime.now(timezone.utc).isoformat()
-    return (
-        json.dumps(
-            {
-                "file_name": file_name,
-                "export_start_date": "2020-01-01",
-                "export_end_date": export_end_date,
-                "row_count": row_count,
-                "sha256": file_sha256,
-                "generated_at_utc": generated_at,
-            },
-            indent=2,
-        )
-        + "\n"
-    )
-
-
-def _sha256_for_file(file_path: Path) -> str:
-    digest = hashlib.sha256()
-    with file_path.open("rb") as handle:
-        while True:
-            chunk = handle.read(1024 * 1024)
-            if not chunk:
-                break
-            digest.update(chunk)
-    return digest.hexdigest()
+from tdw_control_plane.utils.publish_binance_spot_kline_snapshot_to_huggingface import (
+    publish_binance_spot_kline_snapshot_to_huggingface,
+)
 
 
 @asset(
@@ -96,88 +14,12 @@ def _sha256_for_file(file_path: Path) -> str:
 def publish_binance_spot_1h_klines_to_huggingface(
     context: AssetExecutionContext,
 ) -> dict[str, object]:
-    partition_date_str = context.asset_partition_key_for_output()
-
-    export_end_date = partition_date_str
-    export_end_exclusive = (
-        datetime.strptime(export_end_date, "%Y-%m-%d") + timedelta(days=1)
-    ).strftime("%Y-%m-%d 00:00:00")
-    dataset_repo_id = _get_huggingface_dataset_repo_id()
-
-    file_name = (
-        f"{EXPORT_FILENAME_PREFIX}{export_end_date.replace('-', '')}.parquet"
+    return publish_binance_spot_kline_snapshot_to_huggingface(
+        context,
+        kline_size_seconds=3600,
+        file_prefix="btcusdt_1h_kline_20200101_to_",
+        default_repo_id="vaquum/binance_btcusdt_1h_klines",
+        repo_id_env="HUGGINGFACE_1H_DATASET_REPO_ID",
+        cadence_label="1h",
+        resolution_label="1-hour",
     )
-
-    context.log.info(
-        f"Building Binance spot 1h klines snapshot through {export_end_date} UTC."
-    )
-    data = get_binance_spot_klines(
-        kline_size=3600,
-        start_date_limit=EXPORT_START_DATE,
-        end_date_limit=export_end_exclusive,
-        table_name="binance_daily_spot_trades",
-        database_name="origo",
-        include_quantiles=False,
-    )
-
-    if data.height == 0:
-        raise RuntimeError(
-            f"No 1h kline rows were returned for export through {export_end_date}."
-        )
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = Path(tmp_dir)
-        parquet_path = tmp_path / file_name
-        readme_path = tmp_path / "README.md"
-        metadata_path = tmp_path / "latest.json"
-
-        context.log.info(f"Writing snapshot to {parquet_path}.")
-        data.write_parquet(parquet_path, compression="zstd")
-        file_sha256 = _sha256_for_file(parquet_path)
-
-        readme_path.write_text(
-            _build_dataset_card(
-                export_end_date=export_end_date,
-                row_count=data.height,
-                file_name=file_name,
-            ),
-            encoding="utf-8",
-        )
-        metadata_path.write_text(
-            _build_snapshot_metadata(
-                export_end_date=export_end_date,
-                file_name=file_name,
-                row_count=data.height,
-                file_sha256=file_sha256,
-            ),
-            encoding="utf-8",
-        )
-
-        api = HfApi(token=_get_huggingface_token())
-        api.create_repo(
-            repo_id=dataset_repo_id,
-            repo_type="dataset",
-            exist_ok=True,
-        )
-
-        commit_message = f"Add BTCUSDT 1h klines snapshot through {export_end_date}"
-        api.upload_folder(
-            folder_path=str(tmp_path),
-            repo_id=dataset_repo_id,
-            repo_type="dataset",
-            commit_message=commit_message,
-            delete_patterns=[f"{EXPORT_FILENAME_PREFIX}*.parquet"],
-        )
-
-    latest_datetime = data["datetime"].max()
-    context.log.info(
-        f"Published {file_name} to {dataset_repo_id} with {data.height} rows."
-    )
-
-    return {
-        "repo_id": dataset_repo_id,
-        "file_name": file_name,
-        "rows_exported": data.height,
-        "latest_datetime": str(latest_datetime),
-        "sha256": file_sha256,
-    }

--- a/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py
@@ -1,0 +1,183 @@
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from dagster import AssetExecutionContext, asset
+from huggingface_hub import HfApi
+
+from tdw_control_plane.assets.daily_trades_to_origo import daily_partitions
+from tdw_control_plane.query import get_binance_spot_klines
+
+EXPORT_START_DATE = "2020-01-01 00:00:00"
+EXPORT_FILENAME_PREFIX = "btcusdt_1h_kline_20200101_to_"
+
+
+def _get_huggingface_token() -> str:
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "HF_TOKEN or HUGGINGFACE_HUB_TOKEN must be set before publishing to Hugging Face."
+        )
+
+    return token
+
+
+def _get_huggingface_dataset_repo_id() -> str:
+    return os.environ.get(
+        "HUGGINGFACE_1H_DATASET_REPO_ID",
+        "vaquum/binance_btcusdt_1h_klines",
+    )
+
+
+def _build_dataset_card(export_end_date: str, row_count: int, file_name: str) -> str:
+    return f"""# BTCUSDT 1h spot klines
+
+This dataset is exported daily from `origo.binance_daily_spot_trades` using `get_binance_spot_klines` at 1-hour resolution.
+
+Latest snapshot:
+
+- file: `{file_name}`
+- start date: `2020-01-01`
+- rows: `{row_count}`
+- end date: `{export_end_date}`
+- columns: `datetime`, `open`, `high`, `low`, `close`, `mean`, `std`, `volume`, `maker_ratio`, `no_of_trades`, `open_liquidity`, `high_liquidity`, `low_liquidity`, `close_liquidity`, `liquidity_sum`, `maker_volume`, `maker_liquidity`
+
+Notes:
+
+- Source market: Binance spot BTCUSDT
+- Source table: `origo.binance_daily_spot_trades`
+- `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
+- Timestamps are UTC
+"""
+
+
+def _build_snapshot_metadata(
+    export_end_date: str,
+    file_name: str,
+    row_count: int,
+    file_sha256: str,
+) -> str:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    return (
+        json.dumps(
+            {
+                "file_name": file_name,
+                "export_start_date": "2020-01-01",
+                "export_end_date": export_end_date,
+                "row_count": row_count,
+                "sha256": file_sha256,
+                "generated_at_utc": generated_at,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _sha256_for_file(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@asset(
+    partitions_def=daily_partitions,
+    group_name="binance_data",
+    description="Exports daily BTCUSDT 1h spot klines from origo.binance_daily_spot_trades and publishes the latest snapshot to Hugging Face.",
+)
+def publish_binance_spot_1h_klines_to_huggingface(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date_str = context.asset_partition_key_for_output()
+
+    export_end_date = partition_date_str
+    export_end_exclusive = (
+        datetime.strptime(export_end_date, "%Y-%m-%d") + timedelta(days=1)
+    ).strftime("%Y-%m-%d 00:00:00")
+    dataset_repo_id = _get_huggingface_dataset_repo_id()
+
+    file_name = (
+        f"{EXPORT_FILENAME_PREFIX}{export_end_date.replace('-', '')}.parquet"
+    )
+
+    context.log.info(
+        f"Building Binance spot 1h klines snapshot through {export_end_date} UTC."
+    )
+    data = get_binance_spot_klines(
+        kline_size=3600,
+        start_date_limit=EXPORT_START_DATE,
+        end_date_limit=export_end_exclusive,
+        table_name="binance_daily_spot_trades",
+        database_name="origo",
+        include_quantiles=False,
+    )
+
+    if data.height == 0:
+        raise RuntimeError(
+            f"No 1h kline rows were returned for export through {export_end_date}."
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        parquet_path = tmp_path / file_name
+        readme_path = tmp_path / "README.md"
+        metadata_path = tmp_path / "latest.json"
+
+        context.log.info(f"Writing snapshot to {parquet_path}.")
+        data.write_parquet(parquet_path, compression="zstd")
+        file_sha256 = _sha256_for_file(parquet_path)
+
+        readme_path.write_text(
+            _build_dataset_card(
+                export_end_date=export_end_date,
+                row_count=data.height,
+                file_name=file_name,
+            ),
+            encoding="utf-8",
+        )
+        metadata_path.write_text(
+            _build_snapshot_metadata(
+                export_end_date=export_end_date,
+                file_name=file_name,
+                row_count=data.height,
+                file_sha256=file_sha256,
+            ),
+            encoding="utf-8",
+        )
+
+        api = HfApi(token=_get_huggingface_token())
+        api.create_repo(
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            exist_ok=True,
+        )
+
+        commit_message = f"Add BTCUSDT 1h klines snapshot through {export_end_date}"
+        api.upload_folder(
+            folder_path=str(tmp_path),
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            commit_message=commit_message,
+            delete_patterns=[f"{EXPORT_FILENAME_PREFIX}*.parquet"],
+        )
+
+    latest_datetime = data["datetime"].max()
+    context.log.info(
+        f"Published {file_name} to {dataset_repo_id} with {data.height} rows."
+    )
+
+    return {
+        "repo_id": dataset_repo_id,
+        "file_name": file_name,
+        "rows_exported": data.height,
+        "latest_datetime": str(latest_datetime),
+        "sha256": file_sha256,
+    }

--- a/tdw_control_plane/assets/publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_4h_klines_to_huggingface.py
@@ -19,7 +19,7 @@ def publish_binance_spot_4h_klines_to_huggingface(
         kline_size_seconds=14400,
         file_prefix="btcusdt_4h_kline_20200101_to_",
         default_repo_id="vaquum/binance_btcusdt_4h_klines",
-        repo_id_env="HUGGINGFACE_4H_DATASET_REPO_ID",
+        repo_id_env=None,
         cadence_label="4h",
         resolution_label="4-hour",
     )

--- a/tdw_control_plane/assets/publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tdw_control_plane/assets/publish_binance_spot_4h_klines_to_huggingface.py
@@ -9,17 +9,17 @@ from tdw_control_plane.utils.publish_binance_spot_kline_snapshot_to_huggingface 
 @asset(
     partitions_def=daily_partitions,
     group_name="binance_data",
-    description="Exports daily BTCUSDT 1m spot klines from origo.binance_daily_spot_trades and publishes the latest snapshot to Hugging Face.",
+    description="Exports daily BTCUSDT 4h spot klines from origo.binance_daily_spot_trades and publishes the latest snapshot to Hugging Face.",
 )
-def publish_binance_spot_klines_to_huggingface(
+def publish_binance_spot_4h_klines_to_huggingface(
     context: AssetExecutionContext,
 ) -> dict[str, object]:
     return publish_binance_spot_kline_snapshot_to_huggingface(
         context,
-        kline_size_seconds=60,
-        file_prefix="btcusdt_1m_kline_20200101_to_",
-        default_repo_id="vaquum/binance_btcusdt_1m_klines",
-        repo_id_env="HUGGINGFACE_DATASET_REPO_ID",
-        cadence_label="1m",
-        resolution_label="1-minute",
+        kline_size_seconds=14400,
+        file_prefix="btcusdt_4h_kline_20200101_to_",
+        default_repo_id="vaquum/binance_btcusdt_4h_klines",
+        repo_id_env="HUGGINGFACE_4H_DATASET_REPO_ID",
+        cadence_label="4h",
+        resolution_label="4-hour",
     )

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -33,6 +33,9 @@ from .assets.daily_trades_to_tdw import insert_daily_binance_trades_to_tdw
 from .assets.publish_binance_spot_klines_to_huggingface import (
     publish_binance_spot_klines_to_huggingface,
 )
+from .assets.publish_binance_spot_1h_klines_to_huggingface import (
+    publish_binance_spot_1h_klines_to_huggingface,
+)
 from .assets.monthly_trades_to_tdw import insert_monthly_binance_trades_to_tdw
 from .assets.create_tdw_database import create_tdw_database
 from .assets.create_binance_daily_trades_table import create_binance_daily_trades_table
@@ -207,6 +210,10 @@ insert_daily_binance_trades_tdw_job = define_asset_job(
 publish_binance_spot_klines_to_huggingface_job = define_asset_job(
     name="publish_binance_spot_klines_to_huggingface_job",
     selection=["publish_binance_spot_klines_to_huggingface"])
+
+publish_binance_spot_1h_klines_to_huggingface_job = define_asset_job(
+    name="publish_binance_spot_1h_klines_to_huggingface_job",
+    selection=["publish_binance_spot_1h_klines_to_huggingface"])
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
     name="insert_monthly_agg_trades_to_tdw_job",
@@ -544,6 +551,26 @@ def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
     )
 
 
+@asset_sensor(
+    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    job=publish_binance_spot_1h_klines_to_huggingface_job,
+)
+def publish_binance_spot_1h_klines_to_huggingface_sensor(context, asset_event):
+    if not asset_event.dagster_event:
+        return SkipReason(
+            "No Dagster event was attached to the Origo spot trades materialization."
+        )
+
+    partition_key = asset_event.dagster_event.partition
+    if partition_key is None:
+        return SkipReason("Origo spot trades materialization did not include a partition key.")
+
+    return RunRequest(
+        partition_key=partition_key,
+        run_key=f"publish_binance_spot_1h_klines_to_hf::{partition_key}",
+    )
+
+
 defs = Definitions(
     assets=[create_tdw_database,
             create_origo_database,
@@ -568,6 +595,7 @@ defs = Definitions(
             refresh_aligned_1m_exchange_from_binance_futures_origo,
             insert_daily_binance_trades_to_tdw,
             publish_binance_spot_klines_to_huggingface,
+            publish_binance_spot_1h_klines_to_huggingface,
             cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
@@ -593,6 +621,7 @@ defs = Definitions(
 
     sensors=[
         publish_binance_spot_klines_to_huggingface_sensor,
+        publish_binance_spot_1h_klines_to_huggingface_sensor,
     ],
     
     jobs=[create_tdw_database_job,
@@ -613,6 +642,7 @@ defs = Definitions(
           refresh_binance_spot_depth20_data_source_job,
           insert_daily_binance_trades_tdw_job,
           publish_binance_spot_klines_to_huggingface_job,
+          publish_binance_spot_1h_klines_to_huggingface_job,
           roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -9,6 +9,7 @@
 
 import os
 from datetime import datetime, timedelta, timezone
+from typing import Protocol
 
 import requests
 from clickhouse_driver import Client as ClickhouseClient
@@ -35,6 +36,9 @@ from .assets.publish_binance_spot_klines_to_huggingface import (
 )
 from .assets.publish_binance_spot_1h_klines_to_huggingface import (
     publish_binance_spot_1h_klines_to_huggingface,
+)
+from .assets.publish_binance_spot_4h_klines_to_huggingface import (
+    publish_binance_spot_4h_klines_to_huggingface,
 )
 from .assets.monthly_trades_to_tdw import insert_monthly_binance_trades_to_tdw
 from .assets.create_tdw_database import create_tdw_database
@@ -101,6 +105,14 @@ CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 MAX_DAILY_BACKFILL_RUNS_PER_TICK = 14
 MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS = 14
+
+
+class _DagsterEventLike(Protocol):
+    partition: str | None
+
+
+class _AssetEventLike(Protocol):
+    dagster_event: _DagsterEventLike | None
 
 
 # Database Maintenance Jobs
@@ -214,6 +226,10 @@ publish_binance_spot_klines_to_huggingface_job = define_asset_job(
 publish_binance_spot_1h_klines_to_huggingface_job = define_asset_job(
     name="publish_binance_spot_1h_klines_to_huggingface_job",
     selection=["publish_binance_spot_1h_klines_to_huggingface"])
+
+publish_binance_spot_4h_klines_to_huggingface_job = define_asset_job(
+    name="publish_binance_spot_4h_klines_to_huggingface_job",
+    selection=["publish_binance_spot_4h_klines_to_huggingface"])
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
     name="insert_monthly_agg_trades_to_tdw_job",
@@ -531,11 +547,11 @@ def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
     )
 
 
-@asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
-    job=publish_binance_spot_klines_to_huggingface_job,
-)
-def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
+def _publish_binance_spot_klines_to_hf_run_request(
+    asset_event: _AssetEventLike,
+    *,
+    run_key_prefix: str,
+) -> RunRequest | SkipReason:
     if not asset_event.dagster_event:
         return SkipReason(
             "No Dagster event was attached to the Origo spot trades materialization."
@@ -547,7 +563,21 @@ def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
 
     return RunRequest(
         partition_key=partition_key,
-        run_key=f"publish_binance_spot_klines_to_hf::{partition_key}",
+        run_key=f"{run_key_prefix}::{partition_key}",
+    )
+
+
+@asset_sensor(
+    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    job=publish_binance_spot_klines_to_huggingface_job,
+)
+def publish_binance_spot_klines_to_huggingface_sensor(
+    context: object,
+    asset_event: _AssetEventLike,
+) -> RunRequest | SkipReason:
+    return _publish_binance_spot_klines_to_hf_run_request(
+        asset_event,
+        run_key_prefix="publish_binance_spot_klines_to_hf",
     )
 
 
@@ -555,19 +585,27 @@ def publish_binance_spot_klines_to_huggingface_sensor(context, asset_event):
     asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
     job=publish_binance_spot_1h_klines_to_huggingface_job,
 )
-def publish_binance_spot_1h_klines_to_huggingface_sensor(context, asset_event):
-    if not asset_event.dagster_event:
-        return SkipReason(
-            "No Dagster event was attached to the Origo spot trades materialization."
-        )
+def publish_binance_spot_1h_klines_to_huggingface_sensor(
+    context: object,
+    asset_event: _AssetEventLike,
+) -> RunRequest | SkipReason:
+    return _publish_binance_spot_klines_to_hf_run_request(
+        asset_event,
+        run_key_prefix="publish_binance_spot_1h_klines_to_hf",
+    )
 
-    partition_key = asset_event.dagster_event.partition
-    if partition_key is None:
-        return SkipReason("Origo spot trades materialization did not include a partition key.")
 
-    return RunRequest(
-        partition_key=partition_key,
-        run_key=f"publish_binance_spot_1h_klines_to_hf::{partition_key}",
+@asset_sensor(
+    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    job=publish_binance_spot_4h_klines_to_huggingface_job,
+)
+def publish_binance_spot_4h_klines_to_huggingface_sensor(
+    context: object,
+    asset_event: _AssetEventLike,
+) -> RunRequest | SkipReason:
+    return _publish_binance_spot_klines_to_hf_run_request(
+        asset_event,
+        run_key_prefix="publish_binance_spot_4h_klines_to_hf",
     )
 
 
@@ -596,6 +634,7 @@ defs = Definitions(
             insert_daily_binance_trades_to_tdw,
             publish_binance_spot_klines_to_huggingface,
             publish_binance_spot_1h_klines_to_huggingface,
+            publish_binance_spot_4h_klines_to_huggingface,
             cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
@@ -622,6 +661,7 @@ defs = Definitions(
     sensors=[
         publish_binance_spot_klines_to_huggingface_sensor,
         publish_binance_spot_1h_klines_to_huggingface_sensor,
+        publish_binance_spot_4h_klines_to_huggingface_sensor,
     ],
     
     jobs=[create_tdw_database_job,
@@ -643,6 +683,7 @@ defs = Definitions(
           insert_daily_binance_trades_tdw_job,
           publish_binance_spot_klines_to_huggingface_job,
           publish_binance_spot_1h_klines_to_huggingface_job,
+          publish_binance_spot_4h_klines_to_huggingface_job,
           roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,

--- a/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
@@ -25,9 +25,12 @@ def _get_huggingface_token() -> str:
 
 def _get_huggingface_dataset_repo_id(
     *,
-    repo_id_env: str,
+    repo_id_env: str | None,
     default_repo_id: str,
 ) -> str:
+    if repo_id_env is None:
+        return default_repo_id
+
     return os.environ.get(repo_id_env, default_repo_id)
 
 
@@ -100,7 +103,7 @@ def publish_binance_spot_kline_snapshot_to_huggingface(
     kline_size_seconds: int,
     file_prefix: str,
     default_repo_id: str,
-    repo_id_env: str,
+    repo_id_env: str | None,
     cadence_label: str,
     resolution_label: str,
 ) -> dict[str, object]:

--- a/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
@@ -1,0 +1,193 @@
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from dagster import AssetExecutionContext
+from huggingface_hub import HfApi
+
+from tdw_control_plane.query import get_binance_spot_klines
+
+EXPORT_START_DATE = "2020-01-01 00:00:00"
+
+
+def _get_huggingface_token() -> str:
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "HF_TOKEN or HUGGINGFACE_HUB_TOKEN must be set before publishing to Hugging Face."
+        )
+
+    return token
+
+
+def _get_huggingface_dataset_repo_id(
+    *,
+    repo_id_env: str,
+    default_repo_id: str,
+) -> str:
+    return os.environ.get(repo_id_env, default_repo_id)
+
+
+def _build_dataset_card(
+    *,
+    export_end_date: str,
+    row_count: int,
+    file_name: str,
+    cadence_label: str,
+    resolution_label: str,
+) -> str:
+    return f"""# BTCUSDT {cadence_label} spot klines
+
+This dataset is exported daily from `origo.binance_daily_spot_trades` using `get_binance_spot_klines` at {resolution_label} resolution.
+
+Latest snapshot:
+
+- file: `{file_name}`
+- start date: `2020-01-01`
+- rows: `{row_count}`
+- end date: `{export_end_date}`
+- columns: `datetime`, `open`, `high`, `low`, `close`, `mean`, `std`, `volume`, `maker_ratio`, `no_of_trades`, `open_liquidity`, `high_liquidity`, `low_liquidity`, `close_liquidity`, `liquidity_sum`, `maker_volume`, `maker_liquidity`
+
+Notes:
+
+- Source market: Binance spot BTCUSDT
+- Source table: `origo.binance_daily_spot_trades`
+- `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
+- Timestamps are UTC
+"""
+
+
+def _build_snapshot_metadata(
+    export_end_date: str,
+    file_name: str,
+    row_count: int,
+    file_sha256: str,
+) -> str:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    return (
+        json.dumps(
+            {
+                "file_name": file_name,
+                "export_start_date": "2020-01-01",
+                "export_end_date": export_end_date,
+                "row_count": row_count,
+                "sha256": file_sha256,
+                "generated_at_utc": generated_at,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _sha256_for_file(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def publish_binance_spot_kline_snapshot_to_huggingface(
+    context: AssetExecutionContext,
+    *,
+    kline_size_seconds: int,
+    file_prefix: str,
+    default_repo_id: str,
+    repo_id_env: str,
+    cadence_label: str,
+    resolution_label: str,
+) -> dict[str, object]:
+    partition_date_str = context.asset_partition_key_for_output()
+    export_end_date = partition_date_str
+    export_end_exclusive = (
+        datetime.strptime(export_end_date, "%Y-%m-%d") + timedelta(days=1)
+    ).strftime("%Y-%m-%d 00:00:00")
+    dataset_repo_id = _get_huggingface_dataset_repo_id(
+        repo_id_env=repo_id_env,
+        default_repo_id=default_repo_id,
+    )
+
+    file_name = f"{file_prefix}{export_end_date.replace('-', '')}.parquet"
+
+    context.log.info(
+        f"Building Binance spot {cadence_label} klines snapshot through {export_end_date} UTC."
+    )
+    data = get_binance_spot_klines(
+        kline_size=kline_size_seconds,
+        start_date_limit=EXPORT_START_DATE,
+        end_date_limit=export_end_exclusive,
+        table_name="binance_daily_spot_trades",
+        database_name="origo",
+        include_quantiles=False,
+    )
+
+    if data.height == 0:
+        raise RuntimeError(
+            f"No {cadence_label} kline rows were returned for export through {export_end_date}."
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        parquet_path = tmp_path / file_name
+        readme_path = tmp_path / "README.md"
+        metadata_path = tmp_path / "latest.json"
+
+        context.log.info(f"Writing snapshot to {parquet_path}.")
+        data.write_parquet(parquet_path, compression="zstd")
+        file_sha256 = _sha256_for_file(parquet_path)
+
+        readme_path.write_text(
+            _build_dataset_card(
+                export_end_date=export_end_date,
+                row_count=data.height,
+                file_name=file_name,
+                cadence_label=cadence_label,
+                resolution_label=resolution_label,
+            ),
+            encoding="utf-8",
+        )
+        metadata_path.write_text(
+            _build_snapshot_metadata(
+                export_end_date=export_end_date,
+                file_name=file_name,
+                row_count=data.height,
+                file_sha256=file_sha256,
+            ),
+            encoding="utf-8",
+        )
+
+        api = HfApi(token=_get_huggingface_token())
+        api.create_repo(
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            exist_ok=True,
+        )
+
+        commit_message = f"Add BTCUSDT {cadence_label} klines snapshot through {export_end_date}"
+        api.upload_folder(
+            folder_path=str(tmp_path),
+            repo_id=dataset_repo_id,
+            repo_type="dataset",
+            commit_message=commit_message,
+            delete_patterns=[f"{file_prefix}*.parquet"],
+        )
+
+    latest_datetime = data["datetime"].max()
+    context.log.info(
+        f"Published {file_name} to {dataset_repo_id} with {data.height} rows."
+    )
+
+    return {
+        "repo_id": dataset_repo_id,
+        "file_name": file_name,
+        "rows_exported": data.height,
+        "latest_datetime": str(latest_datetime),
+        "sha256": file_sha256,
+    }

--- a/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import polars as pl
+import pytest
+from dagster import AssetKey, materialize
+
+from .helpers import ORIGO_DATABASE
+
+KLINE_EXPORT_COLUMNS = [
+    'datetime',
+    'open',
+    'high',
+    'low',
+    'close',
+    'mean',
+    'std',
+    'volume',
+    'maker_ratio',
+    'no_of_trades',
+    'open_liquidity',
+    'high_liquidity',
+    'low_liquidity',
+    'close_liquidity',
+    'liquidity_sum',
+    'maker_volume',
+    'maker_liquidity',
+]
+
+
+def _origo_trades_1h_kline_dataframe(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    *,
+    database_name: str,
+    table_name: str,
+    start_date_limit: str,
+    end_date_limit: str,
+) -> pl.DataFrame:
+    rows = query_origo(
+        f"""
+        SELECT
+            kline_datetime AS datetime,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            round(avg(price), 5) AS mean,
+            round(stddevPopStable(price), 6) AS std,
+            round(sumKahan(quantity), 9) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            round(sum(price * quantity), 1) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toDateTime(3600 * intDiv(toUnixTimestamp(datetime), 3600)) AS kline_datetime
+            FROM {database_name}.{table_name}
+            WHERE datetime >= toDateTime('{start_date_limit}')
+              AND datetime < toDateTime('{end_date_limit}')
+        )
+        GROUP BY kline_datetime
+        ORDER BY kline_datetime
+        """
+    )
+    return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
+
+
+def test_publish_1h_sensor_targets_origo_spot_trades_materialization(
+    origo_definitions_module: object,
+) -> None:
+    sensor_def = (
+        origo_definitions_module.publish_binance_spot_1h_klines_to_huggingface_sensor
+    )
+
+    assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
+
+
+def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_data_source_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+) -> None:
+    partition_key = '2024-01-01'
+    uploaded: dict[str, object] = {}
+    captured_query: dict[str, object] = {}
+
+    result = materialize_binance_spot_data_source_assets(partition_key=partition_key)
+    assert result.success
+
+    publish_module = importlib.import_module(
+        'tdw_control_plane.assets.publish_binance_spot_1h_klines_to_huggingface'
+    )
+
+    class RecordingHfApi:
+        def __init__(self, token: str) -> None:
+            uploaded['token'] = token
+
+        def create_repo(self, *, repo_id: str, repo_type: str, exist_ok: bool) -> None:
+            uploaded['repo_id'] = repo_id
+            uploaded['repo_type'] = repo_type
+            uploaded['exist_ok'] = exist_ok
+
+        def upload_folder(
+            self,
+            *,
+            folder_path: str,
+            repo_id: str,
+            repo_type: str,
+            commit_message: str,
+            delete_patterns: list[str],
+        ) -> None:
+            folder = Path(folder_path)
+            metadata = json.loads((folder / 'latest.json').read_text())
+            uploaded['upload_repo_id'] = repo_id
+            uploaded['upload_repo_type'] = repo_type
+            uploaded['commit_message'] = commit_message
+            uploaded['delete_patterns'] = delete_patterns
+            uploaded['readme'] = (folder / 'README.md').read_text()
+            uploaded['metadata'] = metadata
+            uploaded['parquet'] = pl.read_parquet(folder / metadata['file_name'])
+
+    def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+        captured_query.update(kwargs)
+        database_name = kwargs.get('database_name')
+        table_name = kwargs.get('table_name')
+        start_date_limit = kwargs.get('start_date_limit')
+        end_date_limit = kwargs.get('end_date_limit')
+
+        assert database_name == ORIGO_DATABASE
+        assert table_name == 'binance_daily_spot_trades'
+        assert isinstance(start_date_limit, str)
+        assert isinstance(end_date_limit, str)
+
+        return _origo_trades_1h_kline_dataframe(
+            query_origo,
+            database_name=database_name,
+            table_name=table_name,
+            start_date_limit=start_date_limit,
+            end_date_limit=end_date_limit,
+        )
+
+    monkeypatch.setenv('HF_TOKEN', 'test-token')
+    monkeypatch.setenv('HUGGINGFACE_1H_DATASET_REPO_ID', 'test/binance-1h-klines')
+    monkeypatch.setattr(publish_module, 'HfApi', RecordingHfApi)
+    monkeypatch.setattr(
+        publish_module,
+        'get_binance_spot_klines',
+        recording_get_binance_spot_klines,
+    )
+
+    publish_result = materialize(
+        [publish_module.publish_binance_spot_1h_klines_to_huggingface],
+        partition_key=partition_key,
+    )
+    assert publish_result.success
+
+    parquet = uploaded['parquet']
+    metadata = uploaded['metadata']
+    readme = uploaded['readme']
+
+    assert isinstance(parquet, pl.DataFrame)
+    assert isinstance(metadata, dict)
+    assert isinstance(readme, str)
+    assert uploaded['token'] == 'test-token'
+    assert uploaded['repo_id'] == 'test/binance-1h-klines'
+    assert uploaded['upload_repo_id'] == 'test/binance-1h-klines'
+    assert metadata['export_end_date'] == partition_key
+    assert metadata['row_count'] == parquet.height
+    assert parquet.columns == KLINE_EXPORT_COLUMNS
+    assert captured_query == {
+        'kline_size': 3600,
+        'start_date_limit': '2020-01-01 00:00:00',
+        'end_date_limit': '2024-01-02 00:00:00',
+        'table_name': 'binance_daily_spot_trades',
+        'database_name': 'origo',
+        'include_quantiles': False,
+    }
+    assert uploaded['commit_message'] == 'Add BTCUSDT 1h klines snapshot through 2024-01-01'
+    assert uploaded['delete_patterns'] == ['btcusdt_1h_kline_20200101_to_*.parquet']
+    assert metadata['file_name'] == 'btcusdt_1h_kline_20200101_to_20240101.parquet'
+    assert '1-hour resolution' in readme
+    assert 'origo.binance_daily_spot_trades' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
@@ -153,7 +153,7 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
         )
 
     monkeypatch.setenv('HF_TOKEN', 'test-token')
-    monkeypatch.setenv('HUGGINGFACE_1H_DATASET_REPO_ID', 'test/binance-1h-klines')
+    monkeypatch.setenv('HUGGINGFACE_DATASET_REPO_ID', 'test/not-used')
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
@@ -175,8 +175,8 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert isinstance(metadata, dict)
     assert isinstance(readme, str)
     assert uploaded['token'] == 'test-token'
-    assert uploaded['repo_id'] == 'test/binance-1h-klines'
-    assert uploaded['upload_repo_id'] == 'test/binance-1h-klines'
+    assert uploaded['repo_id'] == 'vaquum/binance_btcusdt_1h_klines'
+    assert uploaded['upload_repo_id'] == 'vaquum/binance_btcusdt_1h_klines'
     assert metadata['export_end_date'] == partition_key
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS

--- a/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
@@ -32,7 +32,7 @@ KLINE_EXPORT_COLUMNS = [
 ]
 
 
-def _origo_trades_1h_kline_dataframe(
+def _origo_trades_4h_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
     *,
     database_name: str,
@@ -63,7 +63,7 @@ def _origo_trades_1h_kline_dataframe(
         FROM (
             SELECT
                 *,
-                toDateTime(3600 * intDiv(toUnixTimestamp(datetime), 3600)) AS kline_datetime
+                toDateTime(14400 * intDiv(toUnixTimestamp(datetime), 14400)) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')
               AND datetime < toDateTime('{end_date_limit}')
@@ -75,17 +75,17 @@ def _origo_trades_1h_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_1h_sensor_targets_origo_spot_trades_materialization(
+def test_publish_4h_sensor_targets_origo_spot_trades_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = (
-        origo_definitions_module.publish_binance_spot_1h_klines_to_huggingface_sensor
+        origo_definitions_module.publish_binance_spot_4h_klines_to_huggingface_sensor
     )
 
     assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
 
 
-def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
+def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -98,7 +98,7 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert result.success
 
     publish_module = importlib.import_module(
-        'tdw_control_plane.assets.publish_binance_spot_1h_klines_to_huggingface'
+        'tdw_control_plane.assets.publish_binance_spot_4h_klines_to_huggingface'
     )
     publish_helper_module = importlib.import_module(
         'tdw_control_plane.utils.publish_binance_spot_kline_snapshot_to_huggingface'
@@ -144,7 +144,7 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
         assert isinstance(start_date_limit, str)
         assert isinstance(end_date_limit, str)
 
-        return _origo_trades_1h_kline_dataframe(
+        return _origo_trades_4h_kline_dataframe(
             query_origo,
             database_name=database_name,
             table_name=table_name,
@@ -153,7 +153,7 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
         )
 
     monkeypatch.setenv('HF_TOKEN', 'test-token')
-    monkeypatch.setenv('HUGGINGFACE_1H_DATASET_REPO_ID', 'test/binance-1h-klines')
+    monkeypatch.setenv('HUGGINGFACE_4H_DATASET_REPO_ID', 'test/binance-4h-klines')
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
@@ -162,7 +162,7 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     )
 
     publish_result = materialize(
-        [publish_module.publish_binance_spot_1h_klines_to_huggingface],
+        [publish_module.publish_binance_spot_4h_klines_to_huggingface],
         partition_key=partition_key,
     )
     assert publish_result.success
@@ -175,21 +175,21 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert isinstance(metadata, dict)
     assert isinstance(readme, str)
     assert uploaded['token'] == 'test-token'
-    assert uploaded['repo_id'] == 'test/binance-1h-klines'
-    assert uploaded['upload_repo_id'] == 'test/binance-1h-klines'
+    assert uploaded['repo_id'] == 'test/binance-4h-klines'
+    assert uploaded['upload_repo_id'] == 'test/binance-4h-klines'
     assert metadata['export_end_date'] == partition_key
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS
     assert captured_query == {
-        'kline_size': 3600,
+        'kline_size': 14400,
         'start_date_limit': '2020-01-01 00:00:00',
         'end_date_limit': '2024-01-02 00:00:00',
         'table_name': 'binance_daily_spot_trades',
         'database_name': 'origo',
         'include_quantiles': False,
     }
-    assert uploaded['commit_message'] == 'Add BTCUSDT 1h klines snapshot through 2024-01-01'
-    assert uploaded['delete_patterns'] == ['btcusdt_1h_kline_20200101_to_*.parquet']
-    assert metadata['file_name'] == 'btcusdt_1h_kline_20200101_to_20240101.parquet'
-    assert '1-hour resolution' in readme
+    assert uploaded['commit_message'] == 'Add BTCUSDT 4h klines snapshot through 2024-01-01'
+    assert uploaded['delete_patterns'] == ['btcusdt_4h_kline_20200101_to_*.parquet']
+    assert metadata['file_name'] == 'btcusdt_4h_kline_20200101_to_20240101.parquet'
+    assert '4-hour resolution' in readme
     assert 'origo.binance_daily_spot_trades' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
@@ -153,7 +153,7 @@ def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
         )
 
     monkeypatch.setenv('HF_TOKEN', 'test-token')
-    monkeypatch.setenv('HUGGINGFACE_4H_DATASET_REPO_ID', 'test/binance-4h-klines')
+    monkeypatch.setenv('HUGGINGFACE_DATASET_REPO_ID', 'test/not-used')
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
@@ -175,8 +175,8 @@ def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert isinstance(metadata, dict)
     assert isinstance(readme, str)
     assert uploaded['token'] == 'test-token'
-    assert uploaded['repo_id'] == 'test/binance-4h-klines'
-    assert uploaded['upload_repo_id'] == 'test/binance-4h-klines'
+    assert uploaded['repo_id'] == 'vaquum/binance_btcusdt_4h_klines'
+    assert uploaded['upload_repo_id'] == 'vaquum/binance_btcusdt_4h_klines'
     assert metadata['export_end_date'] == partition_key
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -98,6 +98,9 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     publish_module = importlib.import_module(
         'tdw_control_plane.assets.publish_binance_spot_klines_to_huggingface'
     )
+    publish_helper_module = importlib.import_module(
+        'tdw_control_plane.utils.publish_binance_spot_kline_snapshot_to_huggingface'
+    )
 
     class RecordingHfApi:
         def __init__(self, token: str) -> None:
@@ -149,9 +152,9 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
 
     monkeypatch.setenv('HF_TOKEN', 'test-token')
     monkeypatch.setenv('HUGGINGFACE_DATASET_REPO_ID', 'test/binance-klines')
-    monkeypatch.setattr(publish_module, 'HfApi', RecordingHfApi)
+    monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
-        publish_module,
+        publish_helper_module,
         'get_binance_spot_klines',
         recording_get_binance_spot_klines,
     )


### PR DESCRIPTION
Closes #195

## Summary
- Replace copied HF kline publisher logic with one shared cadence helper in `tdw_control_plane/utils`.
- Keep 1m behavior intact through a thin wrapper; add 1h and 4h wrappers with distinct repo env vars, file prefixes, and run keys.
- Register 1h/4h Dagster assets, jobs, and sensors; update tests and version trail for `1.8.0`.

## Validation
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 python -m compileall -q tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py tdw_control_plane/assets/publish_binance_spot_klines_to_huggingface.py tdw_control_plane/assets/publish_binance_spot_1h_klines_to_huggingface.py tdw_control_plane/assets/publish_binance_spot_4h_klines_to_huggingface.py tdw_control_plane/definitions.py tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 pyright --outputjson > /tmp/pyright-issue-195-uv.json` (baseline errors decrease; no diagnostics in publisher modules)
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 python tools/typing_gate.py --base-budget .github/typing_budget.json --pyright-json /tmp/pyright-issue-195-uv.json`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 python tools/version_gate.py --pr-title 'feat(huggingface): publish Binance spot 1h and 4h klines' --base-pyproject /tmp/<base>/base_pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/<base>/base_CHANGELOG.md --head-changelog CHANGELOG.md`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 python tools/slice_gate.py --pr-title 'feat(huggingface): publish Binance spot 1h and 4h klines' --pr-body-file /tmp/<pr>/pr_body.md --pr-files-file /tmp/<pr>/pr_files.txt --template .github/ISSUE_TEMPLATE/slice.yml --repo Vaquum/tdw-control-plane`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-issue-195-venv uv run --frozen --extra dev --python 3.11 pytest tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py -q` blocked locally: Docker daemon unavailable at `/Users/mikkokotila/.docker/run/docker.sock`.
