### PR TITLE
fix(huggingface): preserve dollar kline export timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.16.1 on June 4, 2026
+- Fix Binance spot dollar-kline Hugging Face exports collapsing every timestamp to ~1970 under polars >=1.40 by emitting millisecond-precision DateTime64 so the Arrow round-trip preserves the real dates.
+
 # v1.16.0 on June 4, 2026
 - Add a 10-minute stateless job mirroring the 12 Binance spot kline series to monthly Parquet files on a local mount.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.16.0"
+version = "1.16.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/utils/publish_binance_spot_dollar_kline_snapshot_to_huggingface.py
+++ b/tdw_control_plane/utils/publish_binance_spot_dollar_kline_snapshot_to_huggingface.py
@@ -173,8 +173,12 @@ def _get_binance_spot_dollar_klines(
         arrow_table = client.query_arrow(
             f"""
             SELECT
-                min(source_start_datetime) AS start_datetime,
-                max(source_end_datetime) AS end_datetime,
+                -- toDateTime64(_, 3): emit ms-precision so polars >=1.40 from_arrow keeps the
+                -- value. A plain min()/max() on these DateTime columns arrives as epoch seconds
+                -- and the Datetime("ms") cast below would reinterpret it as ms, collapsing every
+                -- timestamp to ~1970 (the same guard dollar_month uses in binance_spot_kline_rollups).
+                toDateTime64(min(source_start_datetime), 3) AS start_datetime,
+                toDateTime64(max(source_end_datetime), 3) AS end_datetime,
                 target_dollar_bar_id AS dollar_bar_id,
                 argMin(source_open, tuple(source_start_datetime, source_dollar_bar_id)) AS open,
                 max(source_high) AS high,

--- a/tests/origo_source_native/test_publish_binance_spot_dollar_klines_to_huggingface.py
+++ b/tests/origo_source_native/test_publish_binance_spot_dollar_klines_to_huggingface.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import polars as pl
@@ -203,6 +203,40 @@ def test_dollar_kline_query_rejects_unsafe_sql_inputs(
             table_name='binance_spot_dollar_klines',
             database_name='origo',
         )
+
+
+def test_dollar_kline_export_preserves_clickhouse_timestamp_scale(
+    materialize_binance_spot_dollar_klines_assets: Callable[..., object],
+) -> None:
+    """Regression for the polars >=1.40 timestamp collapse.
+
+    ClickHouse ``DateTime`` columns come back from clickhouse-connect as second-precision
+    Arrow timestamps that ``pl.from_arrow`` no longer rescales on polars >=1.40, so a plain
+    ``min()``/``max()`` arrives as epoch seconds and the export's ``cast(Datetime("ms"))``
+    reinterprets them as milliseconds -- collapsing every dollar bar to ~1970-01-19. The
+    export emits ``toDateTime64(_, 3)`` so the real dates survive the arrow round-trip.
+    """
+    result = materialize_binance_spot_dollar_klines_assets(partition_key='2024-01-01')
+    assert result.success
+
+    publish_helper_module = importlib.import_module(
+        'tdw_control_plane.utils.publish_binance_spot_dollar_kline_snapshot_to_huggingface'
+    )
+    data = publish_helper_module._get_binance_spot_dollar_klines(
+        dollar_size=1_000_000.0,
+        start_date_limit='2020-01-01 00:00:00',
+        end_date_limit='2024-02-01 00:00:00',
+        table_name='binance_spot_dollar_klines',
+        database_name=ORIGO_DATABASE,
+    )
+
+    assert data.height > 0
+    assert data['start_datetime'].dtype == pl.Datetime('ms', time_zone='UTC')
+    assert data['end_datetime'].dtype == pl.Datetime('ms', time_zone='UTC')
+    # The fixture covers 2024-01-01 only; the bug would have parked every timestamp on
+    # ~1970-01-19. Assert the real day survived rather than merely "not epoch".
+    assert data['start_datetime'].min() >= datetime(2024, 1, 1, tzinfo=UTC)
+    assert data['end_datetime'].max() < datetime(2024, 1, 2, tzinfo=UTC)
 
 
 def _origo_dollar_klines_dataframe(

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_mount.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_mount.py
@@ -182,10 +182,11 @@ def test_dollar_month_rollup_matches_hf_day_scoped(origo_assets: dict[str, Any])
     )
 
     assert actual.height > 0
-    # Values must match the HF day-scoped aggregation exactly. Datetimes are compared by range,
-    # not equality: the HF arrow path mis-scales second-precision timestamps under polars >=1.40,
-    # so dollar_month keeps the columns in millisecond precision (correct) instead.
-    assert_frame_equal(actual.drop(_DATETIME_COLUMNS), expected.drop(_DATETIME_COLUMNS))
+    # dollar_month and the HF dollar export now share identical timestamp handling
+    # (toDateTime64(_, 3) -> Datetime("ms", "UTC")), so the full frames match -- including the
+    # datetime columns that previously had to be dropped while the HF export mis-scaled
+    # second-precision timestamps to ~1970 under polars >=1.40.
+    assert_frame_equal(actual, expected)
     assert JANUARY_2024 <= actual["start_datetime"].min() < FEBRUARY_2024
     assert JANUARY_2024 <= actual["end_datetime"].max() < FEBRUARY_2024
 


### PR DESCRIPTION
Closes #234

## Summary
The Hugging Face dollar-kline export (`_get_binance_spot_dollar_klines`, all six `vaquum/binance_btcusdt_*_dollar_klines` series) selected `min(start_datetime)` / `max(end_datetime)` from second-precision `DateTime` columns. Under **polars ≥1.40**, `pl.from_arrow` no longer rescales second-precision ClickHouse timestamps, so those values arrive as **epoch seconds** and the export's `.cast(Datetime("ms"))` reinterprets them as **milliseconds** — collapsing every dollar bar to **~1970-01-19**. (The time export dodges this with `(col.cast(Int64) * 1000)`; the dollar export had no compensation.)

**Fix:** wrap both timestamp aggregates in `toDateTime64(_, 3)` so ClickHouse emits millisecond precision over the wire — the same handling the `dollar_month` mirror twin (added in #232) already uses. The polars cast tail is unchanged and is now value-preserving.

## Validation (local, ephemeral ClickHouse via the conftest harness, polars 1.41.2)
- `pytest tests/origo_source_native` → **101 passed** (incl. the new regression test).
- **A/B proof the guard catches it:** reverting the `toDateTime64` wrap makes both `test_dollar_kline_export_preserves_clickhouse_timestamp_scale` and `test_dollar_month_rollup_matches_hf_day_scoped` fail; restoring it makes them pass.
- New `test_dollar_kline_export_preserves_clickhouse_timestamp_scale` runs the real arrow path and asserts the 2024 dates survive (not merely "not epoch").
- Tightened `test_dollar_month_rollup_matches_hf_day_scoped` from "drop datetimes" to full-frame equality now that both paths agree.
- Audited every other `Datetime` cast site (time export, both rollups, `asset_insert_to_tdw`) — the dollar export was the only bug.

## Deploy / remediation
No schema or job change. After deploy, the six live dollar files keep their 1970 timestamps only until the next publish — the daily dollar jobs fully replace each file via `delete_patterns`, so they self-heal on the next ~04:01 UTC run (or a manual Dagit trigger). No backfill needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
