### PR TITLE
fix(origo): write the Arrow bar store as a single record batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.17.1 on June 5, 2026
+- Fix the Arrow bar store writing multi-record-batch files for any series past polars' ~122k-row IPC batch default: a `memory_map=True` reader surfaced those batches as multiple chunks, breaking the single-batch zero-copy `ts` view the store exists to provide. Force one record batch via `record_batch_size`. Self-heals on deploy (the byte change yields a new content-hash version, so each series republishes once as a single batch).
+
 # v1.17.0 on June 5, 2026
 - Add a versioned, mmap-ready Arrow bar store: a run-status sensor rebuilds every series into a single-record-batch, uncompressed Arrow IPC file under LOCAL_ARROW_DIR (default /opt/arrow) whenever the Parquet mirror job succeeds. Measures are carried verbatim at full precision (no downcast), so the store stays bit-for-bit reproducible against the mirror; it is published with an atomic `latest` symlink swap, content-hash versioning, a monotonic freshness guard, and a few retained prior versions so in-flight mmap and pinned-version reads never break mid-swap.
 - Run the Binance spot Parquet mirror every minute (was every 10 minutes) so the mirror — and the Arrow bar store it triggers on completion — track the 1-minute ClickHouse latest projections.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.17.0"
+version = "1.17.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/build_bar_store_arrow.py
+++ b/tdw_control_plane/assets/build_bar_store_arrow.py
@@ -14,7 +14,9 @@ publishes it under ``LOCAL_ARROW_DIR`` so a consumer can ``mmap`` the file and
    reproducible against the Parquet (and thus ClickHouse / Hugging Face). The only
    derived columns are ``ts`` / ``start_ts``, an exact ms->ns re-encode of the bar
    datetimes;
-4. combine to a single record batch (``rechunk``) so the consumer sees one chunk;
+4. write one record batch -- ``record_batch_size`` forces a single batch (polars
+   otherwise splits large frames, and a ``memory_map`` reader surfaces each batch
+   as its own chunk), so the consumer sees one contiguous chunk;
 5. write Feather v2 / Arrow IPC, uncompressed (mmap needs raw bytes).
 
 Publishing is atomic and never in place: the bytes land in a same-dir temp file

--- a/tdw_control_plane/assets/build_bar_store_arrow.py
+++ b/tdw_control_plane/assets/build_bar_store_arrow.py
@@ -251,7 +251,11 @@ def reap_old_versions(
 
 def _ipc_payload(df: pl.DataFrame) -> bytes:
     sink = io.BytesIO()
-    df.write_ipc(sink, compression="uncompressed")
+    # record_batch_size >= height forces a single record batch. Without it polars
+    # splits frames past its default (~122k rows) into multiple batches, which a
+    # ``memory_map=True`` reader surfaces as multiple chunks -- breaking the single
+    # batch / zero-copy ``ts`` contract for every non-trivial series.
+    df.write_ipc(sink, compression="uncompressed", record_batch_size=max(df.height, 1))
     return sink.getvalue()
 
 

--- a/tests/origo_source_native/test_build_bar_store_arrow.py
+++ b/tests/origo_source_native/test_build_bar_store_arrow.py
@@ -202,6 +202,36 @@ def test_asset_publishes_mmap_ready_arrow(tmp_path: Path, monkeypatch: pytest.Mo
     assert len(set(ts.tolist())) == len(ts)
 
 
+def test_large_series_publishes_single_record_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Far past polars' default ~122k-row IPC batch size: a naive write_ipc splits into
+    # several record batches that a memory_map=True reader exposes as multiple chunks,
+    # which breaks the zero-copy ts view. _ipc_payload's record_batch_size forces one
+    # batch. (The small-frame tests above never crossed the threshold, so they missed
+    # this -- it surfaced only in production on million-row series.)
+    monkeypatch.setenv("LOCAL_PARQUET_DIR", str(tmp_path / "parquet"))
+    monkeypatch.setenv("LOCAL_ARROW_DIR", str(tmp_path / "arrow"))
+    spec = spec_for_series("time_1m")
+    rows = 200_000
+    minute_ms = 60_000
+    _write_month(
+        tmp_path / "parquet",
+        spec,
+        _time_frame([BASE_MS + index * minute_ms for index in range(rows)]),
+        2024,
+        1,
+    )
+
+    outcome = publish_series("time_1m", build_series_frame(spec, tmp_path / "parquet"))
+    assert outcome.status == "published"
+
+    frame = pl.read_ipc(series_store_dir("time_1m") / LATEST_NAME, memory_map=True, rechunk=False)
+    assert frame.height == rows
+    assert frame.n_chunks() == 1  # one record batch even well past the split threshold
+    frame["ts"].to_numpy(allow_copy=False)  # zero-copy must succeed (raises if multi-chunk)
+
+
 def test_atomic_swap_keeps_pre_open_handle_readable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #238

## Summary
The Arrow bar store (#236) was writing **multiple record batches** for any series past polars' ~122k-row IPC default. A `memory_map=True` reader — the consumer path this store exists for — surfaces those batches as multiple chunks, so `df["ts"].to_numpy(allow_copy=False)` **raises**, breaking the single-batch zero-copy contract. Found live in prod: `time_1m` 28 batches, `dollar_1M` 42, `time_15m` 2.

**Fix:** `_ipc_payload` now passes `record_batch_size=max(df.height, 1)` to `write_ipc`, forcing exactly one record batch regardless of size. The bytes stay deterministic, so content-hash versioning remains reproducible.

**Why it slipped #236:** the tests used 3-row frames and one non-mmap spot-check, both below the split threshold. This PR adds `test_large_series_publishes_single_record_batch` (200k rows, read via `memory_map=True`) — A/B-proven to fail without the fix (`assert 2 == 1`).

## Validation
- `pytest tests/origo_source_native -q` → **113 passed** (incl. the new large-data test).
- pyright strict: error-count delta 0 vs main; ruff clean.

## Deploy / self-heal
No schema change. On deploy, `record_batch_size` changes the serialized bytes → a new content-hash version → each of the 12 series republishes once as a single batch on the next mirror success; old multi-batch versions are reaped after the retention grace. No backfill, no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
