### PR TITLE
fix(origo): add binance spot dollar klines backfill job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.13.1 on May 20, 2026
+- Add a dedicated Binance spot dollar klines backfill job.
+
 # v1.13.0 on May 20, 2026
 - Add Binance spot dollar imbalance klines on Origo daily spot trades.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.13.0"
+version = "1.13.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -256,6 +256,14 @@ refresh_binance_spot_data_source_job = define_asset_job(
         "refresh_aligned_1m_exchange_from_binance_spot_origo",
     ])
 
+backfill_binance_spot_dollar_klines_origo_job = define_asset_job(
+    name='backfill_binance_spot_dollar_klines_origo_job',
+    selection=[
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+    ],
+)
+
 refresh_binance_futures_data_source_job = define_asset_job(
     name="refresh_binance_futures_data_source_job",
     selection=[
@@ -807,6 +815,7 @@ defs = Definitions(
           create_binance_trades_complete_view_job,
           insert_monthly_binance_trades_job,
           refresh_binance_spot_data_source_job,
+          backfill_binance_spot_dollar_klines_origo_job,
           refresh_binance_futures_data_source_job,
           refresh_binance_spot_depth20_data_source_job,
           insert_daily_binance_trades_tdw_job,

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py
@@ -229,3 +229,21 @@ def test_dollar_kline_assets_job_and_schedule_are_registered(
         origo_assets['create_binance_spot_dollar_klines_table_origo'].key,
         origo_assets['insert_daily_binance_spot_trades_to_origo'].key,
     }
+
+
+def test_dollar_kline_backfill_job_matches_daily_time_bar_partition_pattern(
+    origo_definitions_module: object,
+) -> None:
+    backfill_job = origo_definitions_module.defs.get_job_def(
+        'backfill_binance_spot_dollar_klines_origo_job'
+    )
+    node_names = set(backfill_job.graph.node_dict.keys())
+
+    assert node_names == {
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+    }
+    assert backfill_job.partitions_def is not None
+    assert '2024-01-01' in backfill_job.partitions_def.get_partition_keys(
+        current_time=datetime(2024, 1, 3)
+    )


### PR DESCRIPTION
Closes #208.

## Summary
- Add a dedicated manual Dagster backfill job for Binance spot dollar klines.
- Select only daily spot trades plus dollar klines; no asset/table logic changes.
- Bump patch version and changelog.

## Validation
- `pytest tests/origo_source_native -q`
- `ruff check tools tests/tools`
- `python -m py_compile tdw_control_plane/definitions.py tests/origo_source_native/test_origo_binance_spot_dollar_klines_template.py`
- `typing_gate.py --pyright-json /tmp/backfill-pyright.json --base-budget .github/typing_budget.json`
- `fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
