### PR TITLE
fix(origo): require raw spot trades for dollar imbalance refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.14.2 on May 22, 2026
+- Require raw spot trades before replacing Binance spot dollar imbalance kline partitions.
+
 # v1.14.1 on May 21, 2026
 - Fix the Binance spot dollar kline base size to 1M and publish 1M, 15M, 30M, 60M, 120M, and 240M dollar snapshots.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.14.1"
+version = "1.14.2"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/refresh_binance_spot_dollar_imbalance_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_dollar_imbalance_klines_origo.py
@@ -7,13 +7,13 @@ from typing import Protocol, cast
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
-from dagster import AssetExecutionContext, asset
+from dagster import AssetExecutionContext, AssetRecordsFilter, asset
 
 from .create_binance_spot_dollar_imbalance_klines_table_origo import (
     DOLLAR_IMBALANCE_KLINES_TABLE_NAME,
     create_binance_spot_dollar_imbalance_klines_table_origo,
 )
-from .create_binance_trades_table_origo import RAW_TABLE_NAME
+from .create_binance_trades_table_origo import LEDGER_TABLE_NAME, RAW_TABLE_NAME
 from .create_origo_database import (
     ClickHouseClientProtocol,
     ClickHouseSettings,
@@ -25,6 +25,7 @@ from .daily_trades_to_origo import daily_partitions, insert_daily_binance_spot_t
 DOLLAR_IMBALANCE_KLINE_SIZE = 100_000.0
 DOLLAR_IMBALANCE_BOUNDARY_SEARCH_STEP = 512
 DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
+RAW_TRADES_ASSET_KEY = insert_daily_binance_spot_trades_to_origo.key
 
 
 class _ClickHouseArrowClientProtocol(Protocol):
@@ -117,6 +118,91 @@ def _count_partition_rows(
     if not isinstance(count_value, int):
         raise TypeError(f'Expected int scalar from ClickHouse, got {type(count_value).__name__}')
     return count_value
+
+
+def _count_raw_partition_rows(
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> int:
+    partition_start, partition_end = _partition_datetime_bounds(partition_date)
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{RAW_TABLE_NAME}
+        WHERE datetime >= toDateTime64('{partition_start}', 6)
+          AND datetime < toDateTime64('{partition_end}', 6)
+        """
+    )
+    return int(result[0][0])
+
+
+def _raw_ledger_inserted_row_count(
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> int | None:
+    result = client.execute(
+        f"""
+        SELECT inserted_row_count
+        FROM {database}.{LEDGER_TABLE_NAME}
+        WHERE source_date = toDate('{partition_date}')
+          AND source_file = 'BTCUSDT-trades-{partition_date}.zip'
+          AND status = 'success'
+        ORDER BY loaded_at DESC
+        LIMIT 1
+        """
+    )
+    if len(result) == 0:
+        return None
+    return int(result[0][0])
+
+
+def _raw_partition_was_materialized(
+    context: AssetExecutionContext,
+    partition_date: str,
+) -> bool:
+    records = context.instance.fetch_materializations(
+        AssetRecordsFilter(
+            asset_key=RAW_TRADES_ASSET_KEY,
+            asset_partitions=[partition_date],
+        ),
+        limit=1,
+    )
+    return len(records.records) == 1
+
+
+def _ensure_raw_partition_ready(
+    context: AssetExecutionContext,
+    client: ClickHouseClientProtocol,
+    database: str,
+    partition_date: str,
+) -> None:
+    if not _raw_partition_was_materialized(context, partition_date):
+        raise RuntimeError(
+            f'Raw Binance spot trades have no Dagster materialization for {partition_date}. '
+            f'Run insert_daily_binance_spot_trades_to_origo for that partition first.'
+        )
+
+    raw_count = _count_raw_partition_rows(client, database, partition_date)
+    if raw_count == 0:
+        raise RuntimeError(
+            f'Raw Binance spot trades are missing for {partition_date}. '
+            f'Run insert_daily_binance_spot_trades_to_origo for that partition first.'
+        )
+
+    ledger_count = _raw_ledger_inserted_row_count(client, database, partition_date)
+    if ledger_count is None:
+        raise RuntimeError(
+            f'Raw Binance spot trades ingestion ledger is missing for {partition_date}. '
+            f'Run insert_daily_binance_spot_trades_to_origo for that partition first.'
+        )
+
+    if raw_count != ledger_count:
+        raise RuntimeError(
+            f'Raw Binance spot trades row count mismatch for {partition_date}: '
+            f'raw={raw_count}, ledger={ledger_count}.'
+        )
 
 
 def _query_partition_trades(
@@ -354,6 +440,8 @@ def refresh_binance_spot_dollar_imbalance_klines_origo(
     client = make_clickhouse_client(settings)
 
     try:
+        _ensure_raw_partition_ready(context, client, settings.database, partition_date)
+
         existing_count = _count_partition_rows(client, settings.database, partition_date)
         if existing_count > 0:
             context.log.info(

--- a/tdw_control_plane/assets/refresh_binance_spot_dollar_imbalance_klines_origo.py
+++ b/tdw_control_plane/assets/refresh_binance_spot_dollar_imbalance_klines_origo.py
@@ -125,13 +125,13 @@ def _count_raw_partition_rows(
     database: str,
     partition_date: str,
 ) -> int:
-    partition_start, partition_end = _partition_datetime_bounds(partition_date)
+    start_datetime, end_datetime = _partition_datetime_bounds(partition_date)
     result = client.execute(
         f"""
         SELECT count()
         FROM {database}.{RAW_TABLE_NAME}
-        WHERE datetime >= toDateTime64('{partition_start}', 6)
-          AND datetime < toDateTime64('{partition_end}', 6)
+        WHERE datetime >= toDateTime64('{start_datetime}', 6)
+          AND datetime < toDateTime64('{end_datetime}', 6)
         """
     )
     return int(result[0][0])

--- a/tests/origo_source_native/test_origo_binance_spot_dollar_imbalance_klines_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_dollar_imbalance_klines_template.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from datetime import datetime
 
 import pytest
-from dagster import DefaultScheduleStatus
+from dagster import DagsterInstance, DefaultScheduleStatus, materialize
 
 from .helpers import ORIGO_DATABASE
 
@@ -205,6 +205,62 @@ def test_same_partition_rerun_is_idempotent_for_dollar_imbalance_klines(
     assert second.success
     assert first_rows == second_rows
     assert len(second_rows) == 3
+
+
+def test_dollar_imbalance_kline_refresh_fails_before_replacing_when_raw_partition_is_absent(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    origo_assets: dict[str, object],
+) -> None:
+    instance = DagsterInstance.ephemeral()
+    first = materialize(
+        [
+            origo_assets['create_origo_database'],
+            origo_assets['create_binance_daily_spot_trades_table_origo'],
+            origo_assets['create_binance_spot_dollar_imbalance_klines_table_origo'],
+            origo_assets['insert_daily_binance_spot_trades_to_origo'],
+            origo_assets['refresh_binance_spot_dollar_imbalance_klines_origo'],
+        ],
+        instance=instance,
+        partition_key='2024-01-01',
+    )
+    before_rows = query_origo(
+        f"""
+        SELECT count()
+        FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_IMBALANCE_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        """
+    )
+    query_origo(
+        f"""
+        ALTER TABLE {ORIGO_DATABASE}.{origo_assets['RAW_TABLE_NAME']}
+        DELETE WHERE toDate(datetime) = toDate('2024-01-01')
+        SETTINGS mutations_sync = 2
+        """
+    )
+
+    result = materialize(
+        [
+            origo_assets['create_origo_database'],
+            origo_assets['create_binance_daily_spot_trades_table_origo'],
+            origo_assets['create_binance_spot_dollar_imbalance_klines_table_origo'],
+            origo_assets['refresh_binance_spot_dollar_imbalance_klines_origo'],
+        ],
+        instance=instance,
+        partition_key='2024-01-01',
+        raise_on_error=False,
+    )
+    after_rows = query_origo(
+        f"""
+        SELECT count()
+        FROM {ORIGO_DATABASE}.{origo_assets['DOLLAR_IMBALANCE_KLINES_TABLE_NAME']}
+        WHERE toDate(start_datetime) = toDate('2024-01-01')
+        """
+    )
+
+    assert first.success
+    assert before_rows[0][0] > 0
+    assert not result.success
+    assert before_rows == after_rows
 
 
 def test_dollar_imbalance_kline_assets_job_and_schedule_are_registered(


### PR DESCRIPTION
## What does this PR change?

Closes #220.

Requires the dollar imbalance kline refresh to prove the raw Binance spot trades partition is materialized, present, and ledger-consistent before replacing existing derived rows.

This matches the fixed dollar kline standard: raw spot trades are a hard dependency, and missing raw input fails before stale derived rows can be deleted.

## Validation

- Focused dollar imbalance test file: `6 passed`
- Full `tests/origo_source_native`: `81 passed`
- Ruff: pass
- Version gate: pass
- Fail-loud gate: pass
- Typing gate: pass
- CC gate: pass
- Slice gate: pass locally with a single closing reference
