### PR TITLE
feat(origo): add binance spot volume klines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.11.0 on May 19, 2026
+- Add Binance spot volume klines on Origo daily spot trades.
+
 # v1.10.0 on May 19, 2026
 - Add Hugging Face publishers for BTCUSDT 15-minute, 30-minute, and 2-hour spot kline snapshots from Origo daily spot trades.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.10.0"
+version = "1.11.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/create_binance_spot_volume_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_volume_klines_table_origo.py
@@ -1,0 +1,179 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Protocol, runtime_checkable
+
+from dagster import AssetExecutionContext, asset
+
+from .create_origo_database import create_origo_database
+
+_DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
+_DEFAULT_CLICKHOUSE_PORT = 9000
+_DEFAULT_CLICKHOUSE_USER = 'default'
+VOLUME_KLINES_TABLE_NAME = 'binance_spot_volume_klines'
+
+
+@dataclass(frozen=True)
+class _ClickHouseSettings:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+
+@runtime_checkable
+class _ClickHouseClientLike(Protocol):
+    def execute(
+        self,
+        query: str,
+        params: object | None = None,
+        *,
+        settings: Mapping[str, object] | None = None,
+    ) -> list[tuple[object, ...]]:
+        raise NotImplementedError
+
+    def disconnect(self) -> None:
+        raise NotImplementedError
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f'{name} environment variable must be set.')
+    return value
+
+
+def _get_clickhouse_port() -> int:
+    value = os.environ.get('CLICKHOUSE_PORT', str(_DEFAULT_CLICKHOUSE_PORT))
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError('CLICKHOUSE_PORT environment variable must be an integer.') from exc
+
+
+def _get_clickhouse_settings() -> _ClickHouseSettings:
+    return _ClickHouseSettings(
+        host=os.environ.get('CLICKHOUSE_HOST', _DEFAULT_CLICKHOUSE_HOST),
+        port=_get_clickhouse_port(),
+        user=os.environ.get('CLICKHOUSE_USER', _DEFAULT_CLICKHOUSE_USER),
+        password=_require_env('CLICKHOUSE_PASSWORD'),
+        database=os.environ.get('CLICKHOUSE_DATABASE', 'origo'),
+    )
+
+
+def _make_clickhouse_client(settings: _ClickHouseSettings) -> _ClickHouseClientLike:
+    client_factory = getattr(import_module('clickhouse_driver'), 'Client')
+    client = client_factory(
+        host=settings.host,
+        port=settings.port,
+        user=settings.user,
+        password=settings.password,
+    )
+    if not isinstance(client, _ClickHouseClientLike):
+        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
+    return client
+
+
+def _count_result(result: list[tuple[object, ...]]) -> int:
+    count_value = result[0][0]
+    if not isinstance(count_value, int):
+        raise RuntimeError(f'ClickHouse count query returned non-integer value: {count_value!r}')
+    return count_value
+
+
+def _database_exists(client: _ClickHouseClientLike, database: str) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.databases
+        WHERE name = '{database}'
+        """
+    )
+    return bool(_count_result(result))
+
+
+def _table_exists(
+    client: _ClickHouseClientLike,
+    settings: _ClickHouseSettings,
+    table_name: str,
+) -> bool:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM system.tables
+        WHERE database = '{settings.database}'
+          AND name = '{table_name}'
+        """
+    )
+    return bool(_count_result(result))
+
+
+def _create_volume_klines_table(
+    client: _ClickHouseClientLike,
+    settings: _ClickHouseSettings,
+) -> None:
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {settings.database}.{VOLUME_KLINES_TABLE_NAME} (
+            start_datetime DateTime,
+            end_datetime DateTime,
+            volume_bar_id UInt64 COMMENT 'Partition-date scoped id; resets each day and may skip ids when one trade crosses multiple volume thresholds.',
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            mean Float64,
+            std Float64,
+            median Float64,
+            iqr Float64,
+            volume Float64,
+            maker_ratio Float64,
+            no_of_trades UInt64,
+            open_liquidity Float64,
+            high_liquidity Float64,
+            low_liquidity Float64,
+            close_liquidity Float64,
+            liquidity_sum Float64,
+            maker_volume Float64,
+            maker_liquidity Float64
+        )
+        ENGINE = MergeTree()
+        PARTITION BY toYYYYMM(start_datetime)
+        ORDER BY (start_datetime, end_datetime, volume_bar_id)
+        """
+    )
+
+
+@asset(
+    group_name='origo_setup',
+    deps=[create_origo_database],
+    description=(
+        'Creates the binance_spot_volume_klines table if it does not exist. '
+        'volume_bar_id is scoped to each partition date and may be non-contiguous.'
+    ),
+)
+def create_binance_spot_volume_klines_table_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        if not _database_exists(client, settings.database):
+            raise RuntimeError(
+                f'Database {settings.database} does not exist. Run create_origo_database first.'
+            )
+
+        table_existed = _table_exists(client, settings, VOLUME_KLINES_TABLE_NAME)
+        _create_volume_klines_table(client, settings)
+
+        context.log.info(f'Ensured table {settings.database}.{VOLUME_KLINES_TABLE_NAME} exists.')
+        return {
+            'status': 'success',
+            'table': f'{settings.database}.{VOLUME_KLINES_TABLE_NAME}',
+            'table_action': 'already_exists' if table_existed else 'created',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/create_binance_spot_volume_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_volume_klines_table_origo.py
@@ -1,118 +1,20 @@
-import os
-from collections.abc import Mapping
-from dataclasses import dataclass
-from importlib import import_module
-from typing import Protocol, runtime_checkable
-
 from dagster import AssetExecutionContext, asset
 
-from .create_origo_database import create_origo_database
+from .create_binance_trades_table_origo import database_exists, table_exists
+from .create_origo_database import (
+    ClickHouseClientProtocol,
+    ClickHouseSettings,
+    create_origo_database,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
 
-_DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
-_DEFAULT_CLICKHOUSE_PORT = 9000
-_DEFAULT_CLICKHOUSE_USER = 'default'
 VOLUME_KLINES_TABLE_NAME = 'binance_spot_volume_klines'
 
 
-@dataclass(frozen=True)
-class _ClickHouseSettings:
-    host: str
-    port: int
-    user: str
-    password: str
-    database: str
-
-
-@runtime_checkable
-class _ClickHouseClientLike(Protocol):
-    def execute(
-        self,
-        query: str,
-        params: object | None = None,
-        *,
-        settings: Mapping[str, object] | None = None,
-    ) -> list[tuple[object, ...]]:
-        raise NotImplementedError
-
-    def disconnect(self) -> None:
-        raise NotImplementedError
-
-
-def _require_env(name: str) -> str:
-    value = os.environ.get(name)
-    if not value:
-        raise RuntimeError(f'{name} environment variable must be set.')
-    return value
-
-
-def _get_clickhouse_port() -> int:
-    value = os.environ.get('CLICKHOUSE_PORT', str(_DEFAULT_CLICKHOUSE_PORT))
-    try:
-        return int(value)
-    except ValueError as exc:
-        raise RuntimeError('CLICKHOUSE_PORT environment variable must be an integer.') from exc
-
-
-def _get_clickhouse_settings() -> _ClickHouseSettings:
-    return _ClickHouseSettings(
-        host=os.environ.get('CLICKHOUSE_HOST', _DEFAULT_CLICKHOUSE_HOST),
-        port=_get_clickhouse_port(),
-        user=os.environ.get('CLICKHOUSE_USER', _DEFAULT_CLICKHOUSE_USER),
-        password=_require_env('CLICKHOUSE_PASSWORD'),
-        database=os.environ.get('CLICKHOUSE_DATABASE', 'origo'),
-    )
-
-
-def _make_clickhouse_client(settings: _ClickHouseSettings) -> _ClickHouseClientLike:
-    client_factory = getattr(import_module('clickhouse_driver'), 'Client')
-    client = client_factory(
-        host=settings.host,
-        port=settings.port,
-        user=settings.user,
-        password=settings.password,
-    )
-    if not isinstance(client, _ClickHouseClientLike):
-        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
-    return client
-
-
-def _count_result(result: list[tuple[object, ...]]) -> int:
-    count_value = result[0][0]
-    if not isinstance(count_value, int):
-        raise RuntimeError(f'ClickHouse count query returned non-integer value: {count_value!r}')
-    return count_value
-
-
-def _database_exists(client: _ClickHouseClientLike, database: str) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.databases
-        WHERE name = '{database}'
-        """
-    )
-    return bool(_count_result(result))
-
-
-def _table_exists(
-    client: _ClickHouseClientLike,
-    settings: _ClickHouseSettings,
-    table_name: str,
-) -> bool:
-    result = client.execute(
-        f"""
-        SELECT count()
-        FROM system.tables
-        WHERE database = '{settings.database}'
-          AND name = '{table_name}'
-        """
-    )
-    return bool(_count_result(result))
-
-
 def _create_volume_klines_table(
-    client: _ClickHouseClientLike,
-    settings: _ClickHouseSettings,
+    client: ClickHouseClientProtocol,
+    settings: ClickHouseSettings,
 ) -> None:
     client.execute(
         f"""
@@ -157,16 +59,16 @@ def _create_volume_klines_table(
 def create_binance_spot_volume_klines_table_origo(
     context: AssetExecutionContext,
 ) -> dict[str, object]:
-    settings = _get_clickhouse_settings()
-    client = _make_clickhouse_client(settings)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
 
     try:
-        if not _database_exists(client, settings.database):
+        if not database_exists(client, settings.database):
             raise RuntimeError(
                 f'Database {settings.database} does not exist. Run create_origo_database first.'
             )
 
-        table_existed = _table_exists(client, settings, VOLUME_KLINES_TABLE_NAME)
+        table_existed = table_exists(client, settings, VOLUME_KLINES_TABLE_NAME)
         _create_volume_klines_table(client, settings)
 
         context.log.info(f'Ensured table {settings.database}.{VOLUME_KLINES_TABLE_NAME} exists.')

--- a/tdw_control_plane/assets/create_binance_trades_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_trades_table_origo.py
@@ -2,11 +2,22 @@ from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
 from .create_origo_database import (
+    ClickHouseClientProtocol,
     ClickHouseSettings,
-    _get_clickhouse_settings,
-    _make_clickhouse_client,
     create_origo_database,
+    get_clickhouse_settings,
+    make_clickhouse_client,
 )
+
+__all__ = [
+    'LEDGER_TABLE_NAME',
+    'RAW_TABLE_NAME',
+    '_database_exists',
+    '_table_exists',
+    'create_binance_daily_spot_trades_table_origo',
+    'database_exists',
+    'table_exists',
+]
 
 RAW_TABLE_NAME = 'binance_daily_spot_trades'
 LEDGER_TABLE_NAME = 'binance_daily_spot_trades_ingestion'
@@ -33,6 +44,18 @@ def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_
         """
     )
     return bool(result[0][0])
+
+
+def database_exists(client: ClickHouseClientProtocol, database: str) -> bool:
+    return _database_exists(client, database)
+
+
+def table_exists(
+    client: ClickHouseClientProtocol,
+    settings: ClickHouseSettings,
+    table_name: str,
+) -> bool:
+    return _table_exists(client, settings, table_name)
 
 
 def _create_raw_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:
@@ -85,8 +108,8 @@ def _create_ingestion_ledger(client: ClickhouseClient, settings: ClickHouseSetti
 def create_binance_daily_spot_trades_table_origo(
     context: AssetExecutionContext,
 ) -> dict[str, object]:
-    settings = _get_clickhouse_settings()
-    client = _make_clickhouse_client(settings)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
 
     try:
         if not _database_exists(client, settings.database):

--- a/tdw_control_plane/assets/create_binance_trades_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_trades_table_origo.py
@@ -1,4 +1,3 @@
-from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
 from .create_origo_database import (
@@ -12,8 +11,6 @@ from .create_origo_database import (
 __all__ = [
     'LEDGER_TABLE_NAME',
     'RAW_TABLE_NAME',
-    '_database_exists',
-    '_table_exists',
     'create_binance_daily_spot_trades_table_origo',
     'database_exists',
     'table_exists',
@@ -23,7 +20,7 @@ RAW_TABLE_NAME = 'binance_daily_spot_trades'
 LEDGER_TABLE_NAME = 'binance_daily_spot_trades_ingestion'
 
 
-def _database_exists(client: ClickhouseClient, database: str) -> bool:
+def database_exists(client: ClickHouseClientProtocol, database: str) -> bool:
     result = client.execute(
         f"""
         SELECT count()
@@ -34,7 +31,11 @@ def _database_exists(client: ClickhouseClient, database: str) -> bool:
     return bool(result[0][0])
 
 
-def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_name: str) -> bool:
+def table_exists(
+    client: ClickHouseClientProtocol,
+    settings: ClickHouseSettings,
+    table_name: str,
+) -> bool:
     result = client.execute(
         f"""
         SELECT count()
@@ -46,19 +47,11 @@ def _table_exists(client: ClickhouseClient, settings: ClickHouseSettings, table_
     return bool(result[0][0])
 
 
-def database_exists(client: ClickHouseClientProtocol, database: str) -> bool:
-    return _database_exists(client, database)
+_database_exists = database_exists
+_table_exists = table_exists
 
 
-def table_exists(
-    client: ClickHouseClientProtocol,
-    settings: ClickHouseSettings,
-    table_name: str,
-) -> bool:
-    return _table_exists(client, settings, table_name)
-
-
-def _create_raw_table(client: ClickhouseClient, settings: ClickHouseSettings) -> None:
+def _create_raw_table(client: ClickHouseClientProtocol, settings: ClickHouseSettings) -> None:
     client.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{RAW_TABLE_NAME} (
@@ -78,7 +71,10 @@ def _create_raw_table(client: ClickhouseClient, settings: ClickHouseSettings) ->
     )
 
 
-def _create_ingestion_ledger(client: ClickhouseClient, settings: ClickHouseSettings) -> None:
+def _create_ingestion_ledger(
+    client: ClickHouseClientProtocol,
+    settings: ClickHouseSettings,
+) -> None:
     client.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {settings.database}.{LEDGER_TABLE_NAME} (
@@ -112,13 +108,13 @@ def create_binance_daily_spot_trades_table_origo(
     client = make_clickhouse_client(settings)
 
     try:
-        if not _database_exists(client, settings.database):
+        if not database_exists(client, settings.database):
             raise RuntimeError(
                 f'Database {settings.database} does not exist. Run create_origo_database first.'
             )
 
-        raw_table_existed = _table_exists(client, settings, RAW_TABLE_NAME)
-        ledger_table_existed = _table_exists(client, settings, LEDGER_TABLE_NAME)
+        raw_table_existed = table_exists(client, settings, RAW_TABLE_NAME)
+        ledger_table_existed = table_exists(client, settings, LEDGER_TABLE_NAME)
 
         _create_raw_table(client, settings)
         _create_ingestion_ledger(client, settings)

--- a/tdw_control_plane/assets/create_origo_database.py
+++ b/tdw_control_plane/assets/create_origo_database.py
@@ -1,16 +1,14 @@
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from importlib import import_module
+from typing import Protocol
 
-from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
 
 __all__ = [
     'ClickHouseClientProtocol',
     'ClickHouseSettings',
-    '_get_clickhouse_settings',
-    '_make_clickhouse_client',
     'create_origo_database',
     'get_clickhouse_settings',
     'make_clickhouse_client',
@@ -30,7 +28,6 @@ class ClickHouseSettings:
     database: str
 
 
-@runtime_checkable
 class ClickHouseClientProtocol(Protocol):
     def execute(
         self,
@@ -59,7 +56,7 @@ def _get_clickhouse_port() -> int:
         raise RuntimeError('CLICKHOUSE_PORT environment variable must be an integer.') from exc
 
 
-def _get_clickhouse_settings() -> ClickHouseSettings:
+def get_clickhouse_settings() -> ClickHouseSettings:
     return ClickHouseSettings(
         host=os.environ.get('CLICKHOUSE_HOST', DEFAULT_CLICKHOUSE_HOST),
         port=_get_clickhouse_port(),
@@ -69,8 +66,9 @@ def _get_clickhouse_settings() -> ClickHouseSettings:
     )
 
 
-def _make_clickhouse_client(settings: ClickHouseSettings) -> ClickhouseClient:
-    return ClickhouseClient(
+def make_clickhouse_client(settings: ClickHouseSettings) -> ClickHouseClientProtocol:
+    client_factory = getattr(import_module('clickhouse_driver'), 'Client')
+    return client_factory(
         host=settings.host,
         port=settings.port,
         user=settings.user,
@@ -78,15 +76,8 @@ def _make_clickhouse_client(settings: ClickHouseSettings) -> ClickhouseClient:
     )
 
 
-def get_clickhouse_settings() -> ClickHouseSettings:
-    return _get_clickhouse_settings()
-
-
-def make_clickhouse_client(settings: ClickHouseSettings) -> ClickHouseClientProtocol:
-    client = _make_clickhouse_client(settings)
-    if not isinstance(client, ClickHouseClientProtocol):
-        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
-    return client
+_get_clickhouse_settings = get_clickhouse_settings
+_make_clickhouse_client = make_clickhouse_client
 
 
 @asset(
@@ -94,8 +85,8 @@ def make_clickhouse_client(settings: ClickHouseSettings) -> ClickHouseClientProt
     description='Creates the origo database if it does not already exist',
 )
 def create_origo_database(context: AssetExecutionContext) -> dict[str, object]:
-    settings = _get_clickhouse_settings()
-    client = _make_clickhouse_client(settings)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
 
     try:
         result = client.execute(f"SHOW DATABASES LIKE '{settings.database}'")

--- a/tdw_control_plane/assets/create_origo_database.py
+++ b/tdw_control_plane/assets/create_origo_database.py
@@ -1,8 +1,20 @@
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import AssetExecutionContext, asset
+
+__all__ = [
+    'ClickHouseClientProtocol',
+    'ClickHouseSettings',
+    '_get_clickhouse_settings',
+    '_make_clickhouse_client',
+    'create_origo_database',
+    'get_clickhouse_settings',
+    'make_clickhouse_client',
+]
 
 DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
 DEFAULT_CLICKHOUSE_PORT = 9000
@@ -16,6 +28,20 @@ class ClickHouseSettings:
     user: str
     password: str
     database: str
+
+
+@runtime_checkable
+class ClickHouseClientProtocol(Protocol):
+    def execute(
+        self,
+        query: str,
+        params: object | None = None,
+        settings: Mapping[str, object] | None = None,
+    ) -> list[tuple[object, ...]]:
+        raise NotImplementedError
+
+    def disconnect(self) -> None:
+        raise NotImplementedError
 
 
 def _require_env(name: str) -> str:
@@ -50,6 +76,17 @@ def _make_clickhouse_client(settings: ClickHouseSettings) -> ClickhouseClient:
         user=settings.user,
         password=settings.password,
     )
+
+
+def get_clickhouse_settings() -> ClickHouseSettings:
+    return _get_clickhouse_settings()
+
+
+def make_clickhouse_client(settings: ClickHouseSettings) -> ClickHouseClientProtocol:
+    client = _make_clickhouse_client(settings)
+    if not isinstance(client, ClickHouseClientProtocol):
+        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
+    return client
 
 
 @asset(

--- a/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
@@ -19,7 +19,7 @@ VOLUME_KLINE_SIZE = 100.0
 
 def _partition_date_from_context(context: AssetExecutionContext) -> str:
     partition_key = context.partition_key
-    if partition_key is not None:
+    if isinstance(partition_key, str):
         return partition_key
 
     target_date = datetime.now(UTC) - timedelta(days=1)
@@ -52,7 +52,10 @@ def _count_partition_rows(
         WHERE toDate(start_datetime) = toDate('{partition_date}')
         """
     )
-    return int(result[0][0])
+    count_value = result[0][0]
+    if not isinstance(count_value, int):
+        raise TypeError(f'Expected int scalar from ClickHouse, got {type(count_value).__name__}')
+    return count_value
 
 
 def _insert_partition_rows(

--- a/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
@@ -1,9 +1,4 @@
-import os
-from collections.abc import Mapping
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from importlib import import_module
-from typing import Protocol, runtime_checkable
 
 from dagster import AssetExecutionContext, asset
 
@@ -12,79 +7,19 @@ from .create_binance_spot_volume_klines_table_origo import (
     create_binance_spot_volume_klines_table_origo,
 )
 from .create_binance_trades_table_origo import RAW_TABLE_NAME
+from .create_origo_database import (
+    ClickHouseClientProtocol,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
 from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_trades_to_origo
 
-_DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
-_DEFAULT_CLICKHOUSE_PORT = 9000
-_DEFAULT_CLICKHOUSE_USER = 'default'
 VOLUME_KLINE_SIZE = 100.0
-
-
-@dataclass(frozen=True)
-class _ClickHouseSettings:
-    host: str
-    port: int
-    user: str
-    password: str
-    database: str
-
-
-@runtime_checkable
-class _ClickHouseClientLike(Protocol):
-    def execute(
-        self,
-        query: str,
-        params: object | None = None,
-        *,
-        settings: Mapping[str, object] | None = None,
-    ) -> list[tuple[object, ...]]:
-        raise NotImplementedError
-
-    def disconnect(self) -> None:
-        raise NotImplementedError
-
-
-def _require_env(name: str) -> str:
-    value = os.environ.get(name)
-    if not value:
-        raise RuntimeError(f'{name} environment variable must be set.')
-    return value
-
-
-def _get_clickhouse_port() -> int:
-    value = os.environ.get('CLICKHOUSE_PORT', str(_DEFAULT_CLICKHOUSE_PORT))
-    try:
-        return int(value)
-    except ValueError as exc:
-        raise RuntimeError('CLICKHOUSE_PORT environment variable must be an integer.') from exc
-
-
-def _get_clickhouse_settings() -> _ClickHouseSettings:
-    return _ClickHouseSettings(
-        host=os.environ.get('CLICKHOUSE_HOST', _DEFAULT_CLICKHOUSE_HOST),
-        port=_get_clickhouse_port(),
-        user=os.environ.get('CLICKHOUSE_USER', _DEFAULT_CLICKHOUSE_USER),
-        password=_require_env('CLICKHOUSE_PASSWORD'),
-        database=os.environ.get('CLICKHOUSE_DATABASE', 'origo'),
-    )
-
-
-def _make_clickhouse_client(settings: _ClickHouseSettings) -> _ClickHouseClientLike:
-    client_factory = getattr(import_module('clickhouse_driver'), 'Client')
-    client = client_factory(
-        host=settings.host,
-        port=settings.port,
-        user=settings.user,
-        password=settings.password,
-    )
-    if not isinstance(client, _ClickHouseClientLike):
-        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
-    return client
 
 
 def _partition_date_from_context(context: AssetExecutionContext) -> str:
     partition_key = context.partition_key
-    if isinstance(partition_key, str):
+    if partition_key is not None:
         return partition_key
 
     target_date = datetime.now(UTC) - timedelta(days=1)
@@ -92,7 +27,7 @@ def _partition_date_from_context(context: AssetExecutionContext) -> str:
 
 
 def _delete_partition_rows(
-    client: _ClickHouseClientLike,
+    client: ClickHouseClientProtocol,
     database: str,
     partition_date: str,
 ) -> None:
@@ -106,7 +41,7 @@ def _delete_partition_rows(
 
 
 def _count_partition_rows(
-    client: _ClickHouseClientLike,
+    client: ClickHouseClientProtocol,
     database: str,
     partition_date: str,
 ) -> int:
@@ -117,14 +52,11 @@ def _count_partition_rows(
         WHERE toDate(start_datetime) = toDate('{partition_date}')
         """
     )
-    count_value = result[0][0]
-    if not isinstance(count_value, int):
-        raise RuntimeError(f'ClickHouse count query returned non-integer value: {count_value!r}')
-    return count_value
+    return int(result[0][0])
 
 
 def _insert_partition_rows(
-    client: _ClickHouseClientLike,
+    client: ClickHouseClientProtocol,
     database: str,
     partition_date: str,
 ) -> None:
@@ -194,8 +126,8 @@ def refresh_binance_spot_volume_klines_origo(
     context: AssetExecutionContext,
 ) -> dict[str, object]:
     partition_date = _partition_date_from_context(context)
-    settings = _get_clickhouse_settings()
-    client = _make_clickhouse_client(settings)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
 
     try:
         existing_count = _count_partition_rows(client, settings.database, partition_date)

--- a/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py
@@ -1,0 +1,219 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+from typing import Protocol, runtime_checkable
+
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_spot_volume_klines_table_origo import (
+    VOLUME_KLINES_TABLE_NAME,
+    create_binance_spot_volume_klines_table_origo,
+)
+from .create_binance_trades_table_origo import RAW_TABLE_NAME
+from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_trades_to_origo
+
+_DEFAULT_CLICKHOUSE_HOST = 'clickhouse'
+_DEFAULT_CLICKHOUSE_PORT = 9000
+_DEFAULT_CLICKHOUSE_USER = 'default'
+VOLUME_KLINE_SIZE = 100.0
+
+
+@dataclass(frozen=True)
+class _ClickHouseSettings:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+
+@runtime_checkable
+class _ClickHouseClientLike(Protocol):
+    def execute(
+        self,
+        query: str,
+        params: object | None = None,
+        *,
+        settings: Mapping[str, object] | None = None,
+    ) -> list[tuple[object, ...]]:
+        raise NotImplementedError
+
+    def disconnect(self) -> None:
+        raise NotImplementedError
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f'{name} environment variable must be set.')
+    return value
+
+
+def _get_clickhouse_port() -> int:
+    value = os.environ.get('CLICKHOUSE_PORT', str(_DEFAULT_CLICKHOUSE_PORT))
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError('CLICKHOUSE_PORT environment variable must be an integer.') from exc
+
+
+def _get_clickhouse_settings() -> _ClickHouseSettings:
+    return _ClickHouseSettings(
+        host=os.environ.get('CLICKHOUSE_HOST', _DEFAULT_CLICKHOUSE_HOST),
+        port=_get_clickhouse_port(),
+        user=os.environ.get('CLICKHOUSE_USER', _DEFAULT_CLICKHOUSE_USER),
+        password=_require_env('CLICKHOUSE_PASSWORD'),
+        database=os.environ.get('CLICKHOUSE_DATABASE', 'origo'),
+    )
+
+
+def _make_clickhouse_client(settings: _ClickHouseSettings) -> _ClickHouseClientLike:
+    client_factory = getattr(import_module('clickhouse_driver'), 'Client')
+    client = client_factory(
+        host=settings.host,
+        port=settings.port,
+        user=settings.user,
+        password=settings.password,
+    )
+    if not isinstance(client, _ClickHouseClientLike):
+        raise TypeError('clickhouse_driver.Client does not satisfy the ClickHouse client contract.')
+    return client
+
+
+def _partition_date_from_context(context: AssetExecutionContext) -> str:
+    partition_key = context.partition_key
+    if isinstance(partition_key, str):
+        return partition_key
+
+    target_date = datetime.now(UTC) - timedelta(days=1)
+    return target_date.strftime('%Y-%m-%d')
+
+
+def _delete_partition_rows(
+    client: _ClickHouseClientLike,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        ALTER TABLE {database}.{VOLUME_KLINES_TABLE_NAME}
+        DELETE WHERE toDate(start_datetime) = toDate('{partition_date}')
+        """,
+        settings={'mutations_sync': 2},
+    )
+
+
+def _count_partition_rows(
+    client: _ClickHouseClientLike,
+    database: str,
+    partition_date: str,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{VOLUME_KLINES_TABLE_NAME}
+        WHERE toDate(start_datetime) = toDate('{partition_date}')
+        """
+    )
+    count_value = result[0][0]
+    if not isinstance(count_value, int):
+        raise RuntimeError(f'ClickHouse count query returned non-integer value: {count_value!r}')
+    return count_value
+
+
+def _insert_partition_rows(
+    client: _ClickHouseClientLike,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        INSERT INTO {database}.{VOLUME_KLINES_TABLE_NAME}
+        SELECT
+            min(datetime) AS start_datetime,
+            max(datetime) AS end_datetime,
+            volume_bar_id,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            avg(price) AS mean,
+            stddevPopStable(price) AS std,
+            quantileExact(0.5)(price) AS median,
+            quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr,
+            sumKahan(quantity) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            sum(price * quantity) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            sum(is_buyer_maker * price * quantity) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toUInt64(floor(running_volume_before / {VOLUME_KLINE_SIZE})) AS volume_bar_id
+            FROM (
+                SELECT
+                    *,
+                    greatest(
+                        sum(quantity) OVER (
+                            ORDER BY datetime, trade_id
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                        ) - quantity,
+                        0.0
+                    ) AS running_volume_before
+                FROM {database}.{RAW_TABLE_NAME}
+                WHERE toDate(datetime) = toDate('{partition_date}')
+            )
+        )
+        GROUP BY volume_bar_id
+        ORDER BY volume_bar_id
+        """
+    )
+
+
+@asset(
+    partitions_def=daily_partitions,
+    deps=[
+        create_binance_spot_volume_klines_table_origo,
+        insert_daily_binance_spot_trades_to_origo,
+    ],
+    group_name='binance_data',
+    description=(
+        'Refreshes the daily-scoped Binance spot volume kline projection from '
+        'source-native daily trades; volume_bar_id resets each date and the final '
+        'daily bar may be below the volume threshold.'
+    ),
+)
+def refresh_binance_spot_volume_klines_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date = _partition_date_from_context(context)
+    settings = _get_clickhouse_settings()
+    client = _make_clickhouse_client(settings)
+
+    try:
+        existing_count = _count_partition_rows(client, settings.database, partition_date)
+        if existing_count > 0:
+            context.log.info(
+                f'Found {existing_count} existing Binance spot volume kline rows for '
+                f'{partition_date}. Replacing that partition.'
+            )
+            _delete_partition_rows(client, settings.database, partition_date)
+
+        _insert_partition_rows(client, settings.database, partition_date)
+        inserted_count = _count_partition_rows(client, settings.database, partition_date)
+
+        return {
+            'status': 'success',
+            'partition_date': partition_date,
+            'rows_inserted': inserted_count,
+            'table': f'{settings.database}.{VOLUME_KLINES_TABLE_NAME}',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -82,6 +82,9 @@ from .assets.create_binance_spot_klines_table_origo import (
 from .assets.create_binance_spot_dollar_klines_table_origo import (
     create_binance_spot_dollar_klines_table_origo,
 )
+from .assets.create_binance_spot_volume_klines_table_origo import (
+    create_binance_spot_volume_klines_table_origo,
+)
 from .assets.create_binance_futures_klines_table_origo import (
     create_binance_futures_klines_table_origo,
 )
@@ -94,6 +97,9 @@ from .assets.create_binance_spot_depth20_snapshots_table_origo import (
 from .assets.refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
 from .assets.refresh_binance_spot_dollar_klines_origo import (
     refresh_binance_spot_dollar_klines_origo,
+)
+from .assets.refresh_binance_spot_volume_klines_origo import (
+    refresh_binance_spot_volume_klines_origo,
 )
 from .assets.refresh_binance_futures_klines_origo import refresh_binance_futures_klines_origo
 from .assets.refresh_binance_spot_depth20_1m_origo import (
@@ -169,6 +175,11 @@ create_binance_spot_dollar_klines_table_origo_job = define_asset_job(
     selection=["create_binance_spot_dollar_klines_table_origo"]
 )
 
+create_binance_spot_volume_klines_table_origo_job = define_asset_job(
+    name="create_binance_spot_volume_klines_table_origo_job",
+    selection=["create_binance_spot_volume_klines_table_origo"]
+)
+
 create_binance_futures_klines_table_origo_job = define_asset_job(
     name="create_binance_futures_klines_table_origo_job",
     selection=["create_binance_futures_klines_table_origo"]
@@ -217,6 +228,7 @@ refresh_binance_spot_data_source_job = define_asset_job(
         "insert_daily_binance_spot_trades_to_origo",
         "refresh_binance_spot_klines_origo",
         "refresh_binance_spot_dollar_klines_origo",
+        "refresh_binance_spot_volume_klines_origo",
         "refresh_aligned_1m_exchange_from_binance_spot_origo",
     ])
 
@@ -693,6 +705,7 @@ defs = Definitions(
             create_binance_daily_futures_trades_table_origo,
             create_binance_spot_klines_table_origo,
             create_binance_spot_dollar_klines_table_origo,
+            create_binance_spot_volume_klines_table_origo,
             create_binance_futures_klines_table_origo,
             create_binance_spot_depth20_snapshots_table_origo,
             create_binance_spot_depth20_1m_table_origo,
@@ -703,6 +716,7 @@ defs = Definitions(
             insert_daily_binance_futures_trades_to_origo,
             refresh_binance_spot_klines_origo,
             refresh_binance_spot_dollar_klines_origo,
+            refresh_binance_spot_volume_klines_origo,
             refresh_binance_futures_klines_origo,
             sync_binance_spot_depth20_snapshots_to_origo,
             refresh_binance_spot_depth20_1m_origo,
@@ -755,6 +769,7 @@ defs = Definitions(
           create_binance_daily_futures_trades_table_origo_job,
           create_binance_spot_klines_table_origo_job,
           create_binance_spot_dollar_klines_table_origo_job,
+          create_binance_spot_volume_klines_table_origo_job,
           create_binance_futures_klines_table_origo_job,
           create_binance_spot_depth20_snapshots_table_origo_job,
           create_binance_spot_depth20_1m_table_origo_job,

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -227,6 +227,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     create_binance_spot_dollar_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_spot_dollar_klines_table_origo'
     )
+    create_binance_spot_volume_klines_table_origo_module = _reload_module(
+        'tdw_control_plane.assets.create_binance_spot_volume_klines_table_origo'
+    )
     create_binance_futures_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_futures_klines_table_origo'
     )
@@ -235,6 +238,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     )
     refresh_binance_spot_dollar_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_spot_dollar_klines_origo'
+    )
+    refresh_binance_spot_volume_klines_origo_module = _reload_module(
+        'tdw_control_plane.assets.refresh_binance_spot_volume_klines_origo'
     )
     refresh_binance_futures_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_futures_klines_origo'
@@ -285,6 +291,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'create_binance_spot_dollar_klines_table_origo': (
             create_binance_spot_dollar_klines_table_origo_module.create_binance_spot_dollar_klines_table_origo
         ),
+        'create_binance_spot_volume_klines_table_origo': (
+            create_binance_spot_volume_klines_table_origo_module.create_binance_spot_volume_klines_table_origo
+        ),
         'create_binance_futures_klines_table_origo': (
             create_binance_futures_klines_table_origo_module.create_binance_futures_klines_table_origo
         ),
@@ -294,6 +303,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'refresh_binance_spot_dollar_klines_origo': (
             refresh_binance_spot_dollar_klines_origo_module.refresh_binance_spot_dollar_klines_origo
         ),
+        'refresh_binance_spot_volume_klines_origo': (
+            refresh_binance_spot_volume_klines_origo_module.refresh_binance_spot_volume_klines_origo
+        ),
         'refresh_binance_futures_klines_origo': (
             refresh_binance_futures_klines_origo_module.refresh_binance_futures_klines_origo
         ),
@@ -301,8 +313,14 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'DOLLAR_KLINES_TABLE_NAME': (
             create_binance_spot_dollar_klines_table_origo_module.DOLLAR_KLINES_TABLE_NAME
         ),
+        'VOLUME_KLINES_TABLE_NAME': (
+            create_binance_spot_volume_klines_table_origo_module.VOLUME_KLINES_TABLE_NAME
+        ),
         'refresh_binance_spot_dollar_klines_origo_module': (
             refresh_binance_spot_dollar_klines_origo_module
+        ),
+        'refresh_binance_spot_volume_klines_origo_module': (
+            refresh_binance_spot_volume_klines_origo_module
         ),
         'FUTURES_KLINES_TABLE_NAME': (
             create_binance_futures_klines_table_origo_module.KLINES_TABLE_NAME
@@ -394,6 +412,25 @@ def materialize_binance_spot_dollar_klines_assets(
                 origo_assets['create_binance_spot_dollar_klines_table_origo'],
                 origo_assets['insert_daily_binance_spot_trades_to_origo'],
                 origo_assets['refresh_binance_spot_dollar_klines_origo'],
+            ],
+            partition_key=partition_key,
+        )
+
+    return _run
+
+
+@pytest.fixture()
+def materialize_binance_spot_volume_klines_assets(
+    origo_assets: dict[str, object],
+) -> object:
+    def _run(*, partition_key: str | None = None) -> object:
+        return materialize(
+            [
+                origo_assets['create_origo_database'],
+                origo_assets['create_binance_daily_spot_trades_table_origo'],
+                origo_assets['create_binance_spot_volume_klines_table_origo'],
+                origo_assets['insert_daily_binance_spot_trades_to_origo'],
+                origo_assets['refresh_binance_spot_volume_klines_origo'],
             ],
             partition_key=partition_key,
         )

--- a/tests/origo_source_native/test_origo_binance_spot_volume_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_volume_klines_template.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+from dagster import DefaultScheduleStatus
+
+from .helpers import ORIGO_DATABASE
+
+VOLUME_KLINE_COLUMNS = [
+    'start_datetime',
+    'end_datetime',
+    'volume_bar_id',
+    'open',
+    'high',
+    'low',
+    'close',
+    'mean',
+    'std',
+    'median',
+    'iqr',
+    'volume',
+    'maker_ratio',
+    'no_of_trades',
+    'open_liquidity',
+    'high_liquidity',
+    'low_liquidity',
+    'close_liquidity',
+    'liquidity_sum',
+    'maker_volume',
+    'maker_liquidity',
+]
+VOLUME_KLINE_COLUMN_TYPES = [
+    'DateTime',
+    'DateTime',
+    'UInt64',
+    *(['Float64'] * 10),
+    'UInt64',
+    *(['Float64'] * 7),
+]
+
+
+def _table_metadata(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    table_name: str,
+) -> tuple[str, str, str]:
+    rows = query_origo(
+        f"""
+        SELECT engine, partition_key, sorting_key
+        FROM system.tables
+        WHERE database = '{ORIGO_DATABASE}'
+          AND name = '{table_name}'
+        """
+    )
+
+    assert len(rows) == 1
+    engine, partition_key, sorting_key = rows[0]
+    return str(engine), str(partition_key), str(sorting_key)
+
+
+def _normalize_value(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    return value
+
+
+def _rows_to_dicts(
+    columns: list[str],
+    rows: list[tuple[object, ...]],
+) -> list[dict[str, object]]:
+    return [
+        {column: _normalize_value(value) for column, value in zip(columns, row, strict=True)}
+        for row in rows
+    ]
+
+
+def test_binance_spot_volume_klines_table_name_contract(
+    origo_assets: dict[str, object],
+) -> None:
+    assert origo_assets['VOLUME_KLINES_TABLE_NAME'] == 'binance_spot_volume_klines'
+
+
+def test_binance_spot_volume_klines_schema_matches_spot_kline_statistics_contract(
+    materialize_binance_spot_volume_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_volume_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        DESCRIBE TABLE {ORIGO_DATABASE}.{origo_assets['VOLUME_KLINES_TABLE_NAME']}
+        """
+    )
+
+    assert [name for name, *_ in rows] == VOLUME_KLINE_COLUMNS
+    assert [type_name for _, type_name, *_ in rows] == VOLUME_KLINE_COLUMN_TYPES
+    assert _table_metadata(query_origo, str(origo_assets['VOLUME_KLINES_TABLE_NAME'])) == (
+        'MergeTree',
+        'toYYYYMM(start_datetime)',
+        'start_datetime, end_datetime, volume_bar_id',
+    )
+
+
+def test_binance_spot_volume_klines_rows_match_fixture_with_exact_bar_range(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_volume_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_volume_klines_origo_module'],
+        'VOLUME_KLINE_SIZE',
+        0.01,
+    )
+
+    result = materialize_binance_spot_volume_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(VOLUME_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['VOLUME_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY volume_bar_id
+        """
+    )
+
+    assert _rows_to_dicts(VOLUME_KLINE_COLUMNS, rows) == [
+        {
+            'start_datetime': '2024-01-01 00:00:00',
+            'end_datetime': '2024-01-01 00:00:02',
+            'volume_bar_id': 0,
+            'open': 42000.1,
+            'high': 42010.0,
+            'low': 42000.1,
+            'close': 42005.5,
+            'mean': 42005.200000000004,
+            'std': 4.047221268968605,
+            'median': 42005.5,
+            'iqr': 9.900000000001455,
+            'volume': 0.0045000000000000005,
+            'maker_ratio': 0.6666666666666666,
+            'no_of_trades': 3,
+            'open_liquidity': 42.000099999999996,
+            'high_liquidity': 84.02,
+            'low_liquidity': 42.000099999999996,
+            'close_liquidity': 63.008250000000004,
+            'liquidity_sum': 189.02835,
+            'maker_volume': 0.0025,
+            'maker_liquidity': 105.00835000000001,
+        },
+    ]
+
+
+def test_same_partition_rerun_is_idempotent_for_volume_klines(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_volume_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_volume_klines_origo_module'],
+        'VOLUME_KLINE_SIZE',
+        0.001,
+    )
+
+    first = materialize_binance_spot_volume_klines_assets(partition_key='2024-01-01')
+    first_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(VOLUME_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['VOLUME_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY volume_bar_id
+        """
+    )
+
+    second = materialize_binance_spot_volume_klines_assets(partition_key='2024-01-01')
+    second_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(VOLUME_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['VOLUME_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY volume_bar_id
+        """
+    )
+
+    assert first.success
+    assert second.success
+    assert first_rows == second_rows
+    assert len(second_rows) == 3
+
+
+def test_volume_kline_assets_job_and_schedule_are_registered(
+    origo_definitions_module: object,
+    origo_assets: dict[str, object],
+) -> None:
+    schedule_def = origo_definitions_module.daily_binance_spot_pipeline_schedule
+    resolved_schedule_def = origo_definitions_module.defs.get_repository_def().get_schedule_def(
+        'daily_binance_spot_pipeline_schedule'
+    )
+    data_source_job = origo_definitions_module.defs.get_job_def(
+        'refresh_binance_spot_data_source_job'
+    )
+    create_table_job = origo_definitions_module.defs.get_job_def(
+        'create_binance_spot_volume_klines_table_origo_job'
+    )
+    node_names = set(data_source_job.graph.node_dict.keys())
+    volume_asset = origo_assets['refresh_binance_spot_volume_klines_origo']
+    volume_deps = volume_asset.asset_deps[volume_asset.key]
+
+    assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
+    assert resolved_schedule_def.cron_schedule == '0 4 * * *'
+    assert resolved_schedule_def.execution_timezone == 'UTC'
+    assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
+    assert create_table_job.name == 'create_binance_spot_volume_klines_table_origo_job'
+    assert node_names >= {
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_klines_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+        'refresh_binance_spot_volume_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_spot_origo',
+    }
+    assert volume_deps == {
+        origo_assets['create_binance_spot_volume_klines_table_origo'].key,
+        origo_assets['insert_daily_binance_spot_trades_to_origo'].key,
+    }


### PR DESCRIPTION
Closes #201

Summary:
- Add Origo Binance spot volume kline create/refresh assets.
- Register volume klines in the existing daily spot refresh job and create-table job.
- Add volume kline Origo source-native tests plus version/changelog trail.

Checks:
- Codex CLI issue review: APPROVED
- ruff check tdw_control_plane/assets/create_binance_spot_volume_klines_table_origo.py tdw_control_plane/assets/refresh_binance_spot_volume_klines_origo.py tests/origo_source_native/test_origo_binance_spot_volume_klines_template.py tools tests/tools: PASS
- python3 -m py_compile changed Python surfaces: PASS
- tools/fail_loud_gate.py: PASS
- tools/version_gate.py: PASS
- tools/typing_gate.py: PASS
- tools/slice_gate.py against issue #201: PASS
- pytest tests/origo_source_native -q --maxfail=1: BLOCKED locally, Docker daemon socket missing
