### PR TITLE
feat(origo): add binance spot dollar klines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.9.0 on May 19, 2026
+- Add Binance spot dollar klines on Origo daily spot trades.
+
 # v1.8.0 on May 18, 2026
 - Add Hugging Face publishers for BTCUSDT 1-hour and 4-hour spot kline snapshots from Origo daily spot trades.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.8.0"
+version = "1.9.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
@@ -19,7 +19,8 @@ def _create_dollar_klines_table(
     client.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{DOLLAR_KLINES_TABLE_NAME} (
-            datetime DateTime,
+            start_datetime DateTime,
+            end_datetime DateTime,
             dollar_bar_id UInt64 COMMENT 'Partition-date scoped id; resets each day and may skip ids when one trade crosses multiple dollar thresholds.',
             open Float64,
             high Float64,
@@ -41,8 +42,8 @@ def _create_dollar_klines_table(
             maker_liquidity Float64
         )
         ENGINE = MergeTree()
-        PARTITION BY toYYYYMM(datetime)
-        ORDER BY (datetime, dollar_bar_id)
+        PARTITION BY toYYYYMM(start_datetime)
+        ORDER BY (start_datetime, end_datetime, dollar_bar_id)
         """
     )
 

--- a/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
@@ -1,0 +1,77 @@
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_trades_table_origo import _database_exists, _table_exists
+from .create_origo_database import (
+    ClickHouseSettings,
+    _get_clickhouse_settings,
+    _make_clickhouse_client,
+    create_origo_database,
+)
+
+DOLLAR_KLINES_TABLE_NAME = 'binance_spot_dollar_klines'
+
+
+def _create_dollar_klines_table(
+    client: ClickhouseClient,
+    settings: ClickHouseSettings,
+) -> None:
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {settings.database}.{DOLLAR_KLINES_TABLE_NAME} (
+            datetime DateTime,
+            dollar_bar_id UInt64,
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            mean Float64,
+            std Float64,
+            median Float64,
+            iqr Float64,
+            volume Float64,
+            maker_ratio Float64,
+            no_of_trades UInt64,
+            open_liquidity Float64,
+            high_liquidity Float64,
+            low_liquidity Float64,
+            close_liquidity Float64,
+            liquidity_sum Float64,
+            maker_volume Float64,
+            maker_liquidity Float64
+        )
+        ENGINE = MergeTree()
+        PARTITION BY toYYYYMM(datetime)
+        ORDER BY (datetime, dollar_bar_id)
+        """
+    )
+
+
+@asset(
+    group_name='origo_setup',
+    deps=[create_origo_database],
+    description='Creates the binance_spot_dollar_klines table if it does not exist',
+)
+def create_binance_spot_dollar_klines_table_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        if not _database_exists(client, settings.database):
+            raise RuntimeError(
+                f'Database {settings.database} does not exist. Run create_origo_database first.'
+            )
+
+        table_existed = _table_exists(client, settings, DOLLAR_KLINES_TABLE_NAME)
+        _create_dollar_klines_table(client, settings)
+
+        context.log.info(f'Ensured table {settings.database}.{DOLLAR_KLINES_TABLE_NAME} exists.')
+        return {
+            'status': 'success',
+            'table': f'{settings.database}.{DOLLAR_KLINES_TABLE_NAME}',
+            'table_action': 'already_exists' if table_existed else 'created',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py
@@ -20,7 +20,7 @@ def _create_dollar_klines_table(
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{DOLLAR_KLINES_TABLE_NAME} (
             datetime DateTime,
-            dollar_bar_id UInt64,
+            dollar_bar_id UInt64 COMMENT 'Partition-date scoped id; resets each day and may skip ids when one trade crosses multiple dollar thresholds.',
             open Float64,
             high Float64,
             low Float64,
@@ -50,7 +50,10 @@ def _create_dollar_klines_table(
 @asset(
     group_name='origo_setup',
     deps=[create_origo_database],
-    description='Creates the binance_spot_dollar_klines table if it does not exist',
+    description=(
+        'Creates the binance_spot_dollar_klines table if it does not exist. '
+        'dollar_bar_id is scoped to each partition date and may be non-contiguous.'
+    ),
 )
 def create_binance_spot_dollar_klines_table_origo(
     context: AssetExecutionContext,

--- a/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
@@ -112,7 +112,11 @@ def _insert_partition_rows(
         insert_daily_binance_spot_trades_to_origo,
     ],
     group_name='binance_data',
-    description='Refreshes the Binance spot dollar kline projection from source-native daily trades',
+    description=(
+        'Refreshes the daily-scoped Binance spot dollar kline projection from '
+        'source-native daily trades; dollar_bar_id resets each date and the final '
+        'daily bar may be below the dollar threshold.'
+    ),
 )
 def refresh_binance_spot_dollar_klines_origo(
     context: AssetExecutionContext,

--- a/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
@@ -1,0 +1,143 @@
+from datetime import UTC, datetime, timedelta
+
+from clickhouse_driver import Client as ClickhouseClient
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_spot_dollar_klines_table_origo import (
+    DOLLAR_KLINES_TABLE_NAME,
+    create_binance_spot_dollar_klines_table_origo,
+)
+from .create_binance_trades_table_origo import RAW_TABLE_NAME
+from .create_origo_database import _get_clickhouse_settings, _make_clickhouse_client
+from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_trades_to_origo
+
+DOLLAR_KLINE_SIZE = 100_000.0
+
+
+def _partition_date_from_context(context: AssetExecutionContext) -> str:
+    partition_key = context.partition_key
+    if partition_key is not None:
+        return partition_key
+
+    target_date = datetime.now(UTC) - timedelta(days=1)
+    return target_date.strftime('%Y-%m-%d')
+
+
+def _delete_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        ALTER TABLE {database}.{DOLLAR_KLINES_TABLE_NAME}
+        DELETE WHERE toDate(datetime) = toDate('{partition_date}')
+        """,
+        settings={'mutations_sync': 2},
+    )
+
+
+def _count_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{DOLLAR_KLINES_TABLE_NAME}
+        WHERE toDate(datetime) = toDate('{partition_date}')
+        """
+    )
+    return int(result[0][0])
+
+
+def _insert_partition_rows(
+    client: ClickhouseClient,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        INSERT INTO {database}.{DOLLAR_KLINES_TABLE_NAME}
+        SELECT
+            max(datetime) AS datetime,
+            dollar_bar_id,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            avg(price) AS mean,
+            stddevPopStable(price) AS std,
+            quantileExact(0.5)(price) AS median,
+            quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr,
+            sumKahan(quantity) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            sum(price * quantity) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            sum(is_buyer_maker * price * quantity) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toUInt64(floor(running_quote_before / {DOLLAR_KLINE_SIZE})) AS dollar_bar_id
+            FROM (
+                SELECT
+                    *,
+                    greatest(
+                        sum(quote_quantity) OVER (
+                            ORDER BY datetime, trade_id
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                        ) - quote_quantity,
+                        0.0
+                    ) AS running_quote_before
+                FROM {database}.{RAW_TABLE_NAME}
+                WHERE toDate(datetime) = toDate('{partition_date}')
+            )
+        )
+        GROUP BY dollar_bar_id
+        ORDER BY dollar_bar_id
+        """
+    )
+
+
+@asset(
+    partitions_def=daily_partitions,
+    deps=[
+        create_binance_spot_dollar_klines_table_origo,
+        insert_daily_binance_spot_trades_to_origo,
+    ],
+    group_name='binance_data',
+    description='Refreshes the Binance spot dollar kline projection from source-native daily trades',
+)
+def refresh_binance_spot_dollar_klines_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date = _partition_date_from_context(context)
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        existing_count = _count_partition_rows(client, settings.database, partition_date)
+        if existing_count > 0:
+            context.log.info(
+                f'Found {existing_count} existing Binance spot dollar kline rows for '
+                f'{partition_date}. Replacing that partition.'
+            )
+            _delete_partition_rows(client, settings.database, partition_date)
+
+        _insert_partition_rows(client, settings.database, partition_date)
+        inserted_count = _count_partition_rows(client, settings.database, partition_date)
+
+        return {
+            'status': 'success',
+            'partition_date': partition_date,
+            'rows_inserted': inserted_count,
+            'table': f'{settings.database}.{DOLLAR_KLINES_TABLE_NAME}',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py
@@ -31,7 +31,7 @@ def _delete_partition_rows(
     client.execute(
         f"""
         ALTER TABLE {database}.{DOLLAR_KLINES_TABLE_NAME}
-        DELETE WHERE toDate(datetime) = toDate('{partition_date}')
+        DELETE WHERE toDate(start_datetime) = toDate('{partition_date}')
         """,
         settings={'mutations_sync': 2},
     )
@@ -46,7 +46,7 @@ def _count_partition_rows(
         f"""
         SELECT count()
         FROM {database}.{DOLLAR_KLINES_TABLE_NAME}
-        WHERE toDate(datetime) = toDate('{partition_date}')
+        WHERE toDate(start_datetime) = toDate('{partition_date}')
         """
     )
     return int(result[0][0])
@@ -61,7 +61,8 @@ def _insert_partition_rows(
         f"""
         INSERT INTO {database}.{DOLLAR_KLINES_TABLE_NAME}
         SELECT
-            max(datetime) AS datetime,
+            min(datetime) AS start_datetime,
+            max(datetime) AS end_datetime,
             dollar_bar_id,
             argMin(price, trade_id) AS open,
             max(price) AS high,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -70,6 +70,9 @@ from .assets.create_binance_futures_trades_table_origo import (
 from .assets.create_binance_spot_klines_table_origo import (
     create_binance_spot_klines_table_origo,
 )
+from .assets.create_binance_spot_dollar_klines_table_origo import (
+    create_binance_spot_dollar_klines_table_origo,
+)
 from .assets.create_binance_futures_klines_table_origo import (
     create_binance_futures_klines_table_origo,
 )
@@ -80,6 +83,9 @@ from .assets.create_binance_spot_depth20_snapshots_table_origo import (
     create_binance_spot_depth20_snapshots_table_origo,
 )
 from .assets.refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
+from .assets.refresh_binance_spot_dollar_klines_origo import (
+    refresh_binance_spot_dollar_klines_origo,
+)
 from .assets.refresh_binance_futures_klines_origo import refresh_binance_futures_klines_origo
 from .assets.refresh_binance_spot_depth20_1m_origo import (
     refresh_binance_spot_depth20_1m_origo,
@@ -149,6 +155,11 @@ create_binance_spot_klines_table_origo_job = define_asset_job(
     selection=["create_binance_spot_klines_table_origo"]
 )
 
+create_binance_spot_dollar_klines_table_origo_job = define_asset_job(
+    name="create_binance_spot_dollar_klines_table_origo_job",
+    selection=["create_binance_spot_dollar_klines_table_origo"]
+)
+
 create_binance_futures_klines_table_origo_job = define_asset_job(
     name="create_binance_futures_klines_table_origo_job",
     selection=["create_binance_futures_klines_table_origo"]
@@ -196,6 +207,7 @@ refresh_binance_spot_data_source_job = define_asset_job(
     selection=[
         "insert_daily_binance_spot_trades_to_origo",
         "refresh_binance_spot_klines_origo",
+        "refresh_binance_spot_dollar_klines_origo",
         "refresh_aligned_1m_exchange_from_binance_spot_origo",
     ])
 
@@ -617,6 +629,7 @@ defs = Definitions(
             create_binance_daily_spot_trades_table_origo,
             create_binance_daily_futures_trades_table_origo,
             create_binance_spot_klines_table_origo,
+            create_binance_spot_dollar_klines_table_origo,
             create_binance_futures_klines_table_origo,
             create_binance_spot_depth20_snapshots_table_origo,
             create_binance_spot_depth20_1m_table_origo,
@@ -626,6 +639,7 @@ defs = Definitions(
             insert_daily_binance_spot_trades_to_origo,
             insert_daily_binance_futures_trades_to_origo,
             refresh_binance_spot_klines_origo,
+            refresh_binance_spot_dollar_klines_origo,
             refresh_binance_futures_klines_origo,
             sync_binance_spot_depth20_snapshots_to_origo,
             refresh_binance_spot_depth20_1m_origo,
@@ -671,6 +685,7 @@ defs = Definitions(
           create_binance_daily_spot_trades_table_origo_job,
           create_binance_daily_futures_trades_table_origo_job,
           create_binance_spot_klines_table_origo_job,
+          create_binance_spot_dollar_klines_table_origo_job,
           create_binance_futures_klines_table_origo_job,
           create_binance_spot_depth20_snapshots_table_origo_job,
           create_binance_spot_depth20_1m_table_origo_job,

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -224,11 +224,17 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     create_binance_spot_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_spot_klines_table_origo'
     )
+    create_binance_spot_dollar_klines_table_origo_module = _reload_module(
+        'tdw_control_plane.assets.create_binance_spot_dollar_klines_table_origo'
+    )
     create_binance_futures_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_futures_klines_table_origo'
     )
     refresh_binance_spot_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_spot_klines_origo'
+    )
+    refresh_binance_spot_dollar_klines_origo_module = _reload_module(
+        'tdw_control_plane.assets.refresh_binance_spot_dollar_klines_origo'
     )
     refresh_binance_futures_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_futures_klines_origo'
@@ -276,16 +282,28 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'create_binance_spot_klines_table_origo': (
             create_binance_spot_klines_table_origo_module.create_binance_spot_klines_table_origo
         ),
+        'create_binance_spot_dollar_klines_table_origo': (
+            create_binance_spot_dollar_klines_table_origo_module.create_binance_spot_dollar_klines_table_origo
+        ),
         'create_binance_futures_klines_table_origo': (
             create_binance_futures_klines_table_origo_module.create_binance_futures_klines_table_origo
         ),
         'refresh_binance_spot_klines_origo': (
             refresh_binance_spot_klines_origo_module.refresh_binance_spot_klines_origo
         ),
+        'refresh_binance_spot_dollar_klines_origo': (
+            refresh_binance_spot_dollar_klines_origo_module.refresh_binance_spot_dollar_klines_origo
+        ),
         'refresh_binance_futures_klines_origo': (
             refresh_binance_futures_klines_origo_module.refresh_binance_futures_klines_origo
         ),
         'KLINES_TABLE_NAME': create_binance_spot_klines_table_origo_module.KLINES_TABLE_NAME,
+        'DOLLAR_KLINES_TABLE_NAME': (
+            create_binance_spot_dollar_klines_table_origo_module.DOLLAR_KLINES_TABLE_NAME
+        ),
+        'refresh_binance_spot_dollar_klines_origo_module': (
+            refresh_binance_spot_dollar_klines_origo_module
+        ),
         'FUTURES_KLINES_TABLE_NAME': (
             create_binance_futures_klines_table_origo_module.KLINES_TABLE_NAME
         ),
@@ -357,6 +375,25 @@ def materialize_binance_spot_data_source_assets(
                 origo_assets['insert_daily_binance_spot_trades_to_origo'],
                 origo_assets['refresh_binance_spot_klines_origo'],
                 origo_assets['refresh_aligned_1m_exchange_from_binance_spot_origo'],
+            ],
+            partition_key=partition_key,
+        )
+
+    return _run
+
+
+@pytest.fixture()
+def materialize_binance_spot_dollar_klines_assets(
+    origo_assets: dict[str, object],
+) -> object:
+    def _run(*, partition_key: str | None = None) -> object:
+        return materialize(
+            [
+                origo_assets['create_origo_database'],
+                origo_assets['create_binance_daily_spot_trades_table_origo'],
+                origo_assets['create_binance_spot_dollar_klines_table_origo'],
+                origo_assets['insert_daily_binance_spot_trades_to_origo'],
+                origo_assets['refresh_binance_spot_dollar_klines_origo'],
             ],
             partition_key=partition_key,
         )

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
@@ -8,7 +8,8 @@ import pytest
 from .helpers import ORIGO_DATABASE
 
 DOLLAR_KLINE_COLUMNS = [
-    'datetime',
+    'start_datetime',
+    'end_datetime',
     'dollar_bar_id',
     'open',
     'high',
@@ -30,6 +31,7 @@ DOLLAR_KLINE_COLUMNS = [
     'maker_liquidity',
 ]
 DOLLAR_KLINE_COLUMN_TYPES = [
+    'DateTime',
     'DateTime',
     'UInt64',
     *(['Float64'] * 10),
@@ -96,12 +98,12 @@ def test_binance_spot_dollar_klines_schema_matches_spot_kline_statistics_contrac
     assert [type_name for _, type_name, *_ in rows] == DOLLAR_KLINE_COLUMN_TYPES
     assert _table_metadata(query_origo, str(origo_assets['DOLLAR_KLINES_TABLE_NAME'])) == (
         'MergeTree',
-        'toYYYYMM(datetime)',
-        'datetime, dollar_bar_id',
+        'toYYYYMM(start_datetime)',
+        'start_datetime, end_datetime, dollar_bar_id',
     )
 
 
-def test_binance_spot_dollar_klines_rows_match_fixture_for_small_threshold(
+def test_binance_spot_dollar_klines_rows_match_fixture_with_exact_bar_range(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_dollar_klines_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -110,7 +112,7 @@ def test_binance_spot_dollar_klines_rows_match_fixture_for_small_threshold(
     monkeypatch.setattr(
         origo_assets['refresh_binance_spot_dollar_klines_origo_module'],
         'DOLLAR_KLINE_SIZE',
-        40.0,
+        200.0,
     )
 
     result = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
@@ -121,77 +123,34 @@ def test_binance_spot_dollar_klines_rows_match_fixture_for_small_threshold(
         SELECT
             {', '.join(DOLLAR_KLINE_COLUMNS)}
         FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
-        WHERE toDate(datetime) = toDate('2024-01-01')
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
         ORDER BY dollar_bar_id
         """
     )
 
     assert _rows_to_dicts(DOLLAR_KLINE_COLUMNS, rows) == [
         {
-            'datetime': '2024-01-01 00:00:00',
+            'start_datetime': '2024-01-01 00:00:00',
+            'end_datetime': '2024-01-01 00:00:02',
             'dollar_bar_id': 0,
             'open': 42000.1,
-            'high': 42000.1,
-            'low': 42000.1,
-            'close': 42000.1,
-            'mean': 42000.1,
-            'std': 0.0,
-            'median': 42000.1,
-            'iqr': 0.0,
-            'volume': 0.001,
-            'maker_ratio': 1.0,
-            'no_of_trades': 1,
-            'open_liquidity': 42.000099999999996,
-            'high_liquidity': 42.000099999999996,
-            'low_liquidity': 42.000099999999996,
-            'close_liquidity': 42.000099999999996,
-            'liquidity_sum': 42.000099999999996,
-            'maker_volume': 0.001,
-            'maker_liquidity': 42.000099999999996,
-        },
-        {
-            'datetime': '2024-01-01 00:00:01',
-            'dollar_bar_id': 1,
-            'open': 42010.0,
             'high': 42010.0,
-            'low': 42010.0,
-            'close': 42010.0,
-            'mean': 42010.0,
-            'std': 0.0,
-            'median': 42010.0,
-            'iqr': 0.0,
-            'volume': 0.002,
-            'maker_ratio': 0.0,
-            'no_of_trades': 1,
-            'open_liquidity': 84.02,
-            'high_liquidity': 84.02,
-            'low_liquidity': 84.02,
-            'close_liquidity': 84.02,
-            'liquidity_sum': 84.02,
-            'maker_volume': 0.0,
-            'maker_liquidity': 0.0,
-        },
-        {
-            'datetime': '2024-01-01 00:00:02',
-            'dollar_bar_id': 3,
-            'open': 42005.5,
-            'high': 42005.5,
-            'low': 42005.5,
+            'low': 42000.1,
             'close': 42005.5,
-            'mean': 42005.5,
-            'std': 0.0,
+            'mean': 42005.200000000004,
+            'std': 4.047221268968605,
             'median': 42005.5,
-            'iqr': 0.0,
-            'volume': 0.0015,
-            'maker_ratio': 1.0,
-            'no_of_trades': 1,
-            'open_liquidity': 63.008250000000004,
-            'high_liquidity': 63.008250000000004,
-            'low_liquidity': 63.008250000000004,
+            'iqr': 9.900000000001455,
+            'volume': 0.0045000000000000005,
+            'maker_ratio': 0.6666666666666666,
+            'no_of_trades': 3,
+            'open_liquidity': 42.000099999999996,
+            'high_liquidity': 84.02,
+            'low_liquidity': 42.000099999999996,
             'close_liquidity': 63.008250000000004,
-            'liquidity_sum': 63.008250000000004,
-            'maker_volume': 0.0015,
-            'maker_liquidity': 63.008250000000004,
+            'liquidity_sum': 189.02835,
+            'maker_volume': 0.0025,
+            'maker_liquidity': 105.00835000000001,
         },
     ]
 
@@ -214,7 +173,7 @@ def test_same_partition_rerun_is_idempotent_for_dollar_klines(
         SELECT
             {', '.join(DOLLAR_KLINE_COLUMNS)}
         FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
-        WHERE toDate(datetime) = toDate('2024-01-01')
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
         ORDER BY dollar_bar_id
         """
     )
@@ -225,7 +184,7 @@ def test_same_partition_rerun_is_idempotent_for_dollar_klines(
         SELECT
             {', '.join(DOLLAR_KLINE_COLUMNS)}
         FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
-        WHERE toDate(datetime) = toDate('2024-01-01')
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
         ORDER BY dollar_bar_id
         """
     )

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+
+from .helpers import ORIGO_DATABASE
+
+DOLLAR_KLINE_COLUMNS = [
+    'datetime',
+    'dollar_bar_id',
+    'open',
+    'high',
+    'low',
+    'close',
+    'mean',
+    'std',
+    'median',
+    'iqr',
+    'volume',
+    'maker_ratio',
+    'no_of_trades',
+    'open_liquidity',
+    'high_liquidity',
+    'low_liquidity',
+    'close_liquidity',
+    'liquidity_sum',
+    'maker_volume',
+    'maker_liquidity',
+]
+DOLLAR_KLINE_COLUMN_TYPES = [
+    'DateTime',
+    'UInt64',
+    *(['Float64'] * 10),
+    'UInt64',
+    *(['Float64'] * 7),
+]
+
+
+def _table_metadata(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    table_name: str,
+) -> tuple[str, str, str]:
+    rows = query_origo(
+        f"""
+        SELECT engine, partition_key, sorting_key
+        FROM system.tables
+        WHERE database = '{ORIGO_DATABASE}'
+          AND name = '{table_name}'
+        """
+    )
+
+    assert len(rows) == 1
+    engine, partition_key, sorting_key = rows[0]
+    return str(engine), str(partition_key), str(sorting_key)
+
+
+def _normalize_value(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    return value
+
+
+def _rows_to_dicts(
+    columns: list[str],
+    rows: list[tuple[object, ...]],
+) -> list[dict[str, object]]:
+    return [
+        {column: _normalize_value(value) for column, value in zip(columns, row, strict=True)}
+        for row in rows
+    ]
+
+
+def test_binance_spot_dollar_klines_table_name_contract(
+    origo_assets: dict[str, object],
+) -> None:
+    assert origo_assets['DOLLAR_KLINES_TABLE_NAME'] == 'binance_spot_dollar_klines'
+
+
+def test_binance_spot_dollar_klines_schema_matches_spot_kline_statistics_contract(
+    materialize_binance_spot_dollar_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        DESCRIBE TABLE {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
+        """
+    )
+
+    assert [name for name, *_ in rows] == DOLLAR_KLINE_COLUMNS
+    assert [type_name for _, type_name, *_ in rows] == DOLLAR_KLINE_COLUMN_TYPES
+    assert _table_metadata(query_origo, str(origo_assets['DOLLAR_KLINES_TABLE_NAME'])) == (
+        'MergeTree',
+        'toYYYYMM(datetime)',
+        'datetime, dollar_bar_id',
+    )
+
+
+def test_binance_spot_dollar_klines_rows_match_fixture_for_small_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_dollar_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_dollar_klines_origo_module'],
+        'DOLLAR_KLINE_SIZE',
+        40.0,
+    )
+
+    result = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(DOLLAR_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
+        WHERE toDate(datetime) = toDate('2024-01-01')
+        ORDER BY dollar_bar_id
+        """
+    )
+
+    assert _rows_to_dicts(DOLLAR_KLINE_COLUMNS, rows) == [
+        {
+            'datetime': '2024-01-01 00:00:00',
+            'dollar_bar_id': 0,
+            'open': 42000.1,
+            'high': 42000.1,
+            'low': 42000.1,
+            'close': 42000.1,
+            'mean': 42000.1,
+            'std': 0.0,
+            'median': 42000.1,
+            'iqr': 0.0,
+            'volume': 0.001,
+            'maker_ratio': 1.0,
+            'no_of_trades': 1,
+            'open_liquidity': 42.000099999999996,
+            'high_liquidity': 42.000099999999996,
+            'low_liquidity': 42.000099999999996,
+            'close_liquidity': 42.000099999999996,
+            'liquidity_sum': 42.000099999999996,
+            'maker_volume': 0.001,
+            'maker_liquidity': 42.000099999999996,
+        },
+        {
+            'datetime': '2024-01-01 00:00:01',
+            'dollar_bar_id': 1,
+            'open': 42010.0,
+            'high': 42010.0,
+            'low': 42010.0,
+            'close': 42010.0,
+            'mean': 42010.0,
+            'std': 0.0,
+            'median': 42010.0,
+            'iqr': 0.0,
+            'volume': 0.002,
+            'maker_ratio': 0.0,
+            'no_of_trades': 1,
+            'open_liquidity': 84.02,
+            'high_liquidity': 84.02,
+            'low_liquidity': 84.02,
+            'close_liquidity': 84.02,
+            'liquidity_sum': 84.02,
+            'maker_volume': 0.0,
+            'maker_liquidity': 0.0,
+        },
+        {
+            'datetime': '2024-01-01 00:00:02',
+            'dollar_bar_id': 3,
+            'open': 42005.5,
+            'high': 42005.5,
+            'low': 42005.5,
+            'close': 42005.5,
+            'mean': 42005.5,
+            'std': 0.0,
+            'median': 42005.5,
+            'iqr': 0.0,
+            'volume': 0.0015,
+            'maker_ratio': 1.0,
+            'no_of_trades': 1,
+            'open_liquidity': 63.008250000000004,
+            'high_liquidity': 63.008250000000004,
+            'low_liquidity': 63.008250000000004,
+            'close_liquidity': 63.008250000000004,
+            'liquidity_sum': 63.008250000000004,
+            'maker_volume': 0.0015,
+            'maker_liquidity': 63.008250000000004,
+        },
+    ]
+
+
+def test_same_partition_rerun_is_idempotent_for_dollar_klines(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_dollar_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_dollar_klines_origo_module'],
+        'DOLLAR_KLINE_SIZE',
+        40.0,
+    )
+
+    first = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
+    first_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(DOLLAR_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
+        WHERE toDate(datetime) = toDate('2024-01-01')
+        ORDER BY dollar_bar_id
+        """
+    )
+
+    second = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
+    second_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(DOLLAR_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_KLINES_TABLE_NAME']}
+        WHERE toDate(datetime) = toDate('2024-01-01')
+        ORDER BY dollar_bar_id
+        """
+    )
+
+    assert first.success
+    assert second.success
+    assert first_rows == second_rows
+    assert len(second_rows) == 3
+
+
+def test_dollar_kline_assets_and_job_are_registered(
+    origo_definitions_module: object,
+    origo_assets: dict[str, object],
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    data_source_job = repository_def.get_job_def('refresh_binance_spot_data_source_job')
+    create_table_job = repository_def.get_job_def(
+        'create_binance_spot_dollar_klines_table_origo_job'
+    )
+    node_names = set(data_source_job.graph.node_dict.keys())
+    dollar_asset = origo_assets['refresh_binance_spot_dollar_klines_origo']
+    dollar_deps = dollar_asset.asset_deps[dollar_asset.key]
+
+    assert create_table_job.name == 'create_binance_spot_dollar_klines_table_origo_job'
+    assert node_names >= {
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_klines_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_spot_origo',
+    }
+    assert dollar_deps == {
+        origo_assets['create_binance_spot_dollar_klines_table_origo'].key,
+        origo_assets['insert_daily_binance_spot_trades_to_origo'].key,
+    }

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from datetime import datetime
 
 import pytest
+from dagster import DefaultScheduleStatus
 
 from .helpers import ORIGO_DATABASE
 
@@ -195,10 +196,14 @@ def test_same_partition_rerun_is_idempotent_for_dollar_klines(
     assert len(second_rows) == 3
 
 
-def test_dollar_kline_assets_and_job_are_registered(
+def test_dollar_kline_assets_job_and_schedule_are_registered(
     origo_definitions_module: object,
     origo_assets: dict[str, object],
 ) -> None:
+    schedule_def = origo_definitions_module.daily_binance_spot_pipeline_schedule
+    resolved_schedule_def = origo_definitions_module.defs.get_repository_def().get_schedule_def(
+        'daily_binance_spot_pipeline_schedule'
+    )
     data_source_job = origo_definitions_module.defs.get_job_def(
         'refresh_binance_spot_data_source_job'
     )
@@ -209,6 +214,10 @@ def test_dollar_kline_assets_and_job_are_registered(
     dollar_asset = origo_assets['refresh_binance_spot_dollar_klines_origo']
     dollar_deps = dollar_asset.asset_deps[dollar_asset.key]
 
+    assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
+    assert resolved_schedule_def.cron_schedule == '0 4 * * *'
+    assert resolved_schedule_def.execution_timezone == 'UTC'
+    assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
     assert create_table_job.name == 'create_binance_spot_dollar_klines_table_origo_job'
     assert node_names >= {
         'insert_daily_binance_spot_trades_to_origo',

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
@@ -240,9 +240,10 @@ def test_dollar_kline_assets_and_job_are_registered(
     origo_definitions_module: object,
     origo_assets: dict[str, object],
 ) -> None:
-    repository_def = origo_definitions_module.defs.get_repository_def()
-    data_source_job = repository_def.get_job_def('refresh_binance_spot_data_source_job')
-    create_table_job = repository_def.get_job_def(
+    data_source_job = origo_definitions_module.defs.get_job_def(
+        'refresh_binance_spot_data_source_job'
+    )
+    create_table_job = origo_definitions_module.defs.get_job_def(
         'create_binance_spot_dollar_klines_table_origo_job'
     )
     node_names = set(data_source_job.graph.node_dict.keys())


### PR DESCRIPTION
## Summary
- Add `origo.binance_spot_dollar_klines` with the existing spot kline statistic footprint plus `dollar_bar_id`.
- Add the daily dollar-kline refresh asset and register it in the Binance spot Origo data-source job.
- Add Origo source-native tests, version bump, and changelog entry.

## Validation
- `ruff check tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py tools tests/tools`
- `python3 -m py_compile tdw_control_plane/assets/create_binance_spot_dollar_klines_table_origo.py tdw_control_plane/assets/refresh_binance_spot_dollar_klines_origo.py tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py`
- `pytest tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py -q --maxfail=1` blocked locally because Docker daemon is unavailable.

Closes #197