### PR TITLE
fix(origo): reconcile depth20 partition state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.13.4 on May 20, 2026
+- Add a manual Origo depth20 partition-state reconciliation job for existing ClickHouse rows.
+
 # v1.13.3 on May 20, 2026
 - Add manual Origo backfill jobs for Binance spot raw trades and depth20 snapshots plus 1m projection.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.13.3"
+version = "1.13.4"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/reconcile_binance_spot_depth20_partition_state_origo.py
+++ b/tdw_control_plane/assets/reconcile_binance_spot_depth20_partition_state_origo.py
@@ -51,7 +51,7 @@ def _existing_snapshot_minutes(client: ClickHouseClient, database: str) -> list[
         client.execute(
             f"""
             SELECT DISTINCT toStartOfMinute(datetime) AS minute
-            FROM {database}.{SNAPSHOTS_TABLE_NAME} FINAL
+            FROM {database}.{SNAPSHOTS_TABLE_NAME}
             ORDER BY minute
             """
         )
@@ -63,7 +63,7 @@ def _existing_projection_minutes(client: ClickHouseClient, database: str) -> lis
         client.execute(
             f"""
             SELECT DISTINCT datetime AS minute
-            FROM {database}.{DEPTH20_1M_TABLE_NAME} FINAL
+            FROM {database}.{DEPTH20_1M_TABLE_NAME}
             ORDER BY minute
             """
         )

--- a/tdw_control_plane/assets/reconcile_binance_spot_depth20_partition_state_origo.py
+++ b/tdw_control_plane/assets/reconcile_binance_spot_depth20_partition_state_origo.py
@@ -1,0 +1,137 @@
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import cast
+
+from dagster import AssetExecutionContext, AssetKey, AssetMaterialization, asset
+
+from .create_binance_spot_depth20_1m_table_origo import DEPTH20_1M_TABLE_NAME
+from .create_binance_spot_depth20_snapshots_table_origo import (
+    ClickHouseClient,
+    SNAPSHOTS_TABLE_NAME,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
+from .refresh_binance_spot_depth20_1m_origo import refresh_binance_spot_depth20_1m_origo
+from .sync_binance_spot_depth20_snapshots_to_origo import (
+    DEPTH20_PARTITION_KEY_FORMAT,
+    sync_binance_spot_depth20_snapshots_to_origo,
+)
+
+
+def _datetime_rows(result: object) -> list[datetime]:
+    if not isinstance(result, Sequence) or isinstance(result, (bytes, str)):
+        raise TypeError('Expected ClickHouse row list.')
+
+    rows = cast(Sequence[object], result)
+    values: list[datetime] = []
+    for row in rows:
+        if (
+            not isinstance(row, Sequence)
+            or isinstance(row, (bytes, str))
+            or len(row) != 1
+        ):
+            raise TypeError('Expected ClickHouse single-value row.')
+        value = row[0]
+        if not isinstance(value, datetime):
+            raise TypeError(
+                f'Expected ClickHouse datetime value, got {type(value).__name__}.'
+            )
+        values.append(value)
+    return values
+
+
+def _partition_key(minute: datetime) -> str:
+    if minute.tzinfo is None:
+        minute = minute.replace(tzinfo=timezone.utc)
+    return minute.astimezone(timezone.utc).strftime(DEPTH20_PARTITION_KEY_FORMAT)
+
+
+def _existing_snapshot_minutes(client: ClickHouseClient, database: str) -> list[datetime]:
+    return _datetime_rows(
+        client.execute(
+            f"""
+            SELECT DISTINCT toStartOfMinute(datetime) AS minute
+            FROM {database}.{SNAPSHOTS_TABLE_NAME} FINAL
+            ORDER BY minute
+            """
+        )
+    )
+
+
+def _existing_projection_minutes(client: ClickHouseClient, database: str) -> list[datetime]:
+    return _datetime_rows(
+        client.execute(
+            f"""
+            SELECT DISTINCT datetime AS minute
+            FROM {database}.{DEPTH20_1M_TABLE_NAME} FINAL
+            ORDER BY minute
+            """
+        )
+    )
+
+
+def _report_existing_partitions(
+    context: AssetExecutionContext,
+    *,
+    asset_key: AssetKey,
+    database: str,
+    table_name: str,
+    minutes: list[datetime],
+) -> int:
+    existing_partitions = context.instance.get_materialized_partitions(asset_key)
+    reported_count = 0
+
+    for minute in minutes:
+        partition_key = _partition_key(minute)
+        if partition_key in existing_partitions:
+            continue
+
+        context.instance.report_runless_asset_event(
+            AssetMaterialization(
+                asset_key=asset_key,
+                partition=partition_key,
+                metadata={'source_table': f'{database}.{table_name}'},
+            )
+        )
+        reported_count += 1
+
+    return reported_count
+
+
+@asset(
+    group_name='binance_spot_depth20_data',
+    description='Reconciles Dagster depth20 partition state from existing Origo ClickHouse rows.',
+)
+def reconcile_binance_spot_depth20_partition_state_origo(
+    context: AssetExecutionContext,
+) -> dict[str, object]:
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
+
+    try:
+        snapshot_minutes = _existing_snapshot_minutes(client, settings.database)
+        projection_minutes = _existing_projection_minutes(client, settings.database)
+
+        reported_snapshot_count = _report_existing_partitions(
+            context,
+            asset_key=sync_binance_spot_depth20_snapshots_to_origo.key,
+            database=settings.database,
+            table_name=SNAPSHOTS_TABLE_NAME,
+            minutes=snapshot_minutes,
+        )
+        reported_projection_count = _report_existing_partitions(
+            context,
+            asset_key=refresh_binance_spot_depth20_1m_origo.key,
+            database=settings.database,
+            table_name=DEPTH20_1M_TABLE_NAME,
+            minutes=projection_minutes,
+        )
+
+        return {
+            'snapshot_minutes_found': len(snapshot_minutes),
+            'projection_minutes_found': len(projection_minutes),
+            'snapshot_partitions_reported': reported_snapshot_count,
+            'projection_partitions_reported': reported_projection_count,
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -131,6 +131,9 @@ from .assets.sync_binance_spot_depth20_snapshots_to_origo import (
     depth20_minute_partitions,
     sync_binance_spot_depth20_snapshots_to_origo,
 )
+from .assets.reconcile_binance_spot_depth20_partition_state_origo import (
+    reconcile_binance_spot_depth20_partition_state_origo,
+)
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
@@ -288,6 +291,11 @@ refresh_binance_spot_depth20_data_source_job = define_asset_job(
 backfill_binance_spot_depth20_data_source_job = define_asset_job(
     name='backfill_binance_spot_depth20_data_source_job',
     selection=_BINANCE_SPOT_DEPTH20_DATA_SOURCE_SELECTION,
+)
+
+reconcile_binance_spot_depth20_partition_state_origo_job = define_asset_job(
+    name='reconcile_binance_spot_depth20_partition_state_origo_job',
+    selection=['reconcile_binance_spot_depth20_partition_state_origo'],
 )
 
 insert_daily_binance_trades_tdw_job = define_asset_job(
@@ -758,6 +766,7 @@ defs = Definitions(
             refresh_binance_futures_klines_origo,
             sync_binance_spot_depth20_snapshots_to_origo,
             refresh_binance_spot_depth20_1m_origo,
+            reconcile_binance_spot_depth20_partition_state_origo,
             refresh_aligned_1m_exchange_from_binance_spot_origo,
             refresh_aligned_1m_exchange_from_binance_futures_origo,
             insert_daily_binance_trades_to_tdw,
@@ -822,6 +831,7 @@ defs = Definitions(
           refresh_binance_futures_data_source_job,
           refresh_binance_spot_depth20_data_source_job,
           backfill_binance_spot_depth20_data_source_job,
+          reconcile_binance_spot_depth20_partition_state_origo_job,
           insert_daily_binance_trades_tdw_job,
           publish_binance_spot_klines_to_huggingface_job,
           publish_binance_spot_15m_klines_to_huggingface_job,

--- a/tests/origo_source_native/conftest.py
+++ b/tests/origo_source_native/conftest.py
@@ -282,6 +282,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
     refresh_binance_spot_depth20_1m_origo_module = _reload_module(
         'tdw_control_plane.assets.refresh_binance_spot_depth20_1m_origo'
     )
+    reconcile_binance_spot_depth20_partition_state_origo_module = _reload_module(
+        'tdw_control_plane.assets.reconcile_binance_spot_depth20_partition_state_origo'
+    )
 
     return {
         'create_origo_database': create_origo_database_module.create_origo_database,
@@ -392,6 +395,9 @@ def origo_assets(origo_test_env: dict[str, str]) -> dict[str, Any]:
         ),
         'refresh_binance_spot_depth20_1m_origo': (
             refresh_binance_spot_depth20_1m_origo_module.refresh_binance_spot_depth20_1m_origo
+        ),
+        'reconcile_binance_spot_depth20_partition_state_origo': (
+            reconcile_binance_spot_depth20_partition_state_origo_module.reconcile_binance_spot_depth20_partition_state_origo
         ),
         'DEPTH20_SNAPSHOTS_TABLE_NAME': (
             create_binance_spot_depth20_snapshots_table_origo_module.SNAPSHOTS_TABLE_NAME

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from dagster import DefaultScheduleStatus, build_schedule_context, materialize
+from dagster import DagsterInstance, DefaultScheduleStatus, build_schedule_context, materialize
 
 from .helpers import ORIGO_DATABASE
 
@@ -17,6 +17,9 @@ DEPTH20_EXPECTED_COLUMNS = [
     'book_ask_depth_20_notional',
     'book_imbalance_20',
 ]
+DEPTH20_TEST_LEVELS_SQL = (
+    '[' + ','.join(f'({level}.0,{level}.0)' for level in range(1, 21)) + ']'
+)
 
 
 def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
@@ -175,3 +178,82 @@ def test_binance_spot_depth20_backfill_job_is_manual_data_source_only(
         '2026-05-14T10:29:00+0000',
         '2026-05-14T10:30:00+0000',
     ]
+
+
+def test_binance_spot_depth20_reconcile_job_reports_existing_table_minutes(
+    origo_definitions_module,
+    query_origo,
+    origo_assets: dict[str, object],
+) -> None:
+    reconcile_job = origo_definitions_module.defs.get_job_def(
+        'reconcile_binance_spot_depth20_partition_state_origo_job'
+    )
+    node_names = set(reconcile_job.graph.node_dict.keys())
+    instance = DagsterInstance.ephemeral()
+    partition_key = '2026-05-14T10:28:00+0000'
+
+    setup_result = materialize(
+        [
+            origo_assets['create_origo_database'],
+            origo_assets['create_binance_spot_depth20_snapshots_table_origo'],
+            origo_assets['create_binance_spot_depth20_1m_table_origo'],
+        ],
+        instance=instance,
+    )
+    assert setup_result.success
+
+    query_origo(
+        f"""
+        INSERT INTO {ORIGO_DATABASE}.{origo_assets['DEPTH20_SNAPSHOTS_TABLE_NAME']}
+        (
+            datetime,
+            source_timestamp_ms,
+            last_update_id,
+            bids,
+            asks
+        ) VALUES (
+            toDateTime64('2026-05-14 10:28:00.000', 3),
+            1,
+            1,
+            {DEPTH20_TEST_LEVELS_SQL},
+            {DEPTH20_TEST_LEVELS_SQL}
+        )
+        """
+    )
+    query_origo(
+        f"""
+        INSERT INTO {ORIGO_DATABASE}.{origo_assets['DEPTH20_1M_TABLE_NAME']}
+        (
+            datetime,
+            source_timestamp_ms,
+            book_mid_price,
+            book_spread_bps,
+            book_bid_depth_20_notional,
+            book_ask_depth_20_notional,
+            book_imbalance_20
+        ) VALUES (
+            toDateTime('2026-05-14 10:28:00'),
+            1,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            0.0
+        )
+        """
+    )
+
+    reconcile_result = materialize(
+        [origo_assets['reconcile_binance_spot_depth20_partition_state_origo']],
+        instance=instance,
+    )
+
+    assert node_names == {'reconcile_binance_spot_depth20_partition_state_origo'}
+    assert reconcile_job.partitions_def is None
+    assert reconcile_result.success
+    assert instance.get_materialized_partitions(
+        origo_assets['sync_binance_spot_depth20_snapshots_to_origo'].key
+    ) == {partition_key}
+    assert instance.get_materialized_partitions(
+        origo_assets['refresh_binance_spot_depth20_1m_origo'].key
+    ) == {partition_key}


### PR DESCRIPTION
## What does this PR change?

Adds a manual Dagster job that reconciles depth20 partition materialization state from existing Origo ClickHouse rows. It records runless Dagster materializations for existing snapshot and 1m projection minutes; it does not insert, delete, or update ClickHouse data.

Root cause: PR #215 made depth20 assets partitioned, but historical ClickHouse rows had no matching Dagster partition events, so Dagit showed all existing minutes as missing.

Closes #216

## Validation

- `python -m pytest tests/origo_source_native -q --maxfail=1`
- `uvx ruff==0.15.11 check tools tests/tools`
- `python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json`
- `python tools/typing_gate.py --pyright-json /tmp/depth20-reconcile-pyright.json --base-budget .github/typing_budget.json`
- `python tools/version_gate.py --pr-title "fix(origo): reconcile depth20 partition state" --base-pyproject /tmp/depth20-base-pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/depth20-base-changelog.md --head-changelog CHANGELOG.md`

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable)
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [ ] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable
