### PR TITLE
feat(origo): versioned mmap-ready Arrow bar store from the parquet mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ plugins/
 # Local Parquet mirror (dev bind mount)
 parquet_data/
 
+# Local Arrow bar store (dev bind mount)
+arrow_data/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.17.0 on June 5, 2026
+- Add a versioned, mmap-ready Arrow bar store: a run-status sensor rebuilds every series into a single-record-batch, uncompressed Arrow IPC file under LOCAL_ARROW_DIR (default /opt/arrow) whenever the Parquet mirror job succeeds. Measures are carried verbatim at full precision (no downcast), so the store stays bit-for-bit reproducible against the mirror; it is published with an atomic `latest` symlink swap, content-hash versioning, a monotonic freshness guard, and a few retained prior versions so in-flight mmap and pinned-version reads never break mid-swap.
+- Run the Binance spot Parquet mirror every minute (was every 10 minutes) so the mirror — and the Arrow bar store it triggers on completion — track the 1-minute ClickHouse latest projections.
+
 # v1.16.1 on June 4, 2026
 - Fix Binance spot dollar-kline Hugging Face exports collapsing every timestamp to ~1970 under polars >=1.40 by emitting millisecond-precision DateTime64 so the Arrow round-trip preserves the real dates.
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -50,6 +50,7 @@ services:
     volumes:
       - dagster-instance:/opt/dagster-instance
       - tdw-parquet:/opt/parquet
+      - tdw-arrow:/opt/arrow
     depends_on:
       clickhouse:
         condition: service_healthy
@@ -70,3 +71,9 @@ volumes:
     # (rebuildable via the backfill job), so it does not need the external protection
     # the clickhouse-data / dagster-instance volumes have.
     name: tdw-control-plane_parquet
+  tdw-arrow:
+    # Compose-managed, same rationale as tdw-parquet: holds the versioned Arrow bar
+    # store, which is fully reproducible from the Parquet mirror (re-materialize the
+    # build_bar_store_arrow asset). Dagster is the sole writer; consumers mount this
+    # volume read-only by the pinned name.
+    name: tdw-control-plane_arrow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - .:/opt/app
       - dagster-instance:/opt/dagster-instance
       - ./parquet_data:/opt/parquet
+      - ./arrow_data:/opt/arrow
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.16.1"
+version = "1.17.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/build_bar_store_arrow.py
+++ b/tdw_control_plane/assets/build_bar_store_arrow.py
@@ -1,0 +1,371 @@
+"""Project the 12 Parquet mirror series into a versioned, mmap-ready Arrow bar store.
+
+The Parquet mirror (``publish_binance_spot_klines_to_mount``) keeps a tree of
+monthly files under ``LOCAL_PARQUET_DIR``. This asset reads one whole series,
+shapes it into a single uncompressed Arrow IPC (Feather v2) record batch, and
+publishes it under ``LOCAL_ARROW_DIR`` so a consumer can ``mmap`` the file and
+``searchsorted`` over a zero-copy ``ts`` view. The shaping contract is:
+
+1. read every monthly Parquet file for the series;
+2. sort ascending by ``ts`` (Int64 nanoseconds, UTC) and drop duplicate ``ts``
+   so the index is strictly increasing (the searchsorted correctness contract);
+3. carry every measure column verbatim at full precision -- no downcast. The store
+   is a re-layout of the mirror, not a lossy projection, so it stays bit-for-bit
+   reproducible against the Parquet (and thus ClickHouse / Hugging Face). The only
+   derived columns are ``ts`` / ``start_ts``, an exact ms->ns re-encode of the bar
+   datetimes;
+4. combine to a single record batch (``rechunk``) so the consumer sees one chunk;
+5. write Feather v2 / Arrow IPC, uncompressed (mmap needs raw bytes).
+
+Publishing is atomic and never in place: the bytes land in a same-dir temp file
+that is fsynced and ``os.replace``-d into ``<series>.<version>.arrow``, then a
+fresh relative symlink is ``os.replace``-d onto ``latest.arrow`` last. The
+version is the content hash, so a byte-identical rebuild is a no-op (no churn)
+and a pinned version is reproducible. A per-series lock serializes the
+check-publish-flip-reap critical section, a monotonic freshness guard keeps a
+slow out-of-order run from flipping ``latest`` back to staler data, and retention
+keeps the last ``RETENTION_KEEP`` versions, reaping older ones only after a grace
+window so in-flight ``mmap`` and pinned-version reads never ``ENOENT`` mid-swap.
+
+Dagster (this asset) is the sole writer to ``LOCAL_ARROW_DIR``; consumers
+bind-mount it read-only.
+"""
+
+import fcntl
+import hashlib
+import io
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+from dagster import AssetExecutionContext, Config, RunRequest, StaticPartitionsDefinition, asset
+
+from tdw_control_plane.assets.publish_binance_spot_klines_to_mount import (
+    DEFAULT_MOUNT_DIR,
+    SPECS,
+    MountKlineSpec,
+)
+
+DEFAULT_ARROW_DIR = "/opt/arrow"
+LATEST_NAME = "latest.arrow"
+# How many published versions to retain per series, and how long a superseded
+# version must linger before it can be reaped. >= 3 versions and a ~10-minute
+# grace keep in-flight mmap / pinned-version reads from racing a reap.
+RETENTION_KEEP = 3
+REAP_GRACE_SECONDS = 600
+ORPHAN_TMP_MAX_AGE_SECONDS = 3600
+# Truncated SHA-256 of the IPC payload; 16 hex chars (64 bits) is collision-safe
+# for a per-series version line that turns over a few times an hour.
+VERSION_HEX = 16
+
+# Measure columns shared by both families, carried verbatim from the Parquet mirror
+# at their native dtype (Float64 / Int64) -- no downcast, so the store is bit-for-bit
+# reproducible against the mirror. Canonical order matches the mirror / HF exports.
+_VALUE_COLUMNS: tuple[str, ...] = (
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "volume",
+    "maker_ratio",
+    "no_of_trades",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity",
+)
+# Output column order. ``ts`` is the canonical index (datetime for time bars,
+# end_datetime for dollar bars); dollar bars also carry their open time and id.
+_TIME_OUTPUT_COLUMNS: tuple[str, ...] = ("ts", *_VALUE_COLUMNS)
+_DOLLAR_OUTPUT_COLUMNS: tuple[str, ...] = ("ts", "start_ts", "dollar_bar_id", *_VALUE_COLUMNS)
+
+
+@dataclass(frozen=True)
+class BarSeriesBuild:
+    """The shaped frame plus provenance counts surfaced by the asset."""
+
+    df: pl.DataFrame
+    source_rows: int
+    dropped_duplicate_ts: int
+
+
+@dataclass(frozen=True)
+class PublishOutcome:
+    status: str  # "published" | "skipped_unchanged" | "skipped_not_newer" | "skipped_empty"
+    version: str | None
+    reaped: tuple[str, ...] = ()
+
+
+BAR_STORE_SERIES: tuple[str, ...] = tuple(spec.name for spec in SPECS)
+BAR_STORE_PARTITIONS = StaticPartitionsDefinition(list(BAR_STORE_SERIES))
+
+
+class BarStoreConfig(Config):
+    # Shape and report without writing; useful to inspect a series from Dagit.
+    dry_run: bool = False
+
+
+def parquet_source_root() -> Path:
+    return Path(os.environ.get("LOCAL_PARQUET_DIR", DEFAULT_MOUNT_DIR))
+
+
+def arrow_store_root() -> Path:
+    return Path(os.environ.get("LOCAL_ARROW_DIR", DEFAULT_ARROW_DIR))
+
+
+def series_store_dir(series: str) -> Path:
+    return arrow_store_root() / series
+
+
+def spec_for_series(series: str) -> MountKlineSpec:
+    for spec in SPECS:
+        if spec.name == series:
+            return spec
+    raise ValueError(f"Unknown bar-store series: {series}")
+
+
+def series_source_files(spec: MountKlineSpec, parquet_root: Path) -> list[Path]:
+    base = parquet_root / spec.sub_path
+    if not base.exists():
+        return []
+    return sorted(base.glob("**/*.parquet"))
+
+
+def _output_columns(family: str) -> tuple[str, ...]:
+    return _TIME_OUTPUT_COLUMNS if family == "time" else _DOLLAR_OUTPUT_COLUMNS
+
+
+def build_series_frame(spec: MountKlineSpec, parquet_root: Path) -> BarSeriesBuild:
+    """Read, shape, sort, dedupe, downcast, and single-batch one series.
+
+    ``ts`` is Int64 nanoseconds (UTC): the bar ``datetime`` for time series, the
+    bar ``end_datetime`` for dollar series. Measure columns are carried verbatim
+    (no downcast) so the frame is bit-for-bit reproducible against the Parquet.
+    Duplicate ``ts`` rows (rare; the mirror is already grouped) keep the last
+    occurrence so the index is strictly increasing for searchsorted."""
+    files = series_source_files(spec, parquet_root)
+    if not files:
+        return BarSeriesBuild(pl.DataFrame(), 0, 0)
+
+    raw = pl.read_parquet([str(path) for path in files])
+    source_rows = raw.height
+
+    ts_source = "datetime" if spec.family == "time" else "end_datetime"
+    exprs: list[pl.Expr] = [pl.col(ts_source).dt.epoch(time_unit="ns").cast(pl.Int64).alias("ts")]
+    if spec.family == "dollar":
+        exprs.append(pl.col("start_datetime").dt.epoch(time_unit="ns").cast(pl.Int64).alias("start_ts"))
+        exprs.append(pl.col("dollar_bar_id"))
+    exprs.extend(pl.col(name) for name in _VALUE_COLUMNS)
+
+    shaped = raw.select(exprs).select(_output_columns(spec.family)).sort("ts")
+    deduped = shaped.unique(subset=["ts"], keep="last").sort("ts")
+    dropped = shaped.height - deduped.height
+    return BarSeriesBuild(deduped.rechunk(), source_rows, dropped)
+
+
+def _series_max_ts(frame: pl.DataFrame) -> int | None:
+    value = frame.get_column("ts").max()
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    raise RuntimeError(f"Unexpected ts max type {type(value)!r}")
+
+
+def _existing_max_ts(path: Path) -> int | None:
+    frame = pl.read_ipc(path, columns=["ts"], memory_map=True)
+    return _series_max_ts(frame)
+
+
+def _link_version(latest: Path) -> str | None:
+    """Parse the version (content hash) out of the ``latest`` symlink target."""
+    if not latest.is_symlink():
+        return None
+    name = os.path.basename(os.readlink(latest))
+    if not name.endswith(".arrow"):
+        return None
+    parts = name[: -len(".arrow")].split(".")
+    return parts[-1] if len(parts) >= 2 else None
+
+
+def _fsync_file(handle: io.BufferedWriter) -> None:
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+def _atomic_write_bytes(target: Path, payload: bytes) -> None:
+    tmp = target.parent / f".{target.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+    with open(tmp, "wb") as handle:
+        handle.write(payload)
+        _fsync_file(handle)
+    os.replace(tmp, target)
+
+
+def _atomic_swap_symlink(latest: Path, relative_target: str) -> None:
+    tmp = latest.parent / f".{LATEST_NAME}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+    tmp.unlink(missing_ok=True)
+    os.symlink(relative_target, tmp)
+    os.replace(tmp, latest)
+
+
+def _clear_orphan_tmp(directory: Path, now: float) -> None:
+    cutoff = now - ORPHAN_TMP_MAX_AGE_SECONDS
+    for orphan in directory.glob(".*.tmp-*"):
+        if orphan.stat().st_mtime < cutoff:
+            orphan.unlink(missing_ok=True)
+
+
+def reap_old_versions(
+    directory: Path, series: str, *, keep: int, grace_seconds: float, now: float
+) -> tuple[str, ...]:
+    """Keep the newest ``keep`` versions by mtime; reap older ones, but only once
+    they are older than ``grace_seconds`` and never the one ``latest`` points to."""
+    protected = _link_version(directory / LATEST_NAME)
+    versions = [
+        path
+        for path in directory.glob(f"{series}.*.arrow")
+        if path.is_file() and not path.is_symlink()
+    ]
+    versions.sort(key=lambda path: path.stat().st_mtime_ns, reverse=True)
+
+    reaped: list[str] = []
+    for index, path in enumerate(versions):
+        if index < keep:
+            continue
+        if protected is not None and path.name.endswith(f".{protected}.arrow"):
+            continue
+        if path.stat().st_mtime >= now - grace_seconds:
+            continue
+        path.unlink(missing_ok=True)
+        reaped.append(path.name)
+    return tuple(reaped)
+
+
+def _ipc_payload(df: pl.DataFrame) -> bytes:
+    sink = io.BytesIO()
+    df.write_ipc(sink, compression="uncompressed")
+    return sink.getvalue()
+
+
+def publish_series(series: str, build: BarSeriesBuild) -> PublishOutcome:
+    """Atomically publish the shaped series and flip ``latest`` to it.
+
+    Skips the write entirely when the content hash already is ``latest``
+    (no churn), and skips the flip when ``latest`` already holds fresher data
+    (a slow, out-of-order run must never regress freshness)."""
+    df = build.df
+    if df.height == 0:
+        return PublishOutcome("skipped_empty", None)
+
+    payload = _ipc_payload(df)
+    version = hashlib.sha256(payload).hexdigest()[:VERSION_HEX]
+    new_max = _series_max_ts(df)
+
+    directory = series_store_dir(series)
+    directory.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    _clear_orphan_tmp(directory, now)
+
+    target = directory / f"{series}.{version}.arrow"
+    latest = directory / LATEST_NAME
+
+    # Lock-free fast path: the sensor fired but the bytes are unchanged.
+    if _link_version(latest) == version and target.exists():
+        return PublishOutcome("skipped_unchanged", version)
+
+    if not target.exists():
+        _atomic_write_bytes(target, payload)
+
+    lock_path = directory / f".{series}.lock"
+    with open(lock_path, "w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if _link_version(latest) == version:
+            status = "skipped_unchanged"
+        else:
+            existing_max = _existing_max_ts(latest) if latest.is_symlink() else None
+            if existing_max is not None and new_max is not None and new_max < existing_max:
+                status = "skipped_not_newer"
+            else:
+                _atomic_swap_symlink(latest, target.name)
+                status = "published"
+        reaped = reap_old_versions(
+            directory, series, keep=RETENTION_KEEP, grace_seconds=REAP_GRACE_SECONDS, now=now
+        )
+    return PublishOutcome(status, version, reaped)
+
+
+def bar_store_partition_run_requests(source_run_id: str) -> list[RunRequest]:
+    """One RunRequest per series, run-keyed to the triggering mirror run so each
+    successful mirror tick rebuilds every series exactly once. Driven by the
+    bar_store_source_sensor when publish_binance_spot_klines_to_mount_job succeeds."""
+    return [
+        RunRequest(partition_key=series, run_key=f"{series}:{source_run_id}")
+        for series in BAR_STORE_SERIES
+    ]
+
+
+@asset(
+    name="build_bar_store_arrow",
+    partitions_def=BAR_STORE_PARTITIONS,
+    group_name="binance_bar_store",
+    description=(
+        "Projects one Parquet mirror series (partition = series, e.g. time_1m) into a "
+        "versioned, mmap-ready Arrow IPC file under LOCAL_ARROW_DIR (default "
+        f"{DEFAULT_ARROW_DIR}). Single uncompressed record batch, Int64-ns `ts` index, "
+        "measures carried verbatim at full precision (no downcast, bit-for-bit "
+        "reproducible vs the mirror), atomic `latest.arrow` symlink, content-hash "
+        f"versions, last {RETENTION_KEEP} retained. Triggered by bar_store_source_sensor "
+        "when the Parquet mirror job succeeds."
+    ),
+)
+def build_bar_store_arrow(
+    context: AssetExecutionContext, config: BarStoreConfig
+) -> dict[str, object]:
+    series = context.partition_key
+    spec = spec_for_series(series)
+    parquet_root = parquet_source_root()
+
+    build = build_series_frame(spec, parquet_root)
+    if build.df.height == 0:
+        context.log.warning(
+            f"{series}: no source Parquet under {parquet_root / spec.sub_path}; nothing to publish."
+        )
+        return {"status": "no_source", "series": series, "source_rows": build.source_rows}
+
+    if build.dropped_duplicate_ts > 0:
+        context.log.warning(
+            f"{series}: dropped {build.dropped_duplicate_ts} row(s) with duplicate ts to keep "
+            "the index strictly increasing."
+        )
+
+    if config.dry_run:
+        return {
+            "status": "dry_run",
+            "series": series,
+            "rows": build.df.height,
+            "source_rows": build.source_rows,
+        }
+
+    outcome = publish_series(series, build)
+    context.log.info(
+        f"{series}: {outcome.status} version={outcome.version} rows={build.df.height} "
+        f"reaped={len(outcome.reaped)}"
+    )
+    return {
+        "status": "success",
+        "series": series,
+        "rows": build.df.height,
+        "source_rows": build.source_rows,
+        "dropped_duplicate_ts": build.dropped_duplicate_ts,
+        "version": outcome.version,
+        "outcome": outcome.status,
+        "reaped": len(outcome.reaped),
+    }

--- a/tdw_control_plane/assets/build_bar_store_arrow.py
+++ b/tdw_control_plane/assets/build_bar_store_arrow.py
@@ -144,7 +144,7 @@ def _output_columns(family: str) -> tuple[str, ...]:
 
 
 def build_series_frame(spec: MountKlineSpec, parquet_root: Path) -> BarSeriesBuild:
-    """Read, shape, sort, dedupe, downcast, and single-batch one series.
+    """Read, shape, sort, dedupe, and single-batch one series at full precision.
 
     ``ts`` is Int64 nanoseconds (UTC): the bar ``datetime`` for time series, the
     bar ``end_datetime`` for dollar series. Measure columns are carried verbatim

--- a/tdw_control_plane/assets/build_bar_store_arrow.py
+++ b/tdw_control_plane/assets/build_bar_store_arrow.py
@@ -258,9 +258,11 @@ def _ipc_payload(df: pl.DataFrame) -> bytes:
 def publish_series(series: str, build: BarSeriesBuild) -> PublishOutcome:
     """Atomically publish the shaped series and flip ``latest`` to it.
 
-    Skips the write entirely when the content hash already is ``latest``
-    (no churn), and skips the flip when ``latest`` already holds fresher data
-    (a slow, out-of-order run must never regress freshness)."""
+    The version bytes are written (and ``latest`` flipped) only when this tick
+    actually publishes: an unchanged content hash is a no-op (no churn), and a
+    slow out-of-order tick whose data is staler than ``latest`` is skipped
+    without writing -- so a skipped tick never leaves an unreferenced version on
+    disk to steal a retention slot from a published one or churn disk."""
     df = build.df
     if df.height == 0:
         return PublishOutcome("skipped_empty", None)
@@ -281,9 +283,6 @@ def publish_series(series: str, build: BarSeriesBuild) -> PublishOutcome:
     if _link_version(latest) == version and target.exists():
         return PublishOutcome("skipped_unchanged", version)
 
-    if not target.exists():
-        _atomic_write_bytes(target, payload)
-
     lock_path = directory / f".{series}.lock"
     with open(lock_path, "w", encoding="utf-8") as lock_file:
         fcntl.flock(lock_file, fcntl.LOCK_EX)
@@ -294,6 +293,11 @@ def publish_series(series: str, build: BarSeriesBuild) -> PublishOutcome:
             if existing_max is not None and new_max is not None and new_max < existing_max:
                 status = "skipped_not_newer"
             else:
+                # Write the version file only when we are actually going to publish it,
+                # under the lock: a skipped (stale/unchanged) tick then never leaves an
+                # unreferenced version on disk to occupy a retention slot or churn disk.
+                if not target.exists():
+                    _atomic_write_bytes(target, payload)
                 _atomic_swap_symlink(latest, target.name)
                 status = "published"
         reaped = reap_old_versions(

--- a/tdw_control_plane/assets/publish_binance_spot_klines_to_mount.py
+++ b/tdw_control_plane/assets/publish_binance_spot_klines_to_mount.py
@@ -1,5 +1,5 @@
 """Mirror the 12 HF Binance spot kline series to monthly Parquet files on a
-local mount, refreshed every 10 minutes.
+local mount, refreshed every minute.
 
 Stateless: each tick rebuilds the open month(s) from the Origo projections and
 replaces the month file atomically. The filesystem is the only state. A

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -15,10 +15,14 @@ import requests
 from clickhouse_driver import Client as ClickhouseClient
 from dagster import (
     AssetKey,
+    DagsterRunStatus,
     DefaultScheduleStatus,
+    DefaultSensorStatus,
     Definitions,
     RunConfig,
     RunRequest,
+    RunStatusSensorContext,
+    RunStatusSensorDefinition,
     ScheduleDefinition,
     ScheduleEvaluationContext,
     SkipReason,
@@ -176,6 +180,10 @@ from .assets.publish_binance_spot_klines_to_mount import (
     MOUNT_EXPORT_ASSETS,
     SPECS as MOUNT_EXPORT_SPECS,
     MountExportConfig,
+)
+from .assets.build_bar_store_arrow import (
+    build_bar_store_arrow,
+    bar_store_partition_run_requests,
 )
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
@@ -433,9 +441,17 @@ backfill_binance_spot_klines_to_mount_job = define_asset_job(
 publish_binance_spot_klines_to_mount_schedule = ScheduleDefinition(
     name="publish_binance_spot_klines_to_mount_schedule",
     job=publish_binance_spot_klines_to_mount_job,
-    cron_schedule="*/10 * * * *",
+    cron_schedule="* * * * *",
     execution_timezone="UTC",
     default_status=DefaultScheduleStatus.RUNNING,
+)
+
+# Local Arrow Bar Store Jobs
+
+build_bar_store_arrow_job = define_asset_job(
+    name="build_bar_store_arrow_job",
+    selection=[build_bar_store_arrow],
+    executor_def=in_process_executor,
 )
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
@@ -969,6 +985,30 @@ def publish_binance_spot_240M_dollar_klines_to_huggingface_sensor(
     )
 
 
+def _bar_store_on_mirror_success(context: RunStatusSensorContext) -> list[RunRequest]:
+    """When the Parquet mirror job succeeds, rebuild every Arrow series.
+
+    Event-driven off the mirror job's completion (not a clock or a file poll):
+    each successful mirror tick fans out one Arrow run per series, run-keyed to
+    the mirror run so the same success is never acted on twice. The asset's
+    content-hash versioning still suppresses a republish when bytes are unchanged.
+    """
+    return bar_store_partition_run_requests(context.dagster_run.run_id)
+
+
+# Built as a RunStatusSensorDefinition (class) rather than the @run_status_sensor
+# decorator: the decorator factory is partially typed in the dagster stubs (would add a
+# pyright error), while the class constructor types cleanly.
+bar_store_source_sensor = RunStatusSensorDefinition(
+    name="bar_store_source_sensor",
+    run_status=DagsterRunStatus.SUCCESS,
+    run_status_sensor_fn=_bar_store_on_mirror_success,
+    monitored_jobs=[publish_binance_spot_klines_to_mount_job],
+    request_job=build_bar_store_arrow_job,
+    default_status=DefaultSensorStatus.RUNNING,
+)
+
+
 defs = Definitions(
     assets=[create_tdw_database,
             create_origo_database,
@@ -1020,6 +1060,7 @@ defs = Definitions(
             publish_binance_spot_120M_dollar_klines_to_huggingface,
             publish_binance_spot_240M_dollar_klines_to_huggingface,
             *MOUNT_EXPORT_ASSETS,
+            build_bar_store_arrow,
             cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
@@ -1058,8 +1099,9 @@ defs = Definitions(
         publish_binance_spot_60M_dollar_klines_to_huggingface_sensor,
         publish_binance_spot_120M_dollar_klines_to_huggingface_sensor,
         publish_binance_spot_240M_dollar_klines_to_huggingface_sensor,
+        bar_store_source_sensor,
     ],
-    
+
     jobs=[create_tdw_database_job,
           create_origo_database_job,
           create_binance_trades_table_job,
@@ -1101,6 +1143,7 @@ defs = Definitions(
           publish_binance_spot_240M_dollar_klines_to_huggingface_job,
           publish_binance_spot_klines_to_mount_job,
           backfill_binance_spot_klines_to_mount_job,
+          build_bar_store_arrow_job,
           roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,

--- a/tests/origo_source_native/test_build_bar_store_arrow.py
+++ b/tests/origo_source_native/test_build_bar_store_arrow.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pyarrow as pa
+import pyarrow.ipc as pa_ipc
+import pytest
+from polars.testing import assert_frame_equal
+
+# Importing the asset package reads CLICKHOUSE_PASSWORD at import time; this asset
+# itself never touches ClickHouse (it reads the Parquet mirror off disk), so the
+# tests below need no container -- the placeholder just lets collection succeed.
+os.environ.setdefault("CLICKHOUSE_PASSWORD", "import-guard")
+
+from tdw_control_plane.assets.build_bar_store_arrow import (  # noqa: E402
+    BAR_STORE_PARTITIONS,
+    BAR_STORE_SERIES,
+    LATEST_NAME,
+    REAP_GRACE_SECONDS,
+    RETENTION_KEEP,
+    arrow_store_root,
+    bar_store_partition_run_requests,
+    build_bar_store_arrow,
+    build_series_frame,
+    publish_series,
+    reap_old_versions,
+    series_store_dir,
+    spec_for_series,
+)
+from tdw_control_plane.assets.publish_binance_spot_klines_to_mount import (  # noqa: E402
+    MountKlineSpec,
+)
+
+# 2024-01-01T00:00:00Z in epoch-milliseconds; the mirror writes Datetime("ms", "UTC").
+BASE_MS = 1_704_067_200_000
+NS_PER_MS = 1_000_000
+
+_FLOAT_COLUMNS = (
+    "open",
+    "high",
+    "low",
+    "close",
+    "mean",
+    "std",
+    "volume",
+    "maker_ratio",
+    "open_liquidity",
+    "high_liquidity",
+    "low_liquidity",
+    "close_liquidity",
+    "liquidity_sum",
+    "maker_volume",
+    "maker_liquidity",
+)
+
+
+def _floats(n: int) -> dict[str, pl.Series]:
+    return {
+        name: pl.Series(name, [float(row) + index * 0.5 for row in range(n)], dtype=pl.Float64)
+        for index, name in enumerate(_FLOAT_COLUMNS)
+    }
+
+
+def _time_frame(datetimes_ms: list[int]) -> pl.DataFrame:
+    n = len(datetimes_ms)
+    columns: dict[str, pl.Series] = {
+        "datetime": pl.Series("datetime", datetimes_ms, dtype=pl.Int64).cast(
+            pl.Datetime("ms", time_zone="UTC")
+        ),
+        "no_of_trades": pl.Series("no_of_trades", [10 + row for row in range(n)], dtype=pl.Int64),
+        **_floats(n),
+    }
+    return pl.DataFrame(columns)
+
+
+def _dollar_frame(start_ms: list[int], end_ms: list[int], bar_ids: list[int]) -> pl.DataFrame:
+    n = len(start_ms)
+    columns: dict[str, pl.Series] = {
+        "start_datetime": pl.Series("start_datetime", start_ms, dtype=pl.Int64).cast(
+            pl.Datetime("ms", time_zone="UTC")
+        ),
+        "end_datetime": pl.Series("end_datetime", end_ms, dtype=pl.Int64).cast(
+            pl.Datetime("ms", time_zone="UTC")
+        ),
+        "dollar_bar_id": pl.Series("dollar_bar_id", bar_ids, dtype=pl.Int64),
+        "no_of_trades": pl.Series("no_of_trades", [10 + row for row in range(n)], dtype=pl.Int64),
+        **_floats(n),
+    }
+    return pl.DataFrame(columns)
+
+
+def _write_month(parquet_root: Path, spec: MountKlineSpec, df: pl.DataFrame, year: int, month: int) -> None:
+    path = parquet_root / spec.sub_path / f"{year:04d}" / f"{month:02d}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(path)
+
+
+def test_partitions_cover_twelve_series() -> None:
+    assert len(BAR_STORE_SERIES) == 12
+    assert set(BAR_STORE_PARTITIONS.get_partition_keys()) == set(BAR_STORE_SERIES)
+    assert "time_1m" in BAR_STORE_SERIES
+    assert "dollar_1M" in BAR_STORE_SERIES
+
+
+def test_build_time_frame_shapes_sorts_dedupes(tmp_path: Path) -> None:
+    spec = spec_for_series("time_1m")
+    # Month 1 is out of order; month 2 repeats BASE_MS+2m so the seam carries a duplicate ts.
+    _write_month(tmp_path, spec, _time_frame([BASE_MS + 120_000, BASE_MS, BASE_MS + 60_000]), 2024, 1)
+    _write_month(tmp_path, spec, _time_frame([BASE_MS + 120_000, BASE_MS + 180_000]), 2024, 2)
+
+    build = build_series_frame(spec, tmp_path)
+    df = build.df
+
+    assert df.columns[0] == "ts"
+    assert df.schema["ts"] == pl.Int64
+    # No downcast: measures keep their Parquet-native dtype (bit-for-bit reproducible).
+    assert df.schema["no_of_trades"] == pl.Int64
+    assert all(df.schema[name] == pl.Float64 for name in _FLOAT_COLUMNS)
+
+    ts = df["ts"].to_list()
+    assert ts == sorted(ts)
+    assert len(set(ts)) == len(ts)
+    assert ts[0] == BASE_MS * NS_PER_MS
+    assert build.source_rows == 5
+    assert build.dropped_duplicate_ts == 1
+    assert df.n_chunks() == 1
+
+
+def test_build_dollar_frame_uses_end_as_ts(tmp_path: Path) -> None:
+    spec = spec_for_series("dollar_1M")
+    _write_month(
+        tmp_path,
+        spec,
+        _dollar_frame(
+            start_ms=[BASE_MS, BASE_MS + 1_000],
+            end_ms=[BASE_MS + 999, BASE_MS + 1_999],
+            bar_ids=[0, 1],
+        ),
+        2024,
+        1,
+    )
+
+    df = build_series_frame(spec, tmp_path).df
+
+    assert df.columns[:3] == ["ts", "start_ts", "dollar_bar_id"]
+    assert df.schema["ts"] == pl.Int64
+    assert df.schema["start_ts"] == pl.Int64
+    assert df.schema["dollar_bar_id"] == pl.Int64  # verbatim, no downcast
+    assert df["ts"].to_list() == [(BASE_MS + 999) * NS_PER_MS, (BASE_MS + 1_999) * NS_PER_MS]
+    assert df["start_ts"].to_list() == [BASE_MS * NS_PER_MS, (BASE_MS + 1_000) * NS_PER_MS]
+
+
+def test_store_values_are_bit_identical_to_parquet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    source = _time_frame([BASE_MS, BASE_MS + 60_000, BASE_MS + 120_000])
+    _write_month(tmp_path / "parquet", spec, source, 2024, 1)
+
+    publish_series("time_1m", build_series_frame(spec, tmp_path / "parquet"))
+    stored = pl.read_ipc(series_store_dir("time_1m") / LATEST_NAME, memory_map=True, rechunk=False)
+
+    # Every measure column survives at the exact same dtype and bits as the mirror
+    # (no downcast) -- the store must not diverge from the rest of the system.
+    measures = [*_FLOAT_COLUMNS, "no_of_trades"]
+    expected = source.sort("datetime").select(measures)
+    assert_frame_equal(stored.select(measures), expected)
+
+
+def test_asset_publishes_mmap_ready_arrow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from dagster import materialize
+
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    _write_month(
+        tmp_path / "parquet",
+        spec,
+        _time_frame([BASE_MS, BASE_MS + 60_000, BASE_MS + 120_000]),
+        2024,
+        1,
+    )
+
+    result = materialize([build_bar_store_arrow], partition_key="time_1m")
+    assert result.success
+
+    latest = series_store_dir("time_1m") / LATEST_NAME
+    assert latest.is_symlink()
+
+    # Acceptance: one record batch, zero-copy int64 ts view, strictly increasing.
+    frame = pl.read_ipc(latest, memory_map=True, rechunk=False)
+    assert frame.n_chunks() == 1
+    ts = frame["ts"].to_numpy(allow_copy=False)
+    assert ts.dtype == "int64"
+    assert list(ts) == sorted(ts)
+    assert len(set(ts.tolist())) == len(ts)
+
+
+def test_atomic_swap_keeps_pre_open_handle_readable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    parquet_root = tmp_path / "parquet"
+
+    _write_month(parquet_root, spec, _time_frame([BASE_MS, BASE_MS + 60_000]), 2024, 1)
+    first = publish_series("time_1m", build_series_frame(spec, parquet_root))
+    assert first.status == "published"
+
+    latest = series_store_dir("time_1m") / LATEST_NAME
+    version_one = latest.resolve()
+
+    # Open a handle BEFORE the swap; it pins the v1 inode.
+    handle = pa_ipc.open_file(pa.memory_map(str(latest), "r"))
+    assert handle.read_all().num_rows == 2
+
+    # Publish a fresher version (3 rows) over the same month.
+    _write_month(parquet_root, spec, _time_frame([BASE_MS, BASE_MS + 60_000, BASE_MS + 120_000]), 2024, 1)
+    second = publish_series("time_1m", build_series_frame(spec, parquet_root))
+    assert second.status == "published"
+    assert second.version != first.version
+
+    # The pre-opened handle still reads v1; a fresh read sees v2; v1 is retained.
+    assert handle.read_all().num_rows == 2
+    assert pl.read_ipc(latest, memory_map=True, rechunk=False).height == 3
+    assert version_one.exists()
+    assert latest.resolve() != version_one
+
+
+def test_content_hash_skips_unchanged_and_is_reproducible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    parquet_root = tmp_path / "parquet"
+    _write_month(parquet_root, spec, _time_frame([BASE_MS, BASE_MS + 60_000]), 2024, 1)
+
+    first = publish_series("time_1m", build_series_frame(spec, parquet_root))
+    second = publish_series("time_1m", build_series_frame(spec, parquet_root))
+
+    assert first.status == "published"
+    assert second.status == "skipped_unchanged"
+    # Identical content -> identical version id (content-addressed, reproducible).
+    assert second.version == first.version
+    versions = list(series_store_dir("time_1m").glob("time_1m.*.arrow"))
+    assert len(versions) == 1
+
+
+def test_monotonic_guard_skips_staler(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    parquet_root = tmp_path / "parquet"
+
+    _write_month(parquet_root, spec, _time_frame([BASE_MS, BASE_MS + 60_000, BASE_MS + 120_000]), 2024, 1)
+    assert publish_series("time_1m", build_series_frame(spec, parquet_root)).status == "published"
+
+    # A staler snapshot (older max ts) must never flip `latest` backwards.
+    _write_month(parquet_root, spec, _time_frame([BASE_MS, BASE_MS + 60_000]), 2024, 1)
+    staler = publish_series("time_1m", build_series_frame(spec, parquet_root))
+    assert staler.status == "skipped_not_newer"
+
+    latest = series_store_dir("time_1m") / LATEST_NAME
+    assert pl.read_ipc(latest, memory_map=True, rechunk=False).height == 3
+
+
+def test_retention_keeps_min_versions_and_respects_grace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path))
+    directory = series_store_dir("time_1m")
+    directory.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+
+    # Two stale versions (older than grace) + four recent ones; KEEP == 3.
+    ages = {0: 3 * REAP_GRACE_SECONDS, 1: 2 * REAP_GRACE_SECONDS, 2: 3, 3: 2, 4: 1, 5: 0}
+    paths = []
+    for index, age in ages.items():
+        path = directory / f"time_1m.{index:016x}.arrow"
+        path.write_bytes(b"x")
+        os.utime(path, (now - age, now - age))
+        paths.append(path)
+    latest = directory / LATEST_NAME
+    os.symlink(paths[5].name, latest)
+
+    reaped = reap_old_versions(
+        directory, "time_1m", keep=RETENTION_KEEP, grace_seconds=REAP_GRACE_SECONDS, now=now
+    )
+
+    remaining = {path.name for path in directory.glob("time_1m.*.arrow")}
+    # Only the two beyond-KEEP *and* older-than-grace versions are reaped.
+    assert set(reaped) == {paths[0].name, paths[1].name}
+    # A 4th recent version survives despite KEEP == 3 (grace protects it mid-swap).
+    assert paths[2].name in remaining
+    assert paths[5].name in remaining  # the live `latest` target
+    assert len(remaining) == 4
+
+
+def test_partition_run_requests_cover_all_series() -> None:
+    requests = bar_store_partition_run_requests("mirror-run-abc")
+    # One run per series, run-keyed to the triggering mirror run for idempotency.
+    assert [request.partition_key for request in requests] == list(BAR_STORE_SERIES)
+    assert all(request.run_key == f"{request.partition_key}:mirror-run-abc" for request in requests)
+    # A different mirror run yields distinct run keys, so each success rebuilds once.
+    other = bar_store_partition_run_requests("mirror-run-xyz")
+    assert {request.run_key for request in requests}.isdisjoint(
+        request.run_key for request in other
+    )
+
+
+def test_definitions_wires_bar_store_sensor_to_mirror_job(origo_definitions_module: Any) -> None:
+    sensor = origo_definitions_module.bar_store_source_sensor
+    assert sensor.name == "bar_store_source_sensor"
+
+    job = origo_definitions_module.build_bar_store_arrow_job
+    assert job.name == "build_bar_store_arrow_job"
+
+    # The mirror job the sensor watches must exist in the definitions (defs building
+    # under the fixture validates the run-status sensor is wired to it).
+    mirror_job = origo_definitions_module.publish_binance_spot_klines_to_mount_job
+    assert mirror_job.name == "publish_binance_spot_klines_to_mount_job"
+
+    assert str(arrow_store_root())  # smoke: env-driven root resolves

--- a/tests/origo_source_native/test_publish_binance_spot_klines_to_mount.py
+++ b/tests/origo_source_native/test_publish_binance_spot_klines_to_mount.py
@@ -97,9 +97,9 @@ def test_mount_export_factory_registers_twelve_series() -> None:
     }
 
 
-def test_mount_export_schedule_runs_every_ten_minutes(origo_definitions_module: Any) -> None:
+def test_mount_export_schedule_runs_every_minute(origo_definitions_module: Any) -> None:
     schedule = origo_definitions_module.publish_binance_spot_klines_to_mount_schedule
-    assert schedule.cron_schedule == "*/10 * * * *"
+    assert schedule.cron_schedule == "* * * * *"
     assert schedule.execution_timezone == "UTC"
 
     assert months_for_run("tick", datetime(2024, 3, 15)) == [(2024, 2), (2024, 3)]


### PR DESCRIPTION
Closes #237

## Summary
Tier-1 of the bar-store stack: a Dagster layer that projects the 12-series Parquet mirror (#232) into a **versioned, mmap-ready Arrow** store under `LOCAL_ARROW_DIR` (default `/opt/arrow`), for a downstream consumer library + HTTP service (both out of scope here) to `mmap` and `searchsorted` over a zero-copy `ts` view.

### What's included
- **`assets/build_bar_store_arrow.py`** — one partitioned asset, 12 partitions (one per mirror series). Per series: read the whole series Parquet, derive `ts` (Int64 ns UTC; `datetime` for time bars, `end_datetime` for dollar), sort + dedupe so `ts` is strictly increasing (searchsorted contract), carry every measure column **verbatim at full precision — no downcast**, combine to a single record batch (`rechunk`), write **uncompressed** Arrow IPC (Feather v2). Publish is atomic, never in place: temp in same dir → fsync → `os.replace` to `<series>.<ver>.arrow`, then an atomic relative `latest.arrow` symlink swap **last**. **Version = content hash** (byte-identical rebuild is a no-op; a pinned version is reproducible). A per-series `flock` brackets check-publish-flip-reap; a **monotonic freshness guard** stops a slow out-of-order run flipping `latest` back to staler data; retention keeps the last `N>=3`, reaping older only after a ~10-min grace so in-flight `mmap` / pinned-version reads never `ENOENT` mid-swap.
- **Trigger** — `bar_store_source_sensor`, a `RunStatusSensorDefinition` that fans out one Arrow run per series (run-keyed to the mirror run) when `publish_binance_spot_klines_to_mount_job` **succeeds**. Event-driven off the mirror's completion, not a clock or a file poll.
- **Mirror cadence** — `publish_binance_spot_klines_to_mount_schedule` now runs **every minute** (was `*/10`), so the mirror — and the Arrow store it triggers — track the 1-minute ClickHouse `_latest` projections (Arrow freshness ~1–2 min, was ~10).
- **Compose** — Compose-managed `tdw-arrow` volume (`tdw-control-plane_arrow`) on the `dagster` service (prod) + `./arrow_data` dev bind mount; `arrow_data/` gitignored. Mirrors the `tdw-parquet` pattern; no manual host step.

### Reproducibility (the no-downcast decision)
The store is a **re-layout** of the mirror, not a lossy projection: measure columns are byte-identical (Float64/Int64), and `ts`/`start_ts` are an exact ms→ns re-encode. A wider system reads multiple stores and none may silently diverge, so f32/i32 narrowing was deliberately dropped. `test_store_values_are_bit_identical_to_parquet` locks it in.

## Validation (local; ephemeral ClickHouse via the conftest harness, polars 1.41.2)
- `pytest tests/origo_source_native -q` → **112 passed** (incl. 11 new tests: shaping/sort/dedupe, dollar ts=end, **bit-identical-vs-parquet**, single-batch mmap + zero-copy ts, atomic swap keeps a pre-opened handle readable, content-hash skip/reproducibility, monotonic guard, retention+grace, run-request fan-out, sensor↔mirror-job wiring).
- pyright (strict): **error-count delta 0** vs `origin/main` (1212→1212); the new module has 0 errors; `filesAnalyzed` ratchets up.
- ruff: clean on the new module.

## Acceptance criteria (per series) — all covered
- `read_ipc(latest, memory_map=True, rechunk=False).n_chunks() == 1`
- `df["ts"].to_numpy(allow_copy=False)` succeeds; `ts` strictly increasing
- a handle opened **before** a publish still reads the old version **after** the swap

## Deploy
`docker compose up` auto-creates the Compose-managed `tdw-control-plane_arrow` volume (host `/var/lib/docker/volumes/tdw-control-plane_arrow/_data`, container `/opt/arrow`) — no manual host step. The per-minute mirror schedule drives the run-status sensor, which fans out the 12 Arrow series on each mirror success; the store self-fills on the first successful mirror run. Dagster is the sole writer; consumers mount the volume read-only.

## Operational note
At 1-min cadence × 12 partitions, every mirror success fans out ~12 Arrow runs/min (~17k/day, plus ~1.4k mirror runs/day). With `DefaultRunCoordinator` and no run retention, Dagster run-storage will grow — worth a run-retention policy, or (if run sprawl bites) collapsing the 12 partitions into a single non-partitioned Arrow run (1/min) at the cost of per-series independence. Left partitioned per the original spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
