### PR TITLE
fix(origo): add manual backfill jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.13.3 on May 20, 2026
+- Add manual Origo backfill jobs for Binance spot raw trades and depth20 snapshots.
+
 # v1.13.2 on May 20, 2026
 - Decouple the Binance spot dollar klines backfill job from raw-trades ingestion and fail the dollar refresh when raw trades are absent.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.13.3 on May 20, 2026
-- Add manual Origo backfill jobs for Binance spot raw trades and depth20 snapshots.
+- Add manual Origo backfill jobs for Binance spot raw trades and depth20 snapshots plus 1m projection.
 
 # v1.13.2 on May 20, 2026
 - Decouple the Binance spot dollar klines backfill job from raw-trades ingestion and fail the dollar refresh when raw trades are absent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.13.2"
+version = "1.13.3"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/refresh_binance_spot_depth20_1m_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_depth20_1m_origo.py
@@ -14,7 +14,7 @@ from .create_binance_spot_depth20_snapshots_table_origo import (
     make_clickhouse_client,
 )
 from .sync_binance_spot_depth20_snapshots_to_origo import (
-    MINUTE_START_CONFIG_KEY,
+    depth20_minute_partitions,
     minute_start_from_context,
     sync_binance_spot_depth20_snapshots_to_origo,
 )
@@ -85,12 +85,12 @@ def _insert_minute_row(
 
 
 @asset(
+    partitions_def=depth20_minute_partitions,
     group_name='binance_spot_depth20_data',
     deps=[
         create_binance_spot_depth20_1m_table_origo,
         sync_binance_spot_depth20_snapshots_to_origo,
     ],
-    config_schema={MINUTE_START_CONFIG_KEY: str},
     description='Refreshes the Binance spot depth20 1m source projection from source-native snapshots',
 )
 def refresh_binance_spot_depth20_1m_origo(

--- a/tdw_control_plane/assets/sync_binance_spot_depth20_snapshots_to_origo.py
+++ b/tdw_control_plane/assets/sync_binance_spot_depth20_snapshots_to_origo.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timedelta, timezone
 
 import requests
-from dagster import AssetExecutionContext, asset
+from dagster import AssetExecutionContext, TimeWindowPartitionsDefinition, asset
 
 from .create_binance_spot_depth20_snapshots_table_origo import (
     ClickHouseClient,
@@ -14,7 +14,14 @@ from .create_binance_spot_depth20_snapshots_table_origo import (
     make_clickhouse_client,
 )
 
-MINUTE_START_CONFIG_KEY = 'minute_start'
+DEPTH20_FIRST_MINUTE_UTC = '2026-05-14T10:28:00+0000'
+DEPTH20_PARTITION_KEY_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
+depth20_minute_partitions = TimeWindowPartitionsDefinition(
+    start=DEPTH20_FIRST_MINUTE_UTC,
+    fmt=DEPTH20_PARTITION_KEY_FORMAT,
+    cron_schedule='* * * * *',
+    timezone='UTC',
+)
 SnapshotRow = tuple[datetime, int, int, list[tuple[float, float]], list[tuple[float, float]]]
 
 
@@ -26,9 +33,9 @@ def _require_env(name: str) -> str:
 
 
 def minute_start_from_context(context: AssetExecutionContext) -> datetime:
-    value = context.op_config.get(MINUTE_START_CONFIG_KEY)
-    if not isinstance(value, str):
-        raise RuntimeError(f'{MINUTE_START_CONFIG_KEY} run config must be set.')
+    value = context.partition_key
+    if value is None:
+        raise RuntimeError('Depth20 assets require a minute partition key.')
 
     parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
@@ -100,9 +107,9 @@ def _count_minute_rows(
 
 
 @asset(
+    partitions_def=depth20_minute_partitions,
     group_name='binance_spot_depth20_data',
     deps=[create_binance_spot_depth20_snapshots_table_origo],
-    config_schema={MINUTE_START_CONFIG_KEY: str},
     description='Syncs the last completed minute of Binance spot depth20 snapshots from the history API',
 )
 def sync_binance_spot_depth20_snapshots_to_origo(

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -128,6 +128,7 @@ from .assets.refresh_aligned_1m_exchange_from_binance_futures_origo import (
     refresh_aligned_1m_exchange_from_binance_futures_origo,
 )
 from .assets.sync_binance_spot_depth20_snapshots_to_origo import (
+    depth20_minute_partitions,
     sync_binance_spot_depth20_snapshots_to_origo,
 )
 
@@ -266,6 +267,11 @@ backfill_binance_spot_trades_origo_job = define_asset_job(
     selection=['insert_daily_binance_spot_trades_to_origo'],
 )
 
+_BINANCE_SPOT_DEPTH20_DATA_SOURCE_SELECTION = [
+    'sync_binance_spot_depth20_snapshots_to_origo',
+    'refresh_binance_spot_depth20_1m_origo',
+]
+
 refresh_binance_futures_data_source_job = define_asset_job(
     name="refresh_binance_futures_data_source_job",
     selection=[
@@ -276,18 +282,12 @@ refresh_binance_futures_data_source_job = define_asset_job(
 
 refresh_binance_spot_depth20_data_source_job = define_asset_job(
     name='refresh_binance_spot_depth20_data_source_job',
-    selection=[
-        'sync_binance_spot_depth20_snapshots_to_origo',
-        'refresh_binance_spot_depth20_1m_origo',
-    ],
+    selection=_BINANCE_SPOT_DEPTH20_DATA_SOURCE_SELECTION,
 )
 
 backfill_binance_spot_depth20_data_source_job = define_asset_job(
     name='backfill_binance_spot_depth20_data_source_job',
-    selection=[
-        'sync_binance_spot_depth20_snapshots_to_origo',
-        'refresh_binance_spot_depth20_1m_origo',
-    ],
+    selection=_BINANCE_SPOT_DEPTH20_DATA_SOURCE_SELECTION,
 )
 
 insert_daily_binance_trades_tdw_job = define_asset_job(
@@ -504,20 +504,6 @@ def _last_completed_minute(scheduled_time: datetime | None) -> datetime:
     )
 
 
-def _binance_spot_depth20_run_config(minute_start: datetime) -> dict[str, object]:
-    minute_start_iso = minute_start.isoformat()
-    return {
-        'ops': {
-            'sync_binance_spot_depth20_snapshots_to_origo': {
-                'config': {'minute_start': minute_start_iso}
-            },
-            'refresh_binance_spot_depth20_1m_origo': {
-                'config': {'minute_start': minute_start_iso}
-            },
-        }
-    }
-
-
 daily_binance_spot_pipeline_schedule = build_schedule_from_partitioned_job(
     refresh_binance_spot_data_source_job,
     name='daily_binance_spot_pipeline_schedule',
@@ -540,11 +526,17 @@ daily_binance_futures_pipeline_schedule = build_schedule_from_partitioned_job(
     execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
-def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest:
+def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest | SkipReason:
     minute_start = _last_completed_minute(context.scheduled_execution_time)
+    partition_key = depth20_minute_partitions.get_partition_key_for_timestamp(
+        minute_start.timestamp()
+    )
+    if not depth20_minute_partitions.has_partition_key(partition_key):
+        return SkipReason(f'Depth20 partition {partition_key} is before the partition start.')
+
     return RunRequest(
-        run_key=f'binance_spot_depth20::{minute_start.isoformat()}',
-        run_config=_binance_spot_depth20_run_config(minute_start),
+        partition_key=partition_key,
+        run_key=f'binance_spot_depth20::{partition_key}',
     )
 
 

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -261,6 +261,11 @@ backfill_binance_spot_dollar_klines_origo_job = define_asset_job(
     selection=['refresh_binance_spot_dollar_klines_origo'],
 )
 
+backfill_binance_spot_trades_origo_job = define_asset_job(
+    name='backfill_binance_spot_trades_origo_job',
+    selection=['insert_daily_binance_spot_trades_to_origo'],
+)
+
 refresh_binance_futures_data_source_job = define_asset_job(
     name="refresh_binance_futures_data_source_job",
     selection=[
@@ -271,6 +276,14 @@ refresh_binance_futures_data_source_job = define_asset_job(
 
 refresh_binance_spot_depth20_data_source_job = define_asset_job(
     name='refresh_binance_spot_depth20_data_source_job',
+    selection=[
+        'sync_binance_spot_depth20_snapshots_to_origo',
+        'refresh_binance_spot_depth20_1m_origo',
+    ],
+)
+
+backfill_binance_spot_depth20_data_source_job = define_asset_job(
+    name='backfill_binance_spot_depth20_data_source_job',
     selection=[
         'sync_binance_spot_depth20_snapshots_to_origo',
         'refresh_binance_spot_depth20_1m_origo',
@@ -813,8 +826,10 @@ defs = Definitions(
           insert_monthly_binance_trades_job,
           refresh_binance_spot_data_source_job,
           backfill_binance_spot_dollar_klines_origo_job,
+          backfill_binance_spot_trades_origo_job,
           refresh_binance_futures_data_source_job,
           refresh_binance_spot_depth20_data_source_job,
+          backfill_binance_spot_depth20_data_source_job,
           insert_daily_binance_trades_tdw_job,
           publish_binance_spot_klines_to_huggingface_job,
           publish_binance_spot_15m_klines_to_huggingface_job,

--- a/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_data_source_template.py
@@ -99,6 +99,21 @@ def test_daily_binance_spot_pipeline_schedule_targets_binance_spot_data_source_j
     }
 
 
+def test_binance_spot_trades_backfill_job_is_raw_source_only(
+    origo_definitions_module,
+) -> None:
+    backfill_job = origo_definitions_module.defs.get_job_def(
+        'backfill_binance_spot_trades_origo_job'
+    )
+    node_names = set(backfill_job.graph.node_dict.keys())
+
+    assert node_names == {'insert_daily_binance_spot_trades_to_origo'}
+    assert backfill_job.partitions_def is not None
+    assert '2024-01-01' in backfill_job.partitions_def.get_partition_keys(
+        current_time=datetime(2024, 1, 3)
+    )
+
+
 def test_daily_binance_spot_pipeline_schedule_requests_latest_daily_partition(
     origo_definitions_module,
     materialize_binance_spot_data_source_assets,

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -6,7 +6,8 @@ from dagster import DefaultScheduleStatus, build_schedule_context, materialize
 
 from .helpers import ORIGO_DATABASE
 
-DEPTH20_MINUTE_CONFIG = '2026-05-13T13:23:00+00:00'
+DEPTH20_FIRST_PARTITION_KEY = '2026-05-14T10:28:00+0000'
+DEPTH20_SCHEDULE_PARTITION_KEY = '2026-05-14T10:31:00+0000'
 DEPTH20_EXPECTED_COLUMNS = [
     'datetime',
     'source_timestamp_ms',
@@ -31,19 +32,6 @@ def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
     assert len(rows) == 1
     engine, partition_key, sorting_key = rows[0]
     return str(engine), str(partition_key), str(sorting_key)
-
-
-def _depth20_run_config() -> dict[str, object]:
-    return {
-        'ops': {
-            'sync_binance_spot_depth20_snapshots_to_origo': {
-                'config': {'minute_start': DEPTH20_MINUTE_CONFIG}
-            },
-            'refresh_binance_spot_depth20_1m_origo': {
-                'config': {'minute_start': DEPTH20_MINUTE_CONFIG}
-            },
-        }
-    }
 
 
 def test_binance_spot_depth20_snapshots_table_name_contract(
@@ -147,7 +135,7 @@ def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
     schedule_def = repository_def.get_schedule_def('binance_spot_depth20_1m_schedule')
     job_def = origo_definitions_module.defs.get_job_def('refresh_binance_spot_depth20_data_source_job')
     context = build_schedule_context(
-        scheduled_execution_time=datetime(2026, 5, 13, 13, 24, tzinfo=timezone.utc),
+        scheduled_execution_time=datetime(2026, 5, 14, 10, 32, tzinfo=timezone.utc),
         repository_def=repository_def,
     )
     tick = schedule_def.evaluate_tick(context)
@@ -159,9 +147,12 @@ def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
         'sync_binance_spot_depth20_snapshots_to_origo',
         'refresh_binance_spot_depth20_1m_origo',
     }
+    assert job_def.partitions_def is not None
+    assert job_def.partitions_def.get_first_partition_key() == DEPTH20_FIRST_PARTITION_KEY
     assert len(tick.run_requests) == 1
-    assert tick.run_requests[0].run_key == 'binance_spot_depth20::2026-05-13T13:23:00+00:00'
-    assert tick.run_requests[0].run_config == _depth20_run_config()
+    assert tick.run_requests[0].partition_key == DEPTH20_SCHEDULE_PARTITION_KEY
+    assert tick.run_requests[0].run_key == f'binance_spot_depth20::{DEPTH20_SCHEDULE_PARTITION_KEY}'
+    assert tick.run_requests[0].run_config == {}
 
 
 def test_binance_spot_depth20_backfill_job_is_manual_data_source_only(
@@ -176,4 +167,11 @@ def test_binance_spot_depth20_backfill_job_is_manual_data_source_only(
         'sync_binance_spot_depth20_snapshots_to_origo',
         'refresh_binance_spot_depth20_1m_origo',
     }
-    assert backfill_job.partitions_def is None
+    assert backfill_job.partitions_def is not None
+    assert backfill_job.partitions_def.get_partition_keys(
+        current_time=datetime(2026, 5, 14, 10, 31, tzinfo=timezone.utc)
+    ) == [
+        '2026-05-14T10:28:00+0000',
+        '2026-05-14T10:29:00+0000',
+        '2026-05-14T10:30:00+0000',
+    ]

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -162,3 +162,18 @@ def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
     assert len(tick.run_requests) == 1
     assert tick.run_requests[0].run_key == 'binance_spot_depth20::2026-05-13T13:23:00+00:00'
     assert tick.run_requests[0].run_config == _depth20_run_config()
+
+
+def test_binance_spot_depth20_backfill_job_is_manual_data_source_only(
+    origo_definitions_module,
+) -> None:
+    backfill_job = origo_definitions_module.defs.get_job_def(
+        'backfill_binance_spot_depth20_data_source_job'
+    )
+    node_names = set(backfill_job.graph.node_dict.keys())
+
+    assert node_names == {
+        'sync_binance_spot_depth20_snapshots_to_origo',
+        'refresh_binance_spot_depth20_1m_origo',
+    }
+    assert backfill_job.partitions_def is None


### PR DESCRIPTION
Closes #214

## Summary
- Add manual Origo backfill job for raw Binance spot trades only.
- Add minute-partitioned Origo depth20 backfill job for snapshots plus 1m projection.
- Convert depth20 minute selection from run config to Dagster partition keys starting at `2026-05-14T10:28:00+0000`.
- Add registration tests plus version/changelog.

## Validation
- `/tmp/tdw-control-plane-venv/bin/python -m pytest tests/origo_source_native -q --maxfail=1`
- `uvx ruff==0.15.11 check tools tests/tools`
- `git diff --check`
- `/tmp/tdw-control-plane-venv/bin/python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
- `/tmp/tdw-control-plane-venv/bin/python tools/typing_gate.py --pyright-json /tmp/manual-backfill-jobs-pyright-2.json --base-budget .github/typing_budget.json`
- `/tmp/tdw-control-plane-venv/bin/python tools/version_gate.py ...`
- `/tmp/tdw-control-plane-venv/bin/python tools/slice_gate.py ...`
- `/tmp/tdw-control-plane-venv/bin/python tools/cc_gate.py ...`
