### PR TITLE
feat(origo): add binance spot tick klines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.12.0 on May 20, 2026
+- Add Binance spot tick klines on Origo daily spot trades.
+
 # v1.11.0 on May 19, 2026
 - Add Binance spot volume klines on Origo daily spot trades.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.11.0"
+version = "1.12.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/create_binance_spot_tick_klines_table_origo.py
+++ b/tdw_control_plane/assets/create_binance_spot_tick_klines_table_origo.py
@@ -1,0 +1,81 @@
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_trades_table_origo import database_exists, table_exists
+from .create_origo_database import (
+    ClickHouseClientProtocol,
+    ClickHouseSettings,
+    create_origo_database,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
+
+TICK_KLINES_TABLE_NAME = 'binance_spot_tick_klines'
+
+
+def _create_tick_klines_table(
+    client: ClickHouseClientProtocol,
+    settings: ClickHouseSettings,
+) -> None:
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {settings.database}.{TICK_KLINES_TABLE_NAME} (
+            start_datetime DateTime,
+            end_datetime DateTime,
+            tick_bar_id UInt64 COMMENT 'Partition-date scoped id; resets each day and groups fixed trade counts.',
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            mean Float64,
+            std Float64,
+            median Float64,
+            iqr Float64,
+            volume Float64,
+            maker_ratio Float64,
+            no_of_trades UInt64,
+            open_liquidity Float64,
+            high_liquidity Float64,
+            low_liquidity Float64,
+            close_liquidity Float64,
+            liquidity_sum Float64,
+            maker_volume Float64,
+            maker_liquidity Float64
+        )
+        ENGINE = MergeTree()
+        PARTITION BY toYYYYMM(start_datetime)
+        ORDER BY (start_datetime, end_datetime, tick_bar_id)
+        """
+    )
+
+
+@asset(
+    group_name='origo_setup',
+    deps=[create_origo_database],
+    description=(
+        'Creates the binance_spot_tick_klines table if it does not exist. '
+        'tick_bar_id is scoped to each partition date.'
+    ),
+)
+def create_binance_spot_tick_klines_table_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
+
+    try:
+        if not database_exists(client, settings.database):
+            raise RuntimeError(
+                f'Database {settings.database} does not exist. Run create_origo_database first.'
+            )
+
+        table_existed = table_exists(client, settings, TICK_KLINES_TABLE_NAME)
+        _create_tick_klines_table(client, settings)
+
+        context.log.info(f'Ensured table {settings.database}.{TICK_KLINES_TABLE_NAME} exists.')
+        return {
+            'status': 'success',
+            'table': f'{settings.database}.{TICK_KLINES_TABLE_NAME}',
+            'table_action': 'already_exists' if table_existed else 'created',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/assets/refresh_binance_spot_tick_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_tick_klines_origo.py
@@ -1,0 +1,154 @@
+from datetime import UTC, datetime, timedelta
+
+from dagster import AssetExecutionContext, asset
+
+from .create_binance_spot_tick_klines_table_origo import (
+    TICK_KLINES_TABLE_NAME,
+    create_binance_spot_tick_klines_table_origo,
+)
+from .create_binance_trades_table_origo import RAW_TABLE_NAME
+from .create_origo_database import (
+    ClickHouseClientProtocol,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
+from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_trades_to_origo
+
+TICK_KLINE_SIZE = 1_000
+
+
+def _partition_key_or_none(partition_key: object) -> str | None:
+    if isinstance(partition_key, str):
+        return partition_key
+    return None
+
+
+def _partition_date_from_context(context: AssetExecutionContext) -> str:
+    partition_key = _partition_key_or_none(context.partition_key)
+    if partition_key is not None:
+        return partition_key
+
+    target_date = datetime.now(UTC) - timedelta(days=1)
+    return target_date.strftime('%Y-%m-%d')
+
+
+def _delete_partition_rows(
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        ALTER TABLE {database}.{TICK_KLINES_TABLE_NAME}
+        DELETE WHERE toDate(start_datetime) = toDate('{partition_date}')
+        """,
+        settings={'mutations_sync': 2},
+    )
+
+
+def _count_partition_rows(
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{TICK_KLINES_TABLE_NAME}
+        WHERE toDate(start_datetime) = toDate('{partition_date}')
+        """
+    )
+    count_value = result[0][0]
+    if not isinstance(count_value, int):
+        raise TypeError(f'Expected int scalar from ClickHouse, got {type(count_value).__name__}')
+    return count_value
+
+
+def _insert_partition_rows(
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> None:
+    client.execute(
+        f"""
+        INSERT INTO {database}.{TICK_KLINES_TABLE_NAME}
+        SELECT
+            min(datetime) AS start_datetime,
+            max(datetime) AS end_datetime,
+            tick_bar_id,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            avg(price) AS mean,
+            stddevPopStable(price) AS std,
+            quantileExact(0.5)(price) AS median,
+            quantileExact(0.75)(price) - quantileExact(0.25)(price) AS iqr,
+            sumKahan(quantity) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            sum(price * quantity) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            sum(is_buyer_maker * price * quantity) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toUInt64(intDiv(running_trade_count_before, {TICK_KLINE_SIZE})) AS tick_bar_id
+            FROM (
+                SELECT
+                    *,
+                    row_number() OVER (ORDER BY datetime, trade_id) - 1 AS running_trade_count_before
+                FROM {database}.{RAW_TABLE_NAME}
+                WHERE toDate(datetime) = toDate('{partition_date}')
+            )
+        )
+        GROUP BY tick_bar_id
+        ORDER BY tick_bar_id
+        """
+    )
+
+
+@asset(
+    partitions_def=daily_partitions,
+    deps=[
+        create_binance_spot_tick_klines_table_origo,
+        insert_daily_binance_spot_trades_to_origo,
+    ],
+    group_name='binance_data',
+    description=(
+        'Refreshes the daily-scoped Binance spot tick kline projection from '
+        'source-native daily trades; tick_bar_id resets each date and the final '
+        'daily bar may be below the tick threshold.'
+    ),
+)
+def refresh_binance_spot_tick_klines_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    partition_date = _partition_date_from_context(context)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
+
+    try:
+        existing_count = _count_partition_rows(client, settings.database, partition_date)
+        if existing_count > 0:
+            context.log.info(
+                f'Found {existing_count} existing Binance spot tick kline rows for '
+                f'{partition_date}. Replacing that partition.'
+            )
+            _delete_partition_rows(client, settings.database, partition_date)
+
+        _insert_partition_rows(client, settings.database, partition_date)
+        inserted_count = _count_partition_rows(client, settings.database, partition_date)
+
+        return {
+            'status': 'success',
+            'partition_date': partition_date,
+            'rows_inserted': inserted_count,
+            'table': f'{settings.database}.{TICK_KLINES_TABLE_NAME}',
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -85,6 +85,9 @@ from .assets.create_binance_spot_dollar_klines_table_origo import (
 from .assets.create_binance_spot_volume_klines_table_origo import (
     create_binance_spot_volume_klines_table_origo,
 )
+from .assets.create_binance_spot_tick_klines_table_origo import (
+    create_binance_spot_tick_klines_table_origo,
+)
 from .assets.create_binance_futures_klines_table_origo import (
     create_binance_futures_klines_table_origo,
 )
@@ -100,6 +103,9 @@ from .assets.refresh_binance_spot_dollar_klines_origo import (
 )
 from .assets.refresh_binance_spot_volume_klines_origo import (
     refresh_binance_spot_volume_klines_origo,
+)
+from .assets.refresh_binance_spot_tick_klines_origo import (
+    refresh_binance_spot_tick_klines_origo,
 )
 from .assets.refresh_binance_futures_klines_origo import refresh_binance_futures_klines_origo
 from .assets.refresh_binance_spot_depth20_1m_origo import (
@@ -180,6 +186,11 @@ create_binance_spot_volume_klines_table_origo_job = define_asset_job(
     selection=["create_binance_spot_volume_klines_table_origo"]
 )
 
+create_binance_spot_tick_klines_table_origo_job = define_asset_job(
+    name="create_binance_spot_tick_klines_table_origo_job",
+    selection=["create_binance_spot_tick_klines_table_origo"]
+)
+
 create_binance_futures_klines_table_origo_job = define_asset_job(
     name="create_binance_futures_klines_table_origo_job",
     selection=["create_binance_futures_klines_table_origo"]
@@ -229,6 +240,7 @@ refresh_binance_spot_data_source_job = define_asset_job(
         "refresh_binance_spot_klines_origo",
         "refresh_binance_spot_dollar_klines_origo",
         "refresh_binance_spot_volume_klines_origo",
+        "refresh_binance_spot_tick_klines_origo",
         "refresh_aligned_1m_exchange_from_binance_spot_origo",
     ])
 
@@ -706,6 +718,7 @@ defs = Definitions(
             create_binance_spot_klines_table_origo,
             create_binance_spot_dollar_klines_table_origo,
             create_binance_spot_volume_klines_table_origo,
+            create_binance_spot_tick_klines_table_origo,
             create_binance_futures_klines_table_origo,
             create_binance_spot_depth20_snapshots_table_origo,
             create_binance_spot_depth20_1m_table_origo,
@@ -717,6 +730,7 @@ defs = Definitions(
             refresh_binance_spot_klines_origo,
             refresh_binance_spot_dollar_klines_origo,
             refresh_binance_spot_volume_klines_origo,
+            refresh_binance_spot_tick_klines_origo,
             refresh_binance_futures_klines_origo,
             sync_binance_spot_depth20_snapshots_to_origo,
             refresh_binance_spot_depth20_1m_origo,
@@ -770,6 +784,7 @@ defs = Definitions(
           create_binance_spot_klines_table_origo_job,
           create_binance_spot_dollar_klines_table_origo_job,
           create_binance_spot_volume_klines_table_origo_job,
+          create_binance_spot_tick_klines_table_origo_job,
           create_binance_futures_klines_table_origo_job,
           create_binance_spot_depth20_snapshots_table_origo_job,
           create_binance_spot_depth20_1m_table_origo_job,

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -230,6 +230,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     create_binance_spot_volume_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_spot_volume_klines_table_origo'
     )
+    create_binance_spot_tick_klines_table_origo_module = _reload_module(
+        'tdw_control_plane.assets.create_binance_spot_tick_klines_table_origo'
+    )
     create_binance_futures_klines_table_origo_module = _reload_module(
         'tdw_control_plane.assets.create_binance_futures_klines_table_origo'
     )
@@ -241,6 +244,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     )
     refresh_binance_spot_volume_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_spot_volume_klines_origo'
+    )
+    refresh_binance_spot_tick_klines_origo_module = _reload_module(
+        'tdw_control_plane.assets.refresh_binance_spot_tick_klines_origo'
     )
     refresh_binance_futures_klines_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_futures_klines_origo'
@@ -294,6 +300,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'create_binance_spot_volume_klines_table_origo': (
             create_binance_spot_volume_klines_table_origo_module.create_binance_spot_volume_klines_table_origo
         ),
+        'create_binance_spot_tick_klines_table_origo': (
+            create_binance_spot_tick_klines_table_origo_module.create_binance_spot_tick_klines_table_origo
+        ),
         'create_binance_futures_klines_table_origo': (
             create_binance_futures_klines_table_origo_module.create_binance_futures_klines_table_origo
         ),
@@ -306,6 +315,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'refresh_binance_spot_volume_klines_origo': (
             refresh_binance_spot_volume_klines_origo_module.refresh_binance_spot_volume_klines_origo
         ),
+        'refresh_binance_spot_tick_klines_origo': (
+            refresh_binance_spot_tick_klines_origo_module.refresh_binance_spot_tick_klines_origo
+        ),
         'refresh_binance_futures_klines_origo': (
             refresh_binance_futures_klines_origo_module.refresh_binance_futures_klines_origo
         ),
@@ -316,11 +328,17 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         'VOLUME_KLINES_TABLE_NAME': (
             create_binance_spot_volume_klines_table_origo_module.VOLUME_KLINES_TABLE_NAME
         ),
+        'TICK_KLINES_TABLE_NAME': (
+            create_binance_spot_tick_klines_table_origo_module.TICK_KLINES_TABLE_NAME
+        ),
         'refresh_binance_spot_dollar_klines_origo_module': (
             refresh_binance_spot_dollar_klines_origo_module
         ),
         'refresh_binance_spot_volume_klines_origo_module': (
             refresh_binance_spot_volume_klines_origo_module
+        ),
+        'refresh_binance_spot_tick_klines_origo_module': (
+            refresh_binance_spot_tick_klines_origo_module
         ),
         'FUTURES_KLINES_TABLE_NAME': (
             create_binance_futures_klines_table_origo_module.KLINES_TABLE_NAME
@@ -431,6 +449,25 @@ def materialize_binance_spot_volume_klines_assets(
                 origo_assets['create_binance_spot_volume_klines_table_origo'],
                 origo_assets['insert_daily_binance_spot_trades_to_origo'],
                 origo_assets['refresh_binance_spot_volume_klines_origo'],
+            ],
+            partition_key=partition_key,
+        )
+
+    return _run
+
+
+@pytest.fixture()
+def materialize_binance_spot_tick_klines_assets(
+    origo_assets: dict[str, object],
+) -> object:
+    def _run(*, partition_key: str | None = None) -> object:
+        return materialize(
+            [
+                origo_assets['create_origo_database'],
+                origo_assets['create_binance_daily_spot_trades_table_origo'],
+                origo_assets['create_binance_spot_tick_klines_table_origo'],
+                origo_assets['insert_daily_binance_spot_trades_to_origo'],
+                origo_assets['refresh_binance_spot_tick_klines_origo'],
             ],
             partition_key=partition_key,
         )

--- a/tests/origo_source_native/test_origo_binance_spot_tick_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_tick_klines_template.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+from dagster import DefaultScheduleStatus
+
+from .helpers import ORIGO_DATABASE
+
+TICK_KLINE_COLUMNS = [
+    'start_datetime',
+    'end_datetime',
+    'tick_bar_id',
+    'open',
+    'high',
+    'low',
+    'close',
+    'mean',
+    'std',
+    'median',
+    'iqr',
+    'volume',
+    'maker_ratio',
+    'no_of_trades',
+    'open_liquidity',
+    'high_liquidity',
+    'low_liquidity',
+    'close_liquidity',
+    'liquidity_sum',
+    'maker_volume',
+    'maker_liquidity',
+]
+TICK_KLINE_COLUMN_TYPES = [
+    'DateTime',
+    'DateTime',
+    'UInt64',
+    *(['Float64'] * 10),
+    'UInt64',
+    *(['Float64'] * 7),
+]
+
+
+def _table_metadata(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    table_name: str,
+) -> tuple[str, str, str]:
+    rows = query_origo(
+        f"""
+        SELECT engine, partition_key, sorting_key
+        FROM system.tables
+        WHERE database = '{ORIGO_DATABASE}'
+          AND name = '{table_name}'
+        """
+    )
+
+    assert len(rows) == 1
+    engine, partition_key, sorting_key = rows[0]
+    return str(engine), str(partition_key), str(sorting_key)
+
+
+def _normalize_value(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    return value
+
+
+def _rows_to_dicts(
+    columns: list[str],
+    rows: list[tuple[object, ...]],
+) -> list[dict[str, object]]:
+    return [
+        {column: _normalize_value(value) for column, value in zip(columns, row, strict=True)}
+        for row in rows
+    ]
+
+
+def test_binance_spot_tick_klines_table_name_contract(
+    origo_assets: dict[str, object],
+) -> None:
+    assert origo_assets['TICK_KLINES_TABLE_NAME'] == 'binance_spot_tick_klines'
+
+
+def test_binance_spot_tick_klines_schema_matches_spot_kline_statistics_contract(
+    materialize_binance_spot_tick_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    result = materialize_binance_spot_tick_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        DESCRIBE TABLE {ORIGO_DATABASE}.{origo_assets['TICK_KLINES_TABLE_NAME']}
+        """
+    )
+
+    assert [name for name, *_ in rows] == TICK_KLINE_COLUMNS
+    assert [type_name for _, type_name, *_ in rows] == TICK_KLINE_COLUMN_TYPES
+    assert _table_metadata(query_origo, str(origo_assets['TICK_KLINES_TABLE_NAME'])) == (
+        'MergeTree',
+        'toYYYYMM(start_datetime)',
+        'start_datetime, end_datetime, tick_bar_id',
+    )
+
+
+def test_binance_spot_tick_klines_rows_match_fixture_with_exact_bar_range(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_tick_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_tick_klines_origo_module'],
+        'TICK_KLINE_SIZE',
+        3,
+    )
+
+    result = materialize_binance_spot_tick_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(TICK_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['TICK_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY tick_bar_id
+        """
+    )
+
+    assert _rows_to_dicts(TICK_KLINE_COLUMNS, rows) == [
+        {
+            'start_datetime': '2024-01-01 00:00:00',
+            'end_datetime': '2024-01-01 00:00:02',
+            'tick_bar_id': 0,
+            'open': 42000.1,
+            'high': 42010.0,
+            'low': 42000.1,
+            'close': 42005.5,
+            'mean': 42005.200000000004,
+            'std': 4.047221268968605,
+            'median': 42005.5,
+            'iqr': 9.900000000001455,
+            'volume': 0.0045000000000000005,
+            'maker_ratio': 0.6666666666666666,
+            'no_of_trades': 3,
+            'open_liquidity': 42.000099999999996,
+            'high_liquidity': 84.02,
+            'low_liquidity': 42.000099999999996,
+            'close_liquidity': 63.008250000000004,
+            'liquidity_sum': 189.02835,
+            'maker_volume': 0.0025,
+            'maker_liquidity': 105.00835000000001,
+        },
+    ]
+
+
+def test_same_partition_rerun_is_idempotent_for_tick_klines(
+    monkeypatch: pytest.MonkeyPatch,
+    materialize_binance_spot_tick_klines_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    monkeypatch.setattr(
+        origo_assets['refresh_binance_spot_tick_klines_origo_module'],
+        'TICK_KLINE_SIZE',
+        1,
+    )
+
+    first = materialize_binance_spot_tick_klines_assets(partition_key='2024-01-01')
+    first_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(TICK_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['TICK_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY tick_bar_id
+        """
+    )
+
+    second = materialize_binance_spot_tick_klines_assets(partition_key='2024-01-01')
+    second_rows = query_origo(
+        f"""
+        SELECT
+            {', '.join(TICK_KLINE_COLUMNS)}
+        FROM {ORIGO_DATABASE}.{origo_assets['TICK_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        ORDER BY tick_bar_id
+        """
+    )
+
+    assert first.success
+    assert second.success
+    assert first_rows == second_rows
+    assert len(second_rows) == 3
+
+
+def test_tick_kline_assets_job_and_schedule_are_registered(
+    origo_definitions_module: object,
+    origo_assets: dict[str, object],
+) -> None:
+    schedule_def = origo_definitions_module.daily_binance_spot_pipeline_schedule
+    resolved_schedule_def = origo_definitions_module.defs.get_repository_def().get_schedule_def(
+        'daily_binance_spot_pipeline_schedule'
+    )
+    data_source_job = origo_definitions_module.defs.get_job_def(
+        'refresh_binance_spot_data_source_job'
+    )
+    create_table_job = origo_definitions_module.defs.get_job_def(
+        'create_binance_spot_tick_klines_table_origo_job'
+    )
+    node_names = set(data_source_job.graph.node_dict.keys())
+    tick_asset = origo_assets['refresh_binance_spot_tick_klines_origo']
+    tick_deps = tick_asset.asset_deps[tick_asset.key]
+
+    assert schedule_def.job.name == 'refresh_binance_spot_data_source_job'
+    assert resolved_schedule_def.cron_schedule == '0 4 * * *'
+    assert resolved_schedule_def.execution_timezone == 'UTC'
+    assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
+    assert create_table_job.name == 'create_binance_spot_tick_klines_table_origo_job'
+    assert node_names >= {
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_klines_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+        'refresh_binance_spot_volume_klines_origo',
+        'refresh_binance_spot_tick_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_spot_origo',
+    }
+    assert tick_deps == {
+        origo_assets['create_binance_spot_tick_klines_table_origo'].key,
+        origo_assets['insert_daily_binance_spot_trades_to_origo'].key,
+    }


### PR DESCRIPTION
Closes #204

Summary:
- Add Origo Binance spot tick kline create/refresh assets.
- Register tick klines in the existing daily spot refresh job and create-table job.
- Add tick kline Origo source-native tests plus version/changelog trail.

Checks:
- Codex CLI issue review: APPROVED
- ruff check tdw_control_plane/assets/create_binance_spot_tick_klines_table_origo.py tdw_control_plane/assets/refresh_binance_spot_tick_klines_origo.py tests/origo_source_native/test_origo_binance_spot_tick_klines_template.py tools tests/tools: PASS
- python3 -m py_compile changed Python surfaces: PASS
- tools/fail_loud_gate.py: PASS
- tools/version_gate.py: PASS
- tools/typing_gate.py: PASS
- tools/slice_gate.py against issue #204: PASS
- pytest tests/origo_source_native -q --maxfail=1: BLOCKED locally, Docker daemon socket missing
