### PR TITLE
fix(origo): include latest table creation in scheduled job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.15.1 on May 30, 2026
+- Include latest Binance spot table creation in the scheduled latest data-source job.
+
 # v1.15.0 on May 27, 2026
 - Add rolling latest Binance spot trade, kline, and cut projections in Origo.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.15.0"
+version = "1.15.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -331,6 +331,7 @@ refresh_binance_spot_depth20_data_source_job = define_asset_job(
 refresh_binance_spot_latest_data_source_job = define_asset_job(
     name='refresh_binance_spot_latest_data_source_job',
     selection=[
+        'create_binance_spot_latest_tables_origo',
         'sync_binance_spot_trades_latest_origo',
         'refresh_binance_spot_klines_latest_origo',
         'refresh_binance_spot_dollar_klines_latest_origo',

--- a/tests/origo_source_native/test_origo_binance_spot_latest_projections.py
+++ b/tests/origo_source_native/test_origo_binance_spot_latest_projections.py
@@ -394,6 +394,7 @@ def test_latest_schedule_requests_last_closed_minute_once_per_minute(
     assert resolved_schedule_def.execution_timezone == 'UTC'
     assert resolved_schedule_def.default_status == DefaultScheduleStatus.RUNNING
     assert node_names == {
+        'create_binance_spot_latest_tables_origo',
         'sync_binance_spot_trades_latest_origo',
         'refresh_binance_spot_klines_latest_origo',
         'refresh_binance_spot_dollar_klines_latest_origo',


### PR DESCRIPTION
Closes #224

## Summary
- Includes latest table creation in the scheduled latest Binance spot data-source job.
- Updates the schedule test so CI asserts the create asset is selected with the runtime job.
- Bumps version/changelog to 1.15.1.

## Validation
- `python3 -m py_compile tdw_control_plane/definitions.py tests/origo_source_native/test_origo_binance_spot_latest_projections.py`
- `git diff --check`
- `python3 tools/version_gate.py --pr-title 'fix(origo): include latest table creation in scheduled job' --base-pyproject /tmp/base-pyproject-224.toml --head-pyproject pyproject.toml --base-changelog /tmp/base-CHANGELOG-224.md --head-changelog CHANGELOG.md`
- `python3 tools/fail_loud_gate.py --bootstrap`

## Local Blocker
- `pytest tests/origo_source_native/test_origo_binance_spot_latest_projections.py::test_latest_schedule_requests_last_closed_minute_once_per_minute -q` is blocked locally because Docker daemon is unavailable at `/Users/mikkokotila/.docker/run/docker.sock`; CI runs it with ClickHouse.