### PR TITLE
fix(huggingface): publish time klines from Origo projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.15.2 on June 4, 2026
+- Route Hugging Face Binance spot time-kline exports through the Origo 1m kline projection.
+
 # v1.15.1 on May 30, 2026
 - Include latest Binance spot table creation in the scheduled latest data-source job.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.15.1"
+version = "1.15.2"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -766,7 +766,7 @@ def _publish_binance_spot_dollar_klines_to_hf_run_request(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_klines_to_huggingface_job,
 )
 def publish_binance_spot_klines_to_huggingface_sensor(
@@ -780,7 +780,7 @@ def publish_binance_spot_klines_to_huggingface_sensor(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_15m_klines_to_huggingface_job,
 )
 def publish_binance_spot_15m_klines_to_huggingface_sensor(
@@ -794,7 +794,7 @@ def publish_binance_spot_15m_klines_to_huggingface_sensor(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_30m_klines_to_huggingface_job,
 )
 def publish_binance_spot_30m_klines_to_huggingface_sensor(
@@ -808,7 +808,7 @@ def publish_binance_spot_30m_klines_to_huggingface_sensor(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_1h_klines_to_huggingface_job,
 )
 def publish_binance_spot_1h_klines_to_huggingface_sensor(
@@ -822,7 +822,7 @@ def publish_binance_spot_1h_klines_to_huggingface_sensor(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_2h_klines_to_huggingface_job,
 )
 def publish_binance_spot_2h_klines_to_huggingface_sensor(
@@ -836,7 +836,7 @@ def publish_binance_spot_2h_klines_to_huggingface_sensor(
 
 
 @asset_sensor(
-    asset_key=AssetKey("insert_daily_binance_spot_trades_to_origo"),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_4h_klines_to_huggingface_job,
 )
 def publish_binance_spot_4h_klines_to_huggingface_sensor(

--- a/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
@@ -1,16 +1,78 @@
 import hashlib
 import json
 import os
+import re
 import tempfile
-from datetime import datetime, timedelta, timezone
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
 from pathlib import Path
+from typing import Protocol, cast
 
+import polars as pl
+import pyarrow as pa
 from dagster import AssetExecutionContext
 from huggingface_hub import HfApi
 
-from tdw_control_plane.query import get_binance_spot_klines
-
 EXPORT_START_DATE = "2020-01-01 00:00:00"
+DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
+SUPPORTED_DATETIME_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+)
+KLINE_EXPORT_COLUMNS = [
+    "datetime",
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "volume",
+    "maker_ratio",
+    "no_of_trades",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity",
+]
+
+
+class _ClickHouseArrowClientProtocol(Protocol):
+    def query_arrow(
+        self,
+        query: str,
+        parameters: Mapping[str, object] | None = None,
+    ) -> pa.Table:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+def _get_clickhouse_http_port() -> int:
+    value = os.environ.get("CLICKHOUSE_HTTP_PORT", str(DEFAULT_CLICKHOUSE_HTTP_PORT))
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError("CLICKHOUSE_HTTP_PORT environment variable must be an integer.") from exc
+
+
+def _make_clickhouse_arrow_client() -> _ClickHouseArrowClientProtocol:
+    client_factory = getattr(import_module("clickhouse_connect"), "get_client")
+    return cast(
+        _ClickHouseArrowClientProtocol,
+        client_factory(
+            host=os.environ.get("CLICKHOUSE_HOST", "clickhouse"),
+            port=_get_clickhouse_http_port(),
+            username=os.environ.get("CLICKHOUSE_USER", "default"),
+            password=os.environ["CLICKHOUSE_PASSWORD"],
+        ),
+    )
 
 
 def _get_huggingface_token() -> str:
@@ -34,6 +96,131 @@ def _get_huggingface_dataset_repo_id(
     return os.environ.get(repo_id_env, default_repo_id)
 
 
+def _validate_clickhouse_identifier(value: str, field_name: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_]+", value) is None:
+        raise ValueError(f"Invalid ClickHouse {field_name}: {value}")
+    return value
+
+
+def _normalize_datetime_literal(value: str, field_name: str) -> str:
+    last_error: ValueError | None = None
+    for fmt in SUPPORTED_DATETIME_FORMATS:
+        try:
+            parsed = datetime.strptime(value, fmt)
+            return parsed.strftime("%Y-%m-%d %H:%M:%S")
+        except ValueError as exc:
+            last_error = exc
+
+    message = (
+        f"{field_name} must match one of: YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, YYYY-MM-DDTHH:MM:SS."
+    )
+    if last_error is None:
+        raise ValueError(message)
+    raise ValueError(message) from last_error
+
+
+def _validate_projection_kline_size(kline_size_seconds: int) -> int:
+    if type(kline_size_seconds) is not int:
+        raise TypeError("kline_size_seconds must be an int.")
+    if kline_size_seconds < 60:
+        raise ValueError("kline_size_seconds must be at least 60.")
+    if kline_size_seconds % 60 != 0:
+        raise ValueError("kline_size_seconds must be a multiple of the 60-second projection.")
+    return kline_size_seconds
+
+
+def _get_binance_spot_klines_from_1m_projection(
+    *,
+    kline_size_seconds: int,
+    start_date_limit: str,
+    end_date_limit: str,
+    table_name: str,
+    database_name: str,
+) -> pl.DataFrame:
+    kline_size_seconds = _validate_projection_kline_size(kline_size_seconds)
+    table_name = _validate_clickhouse_identifier(table_name, "table name")
+    database_name = _validate_clickhouse_identifier(database_name, "database name")
+    start_date_limit = _normalize_datetime_literal(start_date_limit, "start_date_limit")
+    end_date_limit = _normalize_datetime_literal(end_date_limit, "end_date_limit")
+    client = _make_clickhouse_arrow_client()
+
+    try:
+        arrow_table = client.query_arrow(
+            f"""
+            SELECT
+                kline_datetime AS datetime,
+                argMin(source_open, source_datetime) AS open,
+                max(source_high) AS high,
+                min(source_low) AS low,
+                argMax(source_close, source_datetime) AS close,
+                sum(source_no_of_trades * source_mean) / sum(source_no_of_trades) AS mean,
+                sqrt(
+                    greatest(
+                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
+                        0
+                    )
+                ) AS std,
+                sumKahan(source_volume) AS volume,
+                sum(source_no_of_trades * source_maker_ratio) / sum(source_no_of_trades) AS maker_ratio,
+                sum(source_no_of_trades) AS no_of_trades,
+                argMin(source_open_liquidity, source_datetime) AS open_liquidity,
+                max(source_high_liquidity) AS high_liquidity,
+                min(source_low_liquidity) AS low_liquidity,
+                argMax(source_close_liquidity, source_datetime) AS close_liquidity,
+                sum(source_liquidity_sum) AS liquidity_sum,
+                sumKahan(source_maker_volume) AS maker_volume,
+                sum(source_maker_liquidity) AS maker_liquidity
+            FROM (
+                SELECT
+                    datetime AS source_datetime,
+                    open AS source_open,
+                    high AS source_high,
+                    low AS source_low,
+                    close AS source_close,
+                    mean AS source_mean,
+                    std AS source_std,
+                    volume AS source_volume,
+                    maker_ratio AS source_maker_ratio,
+                    no_of_trades AS source_no_of_trades,
+                    open_liquidity AS source_open_liquidity,
+                    high_liquidity AS source_high_liquidity,
+                    low_liquidity AS source_low_liquidity,
+                    close_liquidity AS source_close_liquidity,
+                    liquidity_sum AS source_liquidity_sum,
+                    maker_volume AS source_maker_volume,
+                    maker_liquidity AS source_maker_liquidity,
+                    toDateTime({{bucket_seconds:UInt32}} * intDiv(toUnixTimestamp(datetime), {{bucket_seconds:UInt32}})) AS kline_datetime
+                FROM {database_name}.{table_name}
+                WHERE datetime >= toDateTime({{start_dt:String}})
+                  AND datetime < toDateTime({{end_dt:String}})
+            )
+            GROUP BY kline_datetime
+            ORDER BY kline_datetime ASC
+            """,
+            parameters={
+                "bucket_seconds": kline_size_seconds,
+                "start_dt": start_date_limit,
+                "end_dt": end_date_limit,
+            },
+        )
+    finally:
+        client.close()
+
+    data = cast(pl.DataFrame, pl.from_arrow(arrow_table)).select(KLINE_EXPORT_COLUMNS)
+    if data.height == 0:
+        return data
+
+    return data.with_columns([
+        pl.col("datetime").cast(pl.Datetime("ms", time_zone="UTC")),
+        pl.col("mean").round(5),
+        pl.col("std").round(6),
+        pl.col("volume").round(9),
+        pl.col("liquidity_sum").round(1),
+        pl.col("maker_liquidity").round(1),
+    ]).sort("datetime")
+
+
 def _build_dataset_card(
     *,
     export_end_date: str,
@@ -44,7 +231,7 @@ def _build_dataset_card(
 ) -> str:
     return f"""# BTCUSDT {cadence_label} spot klines
 
-This dataset is exported daily from `origo.binance_daily_spot_trades` using `get_binance_spot_klines` at {resolution_label} resolution.
+This dataset is exported daily from `origo.binance_spot_klines` at {resolution_label} resolution.
 
 Latest snapshot:
 
@@ -57,7 +244,7 @@ Latest snapshot:
 Notes:
 
 - Source market: Binance spot BTCUSDT
-- Source table: `origo.binance_daily_spot_trades`
+- Source table: `origo.binance_spot_klines`
 - `median` and `iqr` are intentionally omitted from the exported Parquet snapshot
 - Timestamps are UTC
 """
@@ -69,7 +256,7 @@ def _build_snapshot_metadata(
     row_count: int,
     file_sha256: str,
 ) -> str:
-    generated_at = datetime.now(timezone.utc).isoformat()
+    generated_at = datetime.now(UTC).isoformat()
     return (
         json.dumps(
             {
@@ -122,13 +309,12 @@ def publish_binance_spot_kline_snapshot_to_huggingface(
     context.log.info(
         f"Building Binance spot {cadence_label} klines snapshot through {export_end_date} UTC."
     )
-    data = get_binance_spot_klines(
-        kline_size=kline_size_seconds,
+    data = _get_binance_spot_klines_from_1m_projection(
+        kline_size_seconds=kline_size_seconds,
         start_date_limit=EXPORT_START_DATE,
         end_date_limit=export_end_exclusive,
-        table_name="binance_daily_spot_trades",
+        table_name="binance_spot_klines",
         database_name="origo",
-        include_quantiles=False,
     )
 
     if data.height == 0:

--- a/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
@@ -154,11 +154,15 @@ def _get_binance_spot_klines_from_1m_projection(
                 min(source_low) AS low,
                 argMax(source_close, source_datetime) AS close,
                 sum(source_no_of_trades * source_mean) / sum(source_no_of_trades) AS mean,
-                sqrt(
-                    greatest(
-                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
-                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
-                        0
+                if(
+                    {{bucket_seconds:UInt32}} = 60,
+                    argMin(source_std, source_datetime),
+                    sqrt(
+                        greatest(
+                            sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                            - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
+                            0
+                        )
                     )
                 ) AS std,
                 sumKahan(source_volume) AS volume,

--- a/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py
@@ -216,7 +216,9 @@ def _get_binance_spot_klines_from_1m_projection(
         return data
 
     return data.with_columns([
-        pl.col("datetime").cast(pl.Datetime("ms", time_zone="UTC")),
+        (pl.col("datetime").cast(pl.Int64) * 1000)
+        .cast(pl.Datetime("ms", time_zone="UTC"))
+        .alias("datetime"),
         pl.col("mean").round(5),
         pl.col("std").round(6),
         pl.col("volume").round(9),

--- a/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
@@ -44,34 +44,50 @@ def _origo_projection_1h_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(open, datetime) AS open,
-            max(high) AS high,
-            min(low) AS low,
-            argMax(close, datetime) AS close,
-            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            argMin(source_open, source_datetime) AS open,
+            max(source_high) AS high,
+            min(source_low) AS low,
+            argMax(source_close, source_datetime) AS close,
+            round(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 5) AS mean,
             round(
                 sqrt(
                     greatest(
-                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
-                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
                         0
                     )
                 ),
                 6
             ) AS std,
-            round(sumKahan(volume), 9) AS volume,
-            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
-            sum(no_of_trades) AS no_of_trades,
-            argMin(open_liquidity, datetime) AS open_liquidity,
-            max(high_liquidity) AS high_liquidity,
-            min(low_liquidity) AS low_liquidity,
-            argMax(close_liquidity, datetime) AS close_liquidity,
-            round(sum(liquidity_sum), 1) AS liquidity_sum,
-            sumKahan(maker_volume) AS maker_volume,
-            round(sum(maker_liquidity), 1) AS maker_liquidity
+            round(sumKahan(source_volume), 9) AS volume,
+            sum(source_no_of_trades * source_maker_ratio) / sum(source_no_of_trades) AS maker_ratio,
+            sum(source_no_of_trades) AS no_of_trades,
+            argMin(source_open_liquidity, source_datetime) AS open_liquidity,
+            max(source_high_liquidity) AS high_liquidity,
+            min(source_low_liquidity) AS low_liquidity,
+            argMax(source_close_liquidity, source_datetime) AS close_liquidity,
+            round(sum(source_liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(source_maker_volume) AS maker_volume,
+            round(sum(source_maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
-                *,
+                datetime AS source_datetime,
+                open AS source_open,
+                high AS source_high,
+                low AS source_low,
+                close AS source_close,
+                mean AS source_mean,
+                std AS source_std,
+                volume AS source_volume,
+                maker_ratio AS source_maker_ratio,
+                no_of_trades AS source_no_of_trades,
+                open_liquidity AS source_open_liquidity,
+                high_liquidity AS source_high_liquidity,
+                low_liquidity AS source_low_liquidity,
+                close_liquidity AS source_close_liquidity,
+                liquidity_sum AS source_liquidity_sum,
+                maker_volume AS source_maker_volume,
+                maker_liquidity AS source_maker_liquidity,
                 toDateTime(3600 * intDiv(toUnixTimestamp(datetime), 3600)) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')

--- a/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py
@@ -32,7 +32,7 @@ KLINE_EXPORT_COLUMNS = [
 ]
 
 
-def _origo_trades_1h_kline_dataframe(
+def _origo_projection_1h_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
     *,
     database_name: str,
@@ -44,22 +44,31 @@ def _origo_trades_1h_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(price, trade_id) AS open,
-            max(price) AS high,
-            min(price) AS low,
-            argMax(price, trade_id) AS close,
-            round(avg(price), 5) AS mean,
-            round(stddevPopStable(price), 6) AS std,
-            round(sumKahan(quantity), 9) AS volume,
-            avg(is_buyer_maker) AS maker_ratio,
-            count() AS no_of_trades,
-            argMin(price * quantity, trade_id) AS open_liquidity,
-            max(price * quantity) AS high_liquidity,
-            min(price * quantity) AS low_liquidity,
-            argMax(price * quantity, trade_id) AS close_liquidity,
-            round(sum(price * quantity), 1) AS liquidity_sum,
-            sumKahan(is_buyer_maker * quantity) AS maker_volume,
-            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+            argMin(open, datetime) AS open,
+            max(high) AS high,
+            min(low) AS low,
+            argMax(close, datetime) AS close,
+            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            round(
+                sqrt(
+                    greatest(
+                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
+                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        0
+                    )
+                ),
+                6
+            ) AS std,
+            round(sumKahan(volume), 9) AS volume,
+            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
+            sum(no_of_trades) AS no_of_trades,
+            argMin(open_liquidity, datetime) AS open_liquidity,
+            max(high_liquidity) AS high_liquidity,
+            min(low_liquidity) AS low_liquidity,
+            argMax(close_liquidity, datetime) AS close_liquidity,
+            round(sum(liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(maker_volume) AS maker_volume,
+            round(sum(maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
                 *,
@@ -75,17 +84,17 @@ def _origo_trades_1h_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_1h_sensor_targets_origo_spot_trades_materialization(
+def test_publish_1h_sensor_targets_origo_spot_kline_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = (
         origo_definitions_module.publish_binance_spot_1h_klines_to_huggingface_sensor
     )
 
-    assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
+    assert sensor_def.asset_key == AssetKey('refresh_binance_spot_klines_origo')
 
 
-def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
+def test_publish_1h_snapshot_reads_origo_spot_klines_projection(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -132,19 +141,21 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
             uploaded['metadata'] = metadata
             uploaded['parquet'] = pl.read_parquet(folder / metadata['file_name'])
 
-    def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+    def recording_get_binance_spot_klines_from_1m_projection(**kwargs: object) -> pl.DataFrame:
         captured_query.update(kwargs)
         database_name = kwargs.get('database_name')
         table_name = kwargs.get('table_name')
+        kline_size_seconds = kwargs.get('kline_size_seconds')
         start_date_limit = kwargs.get('start_date_limit')
         end_date_limit = kwargs.get('end_date_limit')
 
         assert database_name == ORIGO_DATABASE
-        assert table_name == 'binance_daily_spot_trades'
+        assert table_name == 'binance_spot_klines'
+        assert kline_size_seconds == 3600
         assert isinstance(start_date_limit, str)
         assert isinstance(end_date_limit, str)
 
-        return _origo_trades_1h_kline_dataframe(
+        return _origo_projection_1h_kline_dataframe(
             query_origo,
             database_name=database_name,
             table_name=table_name,
@@ -157,8 +168,8 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
-        'get_binance_spot_klines',
-        recording_get_binance_spot_klines,
+        '_get_binance_spot_klines_from_1m_projection',
+        recording_get_binance_spot_klines_from_1m_projection,
     )
 
     publish_result = materialize(
@@ -181,15 +192,14 @@ def test_publish_1h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS
     assert captured_query == {
-        'kline_size': 3600,
+        'kline_size_seconds': 3600,
         'start_date_limit': '2020-01-01 00:00:00',
         'end_date_limit': '2024-01-02 00:00:00',
-        'table_name': 'binance_daily_spot_trades',
+        'table_name': 'binance_spot_klines',
         'database_name': 'origo',
-        'include_quantiles': False,
     }
     assert uploaded['commit_message'] == 'Add BTCUSDT 1h klines snapshot through 2024-01-01'
     assert uploaded['delete_patterns'] == ['btcusdt_1h_kline_20200101_to_*.parquet']
     assert metadata['file_name'] == 'btcusdt_1h_kline_20200101_to_20240101.parquet'
     assert '1-hour resolution' in readme
-    assert 'origo.binance_daily_spot_trades' in readme
+    assert 'origo.binance_spot_klines' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
@@ -32,7 +32,7 @@ KLINE_EXPORT_COLUMNS = [
 ]
 
 
-def _origo_trades_4h_kline_dataframe(
+def _origo_projection_4h_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
     *,
     database_name: str,
@@ -44,22 +44,31 @@ def _origo_trades_4h_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(price, trade_id) AS open,
-            max(price) AS high,
-            min(price) AS low,
-            argMax(price, trade_id) AS close,
-            round(avg(price), 5) AS mean,
-            round(stddevPopStable(price), 6) AS std,
-            round(sumKahan(quantity), 9) AS volume,
-            avg(is_buyer_maker) AS maker_ratio,
-            count() AS no_of_trades,
-            argMin(price * quantity, trade_id) AS open_liquidity,
-            max(price * quantity) AS high_liquidity,
-            min(price * quantity) AS low_liquidity,
-            argMax(price * quantity, trade_id) AS close_liquidity,
-            round(sum(price * quantity), 1) AS liquidity_sum,
-            sumKahan(is_buyer_maker * quantity) AS maker_volume,
-            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+            argMin(open, datetime) AS open,
+            max(high) AS high,
+            min(low) AS low,
+            argMax(close, datetime) AS close,
+            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            round(
+                sqrt(
+                    greatest(
+                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
+                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        0
+                    )
+                ),
+                6
+            ) AS std,
+            round(sumKahan(volume), 9) AS volume,
+            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
+            sum(no_of_trades) AS no_of_trades,
+            argMin(open_liquidity, datetime) AS open_liquidity,
+            max(high_liquidity) AS high_liquidity,
+            min(low_liquidity) AS low_liquidity,
+            argMax(close_liquidity, datetime) AS close_liquidity,
+            round(sum(liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(maker_volume) AS maker_volume,
+            round(sum(maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
                 *,
@@ -75,17 +84,17 @@ def _origo_trades_4h_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_4h_sensor_targets_origo_spot_trades_materialization(
+def test_publish_4h_sensor_targets_origo_spot_kline_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = (
         origo_definitions_module.publish_binance_spot_4h_klines_to_huggingface_sensor
     )
 
-    assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
+    assert sensor_def.asset_key == AssetKey('refresh_binance_spot_klines_origo')
 
 
-def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
+def test_publish_4h_snapshot_reads_origo_spot_klines_projection(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -132,19 +141,21 @@ def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
             uploaded['metadata'] = metadata
             uploaded['parquet'] = pl.read_parquet(folder / metadata['file_name'])
 
-    def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+    def recording_get_binance_spot_klines_from_1m_projection(**kwargs: object) -> pl.DataFrame:
         captured_query.update(kwargs)
         database_name = kwargs.get('database_name')
         table_name = kwargs.get('table_name')
+        kline_size_seconds = kwargs.get('kline_size_seconds')
         start_date_limit = kwargs.get('start_date_limit')
         end_date_limit = kwargs.get('end_date_limit')
 
         assert database_name == ORIGO_DATABASE
-        assert table_name == 'binance_daily_spot_trades'
+        assert table_name == 'binance_spot_klines'
+        assert kline_size_seconds == 14400
         assert isinstance(start_date_limit, str)
         assert isinstance(end_date_limit, str)
 
-        return _origo_trades_4h_kline_dataframe(
+        return _origo_projection_4h_kline_dataframe(
             query_origo,
             database_name=database_name,
             table_name=table_name,
@@ -157,8 +168,8 @@ def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
-        'get_binance_spot_klines',
-        recording_get_binance_spot_klines,
+        '_get_binance_spot_klines_from_1m_projection',
+        recording_get_binance_spot_klines_from_1m_projection,
     )
 
     publish_result = materialize(
@@ -181,15 +192,14 @@ def test_publish_4h_snapshot_reads_origo_spot_trades_with_shared_query(
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS
     assert captured_query == {
-        'kline_size': 14400,
+        'kline_size_seconds': 14400,
         'start_date_limit': '2020-01-01 00:00:00',
         'end_date_limit': '2024-01-02 00:00:00',
-        'table_name': 'binance_daily_spot_trades',
+        'table_name': 'binance_spot_klines',
         'database_name': 'origo',
-        'include_quantiles': False,
     }
     assert uploaded['commit_message'] == 'Add BTCUSDT 4h klines snapshot through 2024-01-01'
     assert uploaded['delete_patterns'] == ['btcusdt_4h_kline_20200101_to_*.parquet']
     assert metadata['file_name'] == 'btcusdt_4h_kline_20200101_to_20240101.parquet'
     assert '4-hour resolution' in readme
-    assert 'origo.binance_daily_spot_trades' in readme
+    assert 'origo.binance_spot_klines' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py
@@ -44,34 +44,50 @@ def _origo_projection_4h_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(open, datetime) AS open,
-            max(high) AS high,
-            min(low) AS low,
-            argMax(close, datetime) AS close,
-            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            argMin(source_open, source_datetime) AS open,
+            max(source_high) AS high,
+            min(source_low) AS low,
+            argMax(source_close, source_datetime) AS close,
+            round(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 5) AS mean,
             round(
                 sqrt(
                     greatest(
-                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
-                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
                         0
                     )
                 ),
                 6
             ) AS std,
-            round(sumKahan(volume), 9) AS volume,
-            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
-            sum(no_of_trades) AS no_of_trades,
-            argMin(open_liquidity, datetime) AS open_liquidity,
-            max(high_liquidity) AS high_liquidity,
-            min(low_liquidity) AS low_liquidity,
-            argMax(close_liquidity, datetime) AS close_liquidity,
-            round(sum(liquidity_sum), 1) AS liquidity_sum,
-            sumKahan(maker_volume) AS maker_volume,
-            round(sum(maker_liquidity), 1) AS maker_liquidity
+            round(sumKahan(source_volume), 9) AS volume,
+            sum(source_no_of_trades * source_maker_ratio) / sum(source_no_of_trades) AS maker_ratio,
+            sum(source_no_of_trades) AS no_of_trades,
+            argMin(source_open_liquidity, source_datetime) AS open_liquidity,
+            max(source_high_liquidity) AS high_liquidity,
+            min(source_low_liquidity) AS low_liquidity,
+            argMax(source_close_liquidity, source_datetime) AS close_liquidity,
+            round(sum(source_liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(source_maker_volume) AS maker_volume,
+            round(sum(source_maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
-                *,
+                datetime AS source_datetime,
+                open AS source_open,
+                high AS source_high,
+                low AS source_low,
+                close AS source_close,
+                mean AS source_mean,
+                std AS source_std,
+                volume AS source_volume,
+                maker_ratio AS source_maker_ratio,
+                no_of_trades AS source_no_of_trades,
+                open_liquidity AS source_open_liquidity,
+                high_liquidity AS source_high_liquidity,
+                low_liquidity AS source_low_liquidity,
+                close_liquidity AS source_close_liquidity,
+                liquidity_sum AS source_liquidity_sum,
+                maker_volume AS source_maker_volume,
+                maker_liquidity AS source_maker_liquidity,
                 toDateTime(14400 * intDiv(toUnixTimestamp(datetime), 14400)) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')

--- a/tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py
@@ -65,10 +65,10 @@ KLINE_CASES = [
 ]
 
 
-def _origo_trades_kline_dataframe(
+def _origo_projection_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
     *,
-    kline_size: int,
+    kline_size_seconds: int,
     database_name: str,
     table_name: str,
     start_date_limit: str,
@@ -78,26 +78,35 @@ def _origo_trades_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(price, trade_id) AS open,
-            max(price) AS high,
-            min(price) AS low,
-            argMax(price, trade_id) AS close,
-            round(avg(price), 5) AS mean,
-            round(stddevPopStable(price), 6) AS std,
-            round(sumKahan(quantity), 9) AS volume,
-            avg(is_buyer_maker) AS maker_ratio,
-            count() AS no_of_trades,
-            argMin(price * quantity, trade_id) AS open_liquidity,
-            max(price * quantity) AS high_liquidity,
-            min(price * quantity) AS low_liquidity,
-            argMax(price * quantity, trade_id) AS close_liquidity,
-            round(sum(price * quantity), 1) AS liquidity_sum,
-            sumKahan(is_buyer_maker * quantity) AS maker_volume,
-            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+            argMin(open, datetime) AS open,
+            max(high) AS high,
+            min(low) AS low,
+            argMax(close, datetime) AS close,
+            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            round(
+                sqrt(
+                    greatest(
+                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
+                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        0
+                    )
+                ),
+                6
+            ) AS std,
+            round(sumKahan(volume), 9) AS volume,
+            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
+            sum(no_of_trades) AS no_of_trades,
+            argMin(open_liquidity, datetime) AS open_liquidity,
+            max(high_liquidity) AS high_liquidity,
+            min(low_liquidity) AS low_liquidity,
+            argMax(close_liquidity, datetime) AS close_liquidity,
+            round(sum(liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(maker_volume) AS maker_volume,
+            round(sum(maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
                 *,
-                toDateTime({kline_size} * intDiv(toUnixTimestamp(datetime), {kline_size})) AS kline_datetime
+                toDateTime({kline_size_seconds} * intDiv(toUnixTimestamp(datetime), {kline_size_seconds})) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')
               AND datetime < toDateTime('{end_date_limit}')
@@ -109,17 +118,17 @@ def _origo_trades_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_15m_30m_2h_sensors_target_origo_spot_trades_materialization(
+def test_publish_time_kline_sensors_target_origo_spot_kline_materialization(
     origo_definitions_module: object,
 ) -> None:
     for case in KLINE_CASES:
         sensor_name = case[5]
         sensor_def = getattr(origo_definitions_module, sensor_name)
 
-        assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
+        assert sensor_def.asset_key == AssetKey('refresh_binance_spot_klines_origo')
 
 
-def test_publish_15m_30m_2h_snapshots_read_origo_spot_trades_with_shared_query(
+def test_publish_time_kline_snapshots_read_origo_spot_klines_projection(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -181,21 +190,25 @@ def test_publish_15m_30m_2h_snapshots_read_origo_spot_trades_with_shared_query(
         uploaded.clear()
         captured_query.clear()
 
-        def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+        def recording_get_binance_spot_klines_from_1m_projection(
+            **kwargs: object,
+        ) -> pl.DataFrame:
             captured_query.update(kwargs)
             database_name = kwargs.get('database_name')
             table_name = kwargs.get('table_name')
+            kline_size_seconds = kwargs.get('kline_size_seconds')
             start_date_limit = kwargs.get('start_date_limit')
             end_date_limit = kwargs.get('end_date_limit')
 
             assert database_name == ORIGO_DATABASE
-            assert table_name == 'binance_daily_spot_trades'
+            assert table_name == 'binance_spot_klines'
+            assert isinstance(kline_size_seconds, int)
             assert isinstance(start_date_limit, str)
             assert isinstance(end_date_limit, str)
 
-            return _origo_trades_kline_dataframe(
+            return _origo_projection_kline_dataframe(
                 query_origo,
-                kline_size=kline_size,
+                kline_size_seconds=kline_size_seconds,
                 database_name=database_name,
                 table_name=table_name,
                 start_date_limit=start_date_limit,
@@ -204,8 +217,8 @@ def test_publish_15m_30m_2h_snapshots_read_origo_spot_trades_with_shared_query(
 
         monkeypatch.setattr(
             publish_helper_module,
-            'get_binance_spot_klines',
-            recording_get_binance_spot_klines,
+            '_get_binance_spot_klines_from_1m_projection',
+            recording_get_binance_spot_klines_from_1m_projection,
         )
 
         publish_module = importlib.import_module(module_path)
@@ -232,12 +245,11 @@ def test_publish_15m_30m_2h_snapshots_read_origo_spot_trades_with_shared_query(
         assert metadata['row_count'] == parquet.height
         assert parquet.columns == KLINE_EXPORT_COLUMNS
         assert captured_query == {
-            'kline_size': kline_size,
+            'kline_size_seconds': kline_size,
             'start_date_limit': '2020-01-01 00:00:00',
             'end_date_limit': '2024-01-02 00:00:00',
-            'table_name': 'binance_daily_spot_trades',
+            'table_name': 'binance_spot_klines',
             'database_name': 'origo',
-            'include_quantiles': False,
         }
         assert (
             uploaded['commit_message']
@@ -246,4 +258,4 @@ def test_publish_15m_30m_2h_snapshots_read_origo_spot_trades_with_shared_query(
         assert uploaded['delete_patterns'] == [f'{file_prefix}*.parquet']
         assert metadata['file_name'] == f'{file_prefix}20240101.parquet'
         assert f'{resolution_label} resolution' in readme
-        assert 'origo.binance_daily_spot_trades' in readme
+        assert 'origo.binance_spot_klines' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py
@@ -78,34 +78,50 @@ def _origo_projection_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(open, datetime) AS open,
-            max(high) AS high,
-            min(low) AS low,
-            argMax(close, datetime) AS close,
-            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            argMin(source_open, source_datetime) AS open,
+            max(source_high) AS high,
+            min(source_low) AS low,
+            argMax(source_close, source_datetime) AS close,
+            round(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 5) AS mean,
             round(
                 sqrt(
                     greatest(
-                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
-                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
                         0
                     )
                 ),
                 6
             ) AS std,
-            round(sumKahan(volume), 9) AS volume,
-            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
-            sum(no_of_trades) AS no_of_trades,
-            argMin(open_liquidity, datetime) AS open_liquidity,
-            max(high_liquidity) AS high_liquidity,
-            min(low_liquidity) AS low_liquidity,
-            argMax(close_liquidity, datetime) AS close_liquidity,
-            round(sum(liquidity_sum), 1) AS liquidity_sum,
-            sumKahan(maker_volume) AS maker_volume,
-            round(sum(maker_liquidity), 1) AS maker_liquidity
+            round(sumKahan(source_volume), 9) AS volume,
+            sum(source_no_of_trades * source_maker_ratio) / sum(source_no_of_trades) AS maker_ratio,
+            sum(source_no_of_trades) AS no_of_trades,
+            argMin(source_open_liquidity, source_datetime) AS open_liquidity,
+            max(source_high_liquidity) AS high_liquidity,
+            min(source_low_liquidity) AS low_liquidity,
+            argMax(source_close_liquidity, source_datetime) AS close_liquidity,
+            round(sum(source_liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(source_maker_volume) AS maker_volume,
+            round(sum(source_maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
-                *,
+                datetime AS source_datetime,
+                open AS source_open,
+                high AS source_high,
+                low AS source_low,
+                close AS source_close,
+                mean AS source_mean,
+                std AS source_std,
+                volume AS source_volume,
+                maker_ratio AS source_maker_ratio,
+                no_of_trades AS source_no_of_trades,
+                open_liquidity AS source_open_liquidity,
+                high_liquidity AS source_high_liquidity,
+                low_liquidity AS source_low_liquidity,
+                close_liquidity AS source_close_liquidity,
+                liquidity_sum AS source_liquidity_sum,
+                maker_volume AS source_maker_volume,
+                maker_liquidity AS source_maker_liquidity,
                 toDateTime({kline_size_seconds} * intDiv(toUnixTimestamp(datetime), {kline_size_seconds})) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -85,12 +85,97 @@ def _origo_projection_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
+def _origo_raw_kline_dataframe(
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+    *,
+    kline_size_seconds: int,
+    start_date_limit: str,
+    end_date_limit: str,
+) -> pl.DataFrame:
+    raw_columns = ['datetime_ms', *KLINE_EXPORT_COLUMNS[1:]]
+    rows = query_origo(
+        f"""
+        SELECT
+            toUnixTimestamp(kline_datetime) * 1000 AS datetime_ms,
+            argMin(price, trade_id) AS open,
+            max(price) AS high,
+            min(price) AS low,
+            argMax(price, trade_id) AS close,
+            round(avg(price), 5) AS mean,
+            round(stddevPopStable(price), 6) AS std,
+            round(sumKahan(quantity), 9) AS volume,
+            avg(is_buyer_maker) AS maker_ratio,
+            count() AS no_of_trades,
+            argMin(price * quantity, trade_id) AS open_liquidity,
+            max(price * quantity) AS high_liquidity,
+            min(price * quantity) AS low_liquidity,
+            argMax(price * quantity, trade_id) AS close_liquidity,
+            round(sum(price * quantity), 1) AS liquidity_sum,
+            sumKahan(is_buyer_maker * quantity) AS maker_volume,
+            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+        FROM (
+            SELECT
+                *,
+                toDateTime({kline_size_seconds} * intDiv(toUnixTimestamp(datetime), {kline_size_seconds})) AS kline_datetime
+            FROM {ORIGO_DATABASE}.binance_daily_spot_trades
+            WHERE datetime >= toDateTime('{start_date_limit}')
+              AND datetime < toDateTime('{end_date_limit}')
+        )
+        GROUP BY kline_datetime
+        ORDER BY kline_datetime
+        """
+    )
+    return (
+        pl.DataFrame(rows, schema=raw_columns, orient='row')
+        .with_columns(
+            pl.col('datetime_ms').cast(pl.Datetime('ms', time_zone='UTC')).alias('datetime')
+        )
+        .select(KLINE_EXPORT_COLUMNS)
+    )
+
+
 def test_publish_sensor_targets_origo_spot_kline_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = origo_definitions_module.publish_binance_spot_klines_to_huggingface_sensor
 
     assert sensor_def.asset_key == AssetKey('refresh_binance_spot_klines_origo')
+
+
+def test_one_minute_projection_helper_matches_raw_trade_export_values(
+    materialize_binance_spot_data_source_assets: Callable[..., object],
+    query_origo: Callable[[str], list[tuple[object, ...]]],
+) -> None:
+    partition_key = '2024-01-01'
+    start_date_limit = '2024-01-01 00:00:00'
+    end_date_limit = '2024-01-02 00:00:00'
+
+    result = materialize_binance_spot_data_source_assets(partition_key=partition_key)
+    assert getattr(result, 'success') is True
+
+    publish_helper_module = importlib.import_module(
+        'tdw_control_plane.utils.publish_binance_spot_kline_snapshot_to_huggingface'
+    )
+    projection_helper = getattr(
+        publish_helper_module,
+        '_get_binance_spot_klines_from_1m_projection',
+    )
+
+    actual = projection_helper(
+        kline_size_seconds=60,
+        start_date_limit=start_date_limit,
+        end_date_limit=end_date_limit,
+        table_name='binance_spot_klines',
+        database_name=ORIGO_DATABASE,
+    )
+    expected = _origo_raw_kline_dataframe(
+        query_origo,
+        kline_size_seconds=60,
+        start_date_limit=start_date_limit,
+        end_date_limit=end_date_limit,
+    )
+
+    assert actual.rows() == expected.rows()
 
 
 def test_publish_snapshot_reads_origo_spot_klines_projection(

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -32,9 +32,10 @@ KLINE_EXPORT_COLUMNS = [
 ]
 
 
-def _origo_trades_kline_dataframe(
+def _origo_projection_kline_dataframe(
     query_origo: Callable[[str], list[tuple[object, ...]]],
     *,
+    kline_size_seconds: int,
     database_name: str,
     table_name: str,
     start_date_limit: str,
@@ -44,26 +45,35 @@ def _origo_trades_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(price, trade_id) AS open,
-            max(price) AS high,
-            min(price) AS low,
-            argMax(price, trade_id) AS close,
-            round(avg(price), 5) AS mean,
-            round(stddevPopStable(price), 6) AS std,
-            round(sumKahan(quantity), 9) AS volume,
-            avg(is_buyer_maker) AS maker_ratio,
-            count() AS no_of_trades,
-            argMin(price * quantity, trade_id) AS open_liquidity,
-            max(price * quantity) AS high_liquidity,
-            min(price * quantity) AS low_liquidity,
-            argMax(price * quantity, trade_id) AS close_liquidity,
-            round(sum(price * quantity), 1) AS liquidity_sum,
-            sumKahan(is_buyer_maker * quantity) AS maker_volume,
-            round(sum(is_buyer_maker * price * quantity), 1) AS maker_liquidity
+            argMin(open, datetime) AS open,
+            max(high) AS high,
+            min(low) AS low,
+            argMax(close, datetime) AS close,
+            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            round(
+                sqrt(
+                    greatest(
+                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
+                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        0
+                    )
+                ),
+                6
+            ) AS std,
+            round(sumKahan(volume), 9) AS volume,
+            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
+            sum(no_of_trades) AS no_of_trades,
+            argMin(open_liquidity, datetime) AS open_liquidity,
+            max(high_liquidity) AS high_liquidity,
+            min(low_liquidity) AS low_liquidity,
+            argMax(close_liquidity, datetime) AS close_liquidity,
+            round(sum(liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(maker_volume) AS maker_volume,
+            round(sum(maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
                 *,
-                toDateTime(60 * intDiv(toUnixTimestamp(datetime), 60)) AS kline_datetime
+                toDateTime({kline_size_seconds} * intDiv(toUnixTimestamp(datetime), {kline_size_seconds})) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')
               AND datetime < toDateTime('{end_date_limit}')
@@ -75,15 +85,15 @@ def _origo_trades_kline_dataframe(
     return pl.DataFrame(rows, schema=KLINE_EXPORT_COLUMNS, orient='row')
 
 
-def test_publish_sensor_targets_origo_spot_trades_materialization(
+def test_publish_sensor_targets_origo_spot_kline_materialization(
     origo_definitions_module: object,
 ) -> None:
     sensor_def = origo_definitions_module.publish_binance_spot_klines_to_huggingface_sensor
 
-    assert sensor_def.asset_key == AssetKey('insert_daily_binance_spot_trades_to_origo')
+    assert sensor_def.asset_key == AssetKey('refresh_binance_spot_klines_origo')
 
 
-def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
+def test_publish_snapshot_reads_origo_spot_klines_projection(
     monkeypatch: pytest.MonkeyPatch,
     materialize_binance_spot_data_source_assets: Callable[..., object],
     query_origo: Callable[[str], list[tuple[object, ...]]],
@@ -130,20 +140,23 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
             uploaded['metadata'] = metadata
             uploaded['parquet'] = pl.read_parquet(folder / metadata['file_name'])
 
-    def recording_get_binance_spot_klines(**kwargs: object) -> pl.DataFrame:
+    def recording_get_binance_spot_klines_from_1m_projection(**kwargs: object) -> pl.DataFrame:
         captured_query.update(kwargs)
         database_name = kwargs.get('database_name')
         table_name = kwargs.get('table_name')
+        kline_size_seconds = kwargs.get('kline_size_seconds')
         start_date_limit = kwargs.get('start_date_limit')
         end_date_limit = kwargs.get('end_date_limit')
 
         assert database_name == ORIGO_DATABASE
-        assert table_name == 'binance_daily_spot_trades'
+        assert table_name == 'binance_spot_klines'
+        assert isinstance(kline_size_seconds, int)
         assert isinstance(start_date_limit, str)
         assert isinstance(end_date_limit, str)
 
-        return _origo_trades_kline_dataframe(
+        return _origo_projection_kline_dataframe(
             query_origo,
+            kline_size_seconds=kline_size_seconds,
             database_name=database_name,
             table_name=table_name,
             start_date_limit=start_date_limit,
@@ -155,8 +168,8 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     monkeypatch.setattr(publish_helper_module, 'HfApi', RecordingHfApi)
     monkeypatch.setattr(
         publish_helper_module,
-        'get_binance_spot_klines',
-        recording_get_binance_spot_klines,
+        '_get_binance_spot_klines_from_1m_projection',
+        recording_get_binance_spot_klines_from_1m_projection,
     )
 
     publish_result = materialize(
@@ -179,11 +192,10 @@ def test_publish_snapshot_reads_origo_spot_trades_with_shared_query(
     assert metadata['row_count'] == parquet.height
     assert parquet.columns == KLINE_EXPORT_COLUMNS
     assert captured_query == {
-        'kline_size': 60,
+        'kline_size_seconds': 60,
         'start_date_limit': '2020-01-01 00:00:00',
         'end_date_limit': '2024-01-02 00:00:00',
-        'table_name': 'binance_daily_spot_trades',
+        'table_name': 'binance_spot_klines',
         'database_name': 'origo',
-        'include_quantiles': False,
     }
-    assert 'origo.binance_daily_spot_trades' in readme
+    assert 'origo.binance_spot_klines' in readme

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py
@@ -45,34 +45,50 @@ def _origo_projection_kline_dataframe(
         f"""
         SELECT
             kline_datetime AS datetime,
-            argMin(open, datetime) AS open,
-            max(high) AS high,
-            min(low) AS low,
-            argMax(close, datetime) AS close,
-            round(sum(no_of_trades * mean) / sum(no_of_trades), 5) AS mean,
+            argMin(source_open, source_datetime) AS open,
+            max(source_high) AS high,
+            min(source_low) AS low,
+            argMax(source_close, source_datetime) AS close,
+            round(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 5) AS mean,
             round(
                 sqrt(
                     greatest(
-                        sum(no_of_trades * ((std * std) + (mean * mean))) / sum(no_of_trades)
-                        - pow(sum(no_of_trades * mean) / sum(no_of_trades), 2),
+                        sum(source_no_of_trades * ((source_std * source_std) + (source_mean * source_mean))) / sum(source_no_of_trades)
+                        - pow(sum(source_no_of_trades * source_mean) / sum(source_no_of_trades), 2),
                         0
                     )
                 ),
                 6
             ) AS std,
-            round(sumKahan(volume), 9) AS volume,
-            sum(no_of_trades * maker_ratio) / sum(no_of_trades) AS maker_ratio,
-            sum(no_of_trades) AS no_of_trades,
-            argMin(open_liquidity, datetime) AS open_liquidity,
-            max(high_liquidity) AS high_liquidity,
-            min(low_liquidity) AS low_liquidity,
-            argMax(close_liquidity, datetime) AS close_liquidity,
-            round(sum(liquidity_sum), 1) AS liquidity_sum,
-            sumKahan(maker_volume) AS maker_volume,
-            round(sum(maker_liquidity), 1) AS maker_liquidity
+            round(sumKahan(source_volume), 9) AS volume,
+            sum(source_no_of_trades * source_maker_ratio) / sum(source_no_of_trades) AS maker_ratio,
+            sum(source_no_of_trades) AS no_of_trades,
+            argMin(source_open_liquidity, source_datetime) AS open_liquidity,
+            max(source_high_liquidity) AS high_liquidity,
+            min(source_low_liquidity) AS low_liquidity,
+            argMax(source_close_liquidity, source_datetime) AS close_liquidity,
+            round(sum(source_liquidity_sum), 1) AS liquidity_sum,
+            sumKahan(source_maker_volume) AS maker_volume,
+            round(sum(source_maker_liquidity), 1) AS maker_liquidity
         FROM (
             SELECT
-                *,
+                datetime AS source_datetime,
+                open AS source_open,
+                high AS source_high,
+                low AS source_low,
+                close AS source_close,
+                mean AS source_mean,
+                std AS source_std,
+                volume AS source_volume,
+                maker_ratio AS source_maker_ratio,
+                no_of_trades AS source_no_of_trades,
+                open_liquidity AS source_open_liquidity,
+                high_liquidity AS source_high_liquidity,
+                low_liquidity AS source_low_liquidity,
+                close_liquidity AS source_close_liquidity,
+                liquidity_sum AS source_liquidity_sum,
+                maker_volume AS source_maker_volume,
+                maker_liquidity AS source_maker_liquidity,
                 toDateTime({kline_size_seconds} * intDiv(toUnixTimestamp(datetime), {kline_size_seconds})) AS kline_datetime
             FROM {database_name}.{table_name}
             WHERE datetime >= toDateTime('{start_date_limit}')


### PR DESCRIPTION
## Summary
- Route Hugging Face spot time-kline exports through `origo.binance_spot_klines`.
- Move the six time-kline publish sensors to `refresh_binance_spot_klines_origo`.
- Keep HF file names, repos, metadata shape, and exported columns unchanged.

Closes #226

## Validation
- `ruff check tools tests/tools`
- `ruff check --fix tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py`
- `/tmp/tdw-control-plane-venv/bin/python -m compileall tdw_control_plane tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py`
- `pyright --pythonpath /tmp/tdw-control-plane-venv/bin/python tdw_control_plane/utils/publish_binance_spot_kline_snapshot_to_huggingface.py`
- fake-client projection helper check against `origo.binance_spot_klines`
- `/tmp/tdw-control-plane-venv/bin/python -m pytest --collect-only tests/origo_source_native/test_publish_binance_spot_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_additional_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_1h_klines_to_huggingface.py tests/origo_source_native/test_publish_binance_spot_4h_klines_to_huggingface.py -q`

## Local Blocker
- Full Origo pytest execution is blocked locally because Docker daemon is not running: `connect: no such file or directory` for `/Users/mikkokotila/.docker/run/docker.sock`.
