### PR TITLE
feat(origo): publish spot depth snapshots to Arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.19.0 on June 15, 2026
+- Publish Binance spot depth20 and depth200 raw snapshots as mmap-ready Arrow IPC files under `/opt/arrow`.
+
 # v1.18.1 on June 15, 2026
 - Wire Binance spot depth200 service credentials into the deployment environment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.18.1"
+version = "1.19.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
+++ b/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
@@ -1,0 +1,256 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+import polars as pl
+import pyarrow as pa
+from dagster import AssetExecutionContext, Config, StaticPartitionsDefinition, asset
+
+from tdw_control_plane.assets.build_bar_store_arrow import BarSeriesBuild, publish_series
+from tdw_control_plane.assets.create_binance_spot_depth20_snapshots_table_origo import (
+    ClickHouseClient,
+    get_clickhouse_settings,
+    make_clickhouse_client,
+)
+from tdw_control_plane.assets.create_binance_spot_depth20_snapshots_table_origo import (
+    SNAPSHOTS_TABLE_NAME as DEPTH20_SNAPSHOTS_TABLE_NAME,
+)
+from tdw_control_plane.assets.create_binance_spot_depth200_snapshots_table_origo import (
+    SNAPSHOTS_TABLE_NAME as DEPTH200_SNAPSHOTS_TABLE_NAME,
+)
+
+DEPTH_SNAPSHOT_SERIES: tuple[str, ...] = ('depth20_snapshots', 'depth200_snapshots')
+DEPTH_SNAPSHOT_PARTITIONS = StaticPartitionsDefinition(list(DEPTH_SNAPSHOT_SERIES))
+
+BookLevel = tuple[float, float]
+
+
+class DepthSnapshotStoreConfig(Config):
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class DepthSnapshotSpec:
+    series: str
+    table_name: str
+    depth: int
+
+
+@dataclass(frozen=True)
+class DepthSnapshotRow:
+    ts: int
+    source_timestamp_ms: int
+    last_update_id: int
+    bids: tuple[BookLevel, ...]
+    asks: tuple[BookLevel, ...]
+
+
+_DEPTH_SNAPSHOT_SPECS: tuple[DepthSnapshotSpec, ...] = (
+    DepthSnapshotSpec('depth20_snapshots', DEPTH20_SNAPSHOTS_TABLE_NAME, 20),
+    DepthSnapshotSpec('depth200_snapshots', DEPTH200_SNAPSHOTS_TABLE_NAME, 200),
+)
+
+
+def spec_for_depth_snapshot_series(series: str) -> DepthSnapshotSpec:
+    for spec in _DEPTH_SNAPSHOT_SPECS:
+        if spec.series == series:
+            return spec
+    raise ValueError(f'Unknown depth snapshot series: {series}')
+
+
+def _snapshot_rows(result: object, spec: DepthSnapshotSpec) -> tuple[DepthSnapshotRow, ...]:
+    if not isinstance(result, Sequence) or isinstance(result, (bytes, str)):
+        raise TypeError('Expected ClickHouse row sequence for depth snapshots.')
+    if not result:
+        raise RuntimeError(f'No source rows found in {spec.table_name}.')
+
+    raw_rows = cast(Sequence[object], result)
+    rows: list[DepthSnapshotRow] = []
+    for index, raw_row in enumerate(raw_rows):
+        row = _row_sequence(raw_row, index)
+        if len(row) != 5:
+            raise TypeError(f'Expected depth snapshot row {index} to have 5 values.')
+        ts = _int_value(row[0], f'row {index} ts')
+        rows.append(
+            DepthSnapshotRow(
+                ts=ts,
+                source_timestamp_ms=_int_value(row[1], f'row {index} source_timestamp_ms'),
+                last_update_id=_int_value(row[2], f'row {index} last_update_id'),
+                bids=_book_levels(row[3], 'bids', spec.depth, ts),
+                asks=_book_levels(row[4], 'asks', spec.depth, ts),
+            )
+        )
+    return tuple(rows)
+
+
+def _row_sequence(value: object, row_index: int) -> Sequence[object]:
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, str)):
+        raise TypeError(f'Expected depth snapshot row {row_index} to be a sequence.')
+    return cast(Sequence[object], value)
+
+
+def _int_value(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f'Expected {name} to be int, got {type(value).__name__}.')
+    return value
+
+
+def _float_value(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (float, int)):
+        raise TypeError(f'Expected {name} to be numeric, got {type(value).__name__}.')
+    return float(value)
+
+
+def _book_levels(
+    value: object,
+    side: str,
+    depth: int,
+    ts: int,
+) -> tuple[BookLevel, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, str)):
+        raise TypeError(f'Expected {side} levels at ts={ts} to be a sequence.')
+    raw_levels = cast(Sequence[object], value)
+    if len(raw_levels) != depth:
+        raise RuntimeError(f'Expected {depth} {side} levels at ts={ts}, got {len(raw_levels)}.')
+
+    levels: list[BookLevel] = []
+    for index, raw_level in enumerate(raw_levels):
+        level = _row_sequence(raw_level, index)
+        if len(level) != 2:
+            raise TypeError(f'Expected {side} level {index} at ts={ts} to have 2 values.')
+        levels.append(
+            (
+                _float_value(level[0], f'{side} level {index} price at ts={ts}'),
+                _float_value(level[1], f'{side} level {index} qty at ts={ts}'),
+            )
+        )
+    return tuple(levels)
+
+
+def _dedupe_sort_rows(rows: Sequence[DepthSnapshotRow]) -> tuple[DepthSnapshotRow, ...]:
+    by_ts: dict[int, DepthSnapshotRow] = {}
+    for row in rows:
+        by_ts[row.ts] = row
+    return tuple(by_ts[ts] for ts in sorted(by_ts))
+
+
+def _book_array(
+    rows: Sequence[DepthSnapshotRow],
+    side: str,
+    depth: int,
+) -> pa.FixedSizeListArray:
+    prices: list[float] = []
+    quantities: list[float] = []
+    for row in rows:
+        levels = row.bids if side == 'bids' else row.asks
+        for price, quantity in levels:
+            prices.append(price)
+            quantities.append(quantity)
+
+    struct_values = pa.StructArray.from_arrays(
+        [
+            pa.array(prices, type=pa.float64()),
+            pa.array(quantities, type=pa.float64()),
+        ],
+        names=['price', 'qty'],
+    )
+    return pa.FixedSizeListArray.from_arrays(struct_values, depth)
+
+
+def _snapshot_table(rows: Sequence[DepthSnapshotRow], depth: int) -> pa.Table:
+    return pa.table(
+        {
+            'ts': pa.array([row.ts for row in rows], type=pa.int64()),
+            'source_timestamp_ms': pa.array(
+                [row.source_timestamp_ms for row in rows], type=pa.uint64()
+            ),
+            'last_update_id': pa.array([row.last_update_id for row in rows], type=pa.uint64()),
+            'bids': _book_array(rows, 'bids', depth),
+            'asks': _book_array(rows, 'asks', depth),
+        }
+    )
+
+
+def build_depth_snapshot_frame(
+    client: ClickHouseClient,
+    database: str,
+    spec: DepthSnapshotSpec,
+) -> BarSeriesBuild:
+    result = client.execute(
+        f"""
+        SELECT
+            toUnixTimestamp64Nano(datetime) AS ts,
+            source_timestamp_ms,
+            last_update_id,
+            bids,
+            asks
+        FROM {database}.{spec.table_name} FINAL
+        ORDER BY ts ASC, source_timestamp_ms ASC
+        """
+    )
+    rows = _snapshot_rows(result, spec)
+    deduped = _dedupe_sort_rows(rows)
+    table = _snapshot_table(deduped, spec.depth)
+    frame = pl.from_arrow(table)
+    if not isinstance(frame, pl.DataFrame):
+        raise TypeError('Expected depth snapshot Arrow table to become a Polars DataFrame.')
+    return BarSeriesBuild(
+        frame.rechunk(),
+        source_rows=len(rows),
+        dropped_duplicate_ts=len(rows) - len(deduped),
+    )
+
+
+@asset(
+    name='build_depth_snapshot_store_arrow',
+    partitions_def=DEPTH_SNAPSHOT_PARTITIONS,
+    group_name='binance_depth_snapshot_store',
+    description=(
+        'Projects raw Binance spot depth20/depth200 ClickHouse snapshots into '
+        'versioned, mmap-ready Arrow IPC files under LOCAL_ARROW_DIR. Each partition '
+        'writes one uncompressed record batch with fixed-size nested bid/ask book columns.'
+    ),
+)
+def build_depth_snapshot_store_arrow(
+    context: AssetExecutionContext,
+    config: DepthSnapshotStoreConfig,
+) -> dict[str, object]:
+    series = context.partition_key
+    spec = spec_for_depth_snapshot_series(series)
+    settings = get_clickhouse_settings()
+    client = make_clickhouse_client(settings)
+
+    try:
+        build = build_depth_snapshot_frame(client, settings.database, spec)
+        if build.dropped_duplicate_ts > 0:
+            context.log.warning(
+                f'{series}: dropped {build.dropped_duplicate_ts} row(s) with duplicate ts to keep '
+                'the index strictly increasing.'
+            )
+
+        if config.dry_run:
+            return {
+                'status': 'dry_run',
+                'series': series,
+                'rows': build.df.height,
+                'source_rows': build.source_rows,
+                'dropped_duplicate_ts': build.dropped_duplicate_ts,
+            }
+
+        outcome = publish_series(series, build)
+        context.log.info(
+            f'{series}: {outcome.status} version={outcome.version} rows={build.df.height} '
+            f'reaped={len(outcome.reaped)}'
+        )
+        return {
+            'status': 'success',
+            'series': series,
+            'rows': build.df.height,
+            'source_rows': build.source_rows,
+            'dropped_duplicate_ts': build.dropped_duplicate_ts,
+            'version': outcome.version,
+            'outcome': outcome.status,
+            'reaped': len(outcome.reaped),
+        }
+    finally:
+        client.disconnect()

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -201,6 +201,7 @@ from .assets.build_bar_store_arrow import (
     build_bar_store_arrow,
     bar_store_partition_run_requests,
 )
+from .assets.build_depth_snapshot_store_arrow import build_depth_snapshot_store_arrow
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
@@ -497,6 +498,12 @@ publish_binance_spot_klines_to_mount_schedule = ScheduleDefinition(
 build_bar_store_arrow_job = define_asset_job(
     name="build_bar_store_arrow_job",
     selection=[build_bar_store_arrow],
+    executor_def=in_process_executor,
+)
+
+build_depth_snapshot_store_arrow_job = define_asset_job(
+    name='build_depth_snapshot_store_arrow_job',
+    selection=[build_depth_snapshot_store_arrow],
     executor_def=in_process_executor,
 )
 
@@ -1132,6 +1139,7 @@ defs = Definitions(
             publish_binance_spot_240M_dollar_klines_to_huggingface,
             *MOUNT_EXPORT_ASSETS,
             build_bar_store_arrow,
+            build_depth_snapshot_store_arrow,
             cleanup_binance_daily_trades_for_finalized_month,
             create_binance_trades_monthly_summary,
             create_binance_trades_daily_summary,
@@ -1221,6 +1229,7 @@ defs = Definitions(
           publish_binance_spot_klines_to_mount_job,
           backfill_binance_spot_klines_to_mount_job,
           build_bar_store_arrow_job,
+          build_depth_snapshot_store_arrow_job,
           roll_forward_monthly_binance_trades_job,
           create_binance_trades_monthly_summary_job,
           create_binance_trades_daily_summary_job,

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.ipc as pa_ipc
+import pytest
+from dagster import materialize
+
+os.environ.setdefault('CLICKHOUSE_PASSWORD', 'import-guard')
+
+import tdw_control_plane.assets.build_depth_snapshot_store_arrow as depth_store
+from tdw_control_plane.assets.build_bar_store_arrow import LATEST_NAME, series_store_dir
+from tdw_control_plane.assets.build_depth_snapshot_store_arrow import (
+    DEPTH_SNAPSHOT_PARTITIONS,
+    DEPTH_SNAPSHOT_SERIES,
+    DepthSnapshotSpec,
+    build_depth_snapshot_frame,
+    build_depth_snapshot_store_arrow,
+    spec_for_depth_snapshot_series,
+)
+
+SnapshotRow = tuple[int, int, int, list[tuple[float, float]], list[tuple[float, float]]]
+
+
+class FakeClickHouseClient:
+    def __init__(self, rows: Sequence[SnapshotRow]) -> None:
+        self.rows = rows
+        self.queries: list[str] = []
+        self.disconnected = False
+
+    def execute(
+        self,
+        query: str,
+        params: object | None = None,
+        settings: object | None = None,
+    ) -> object:
+        self.queries.append(query)
+        return self.rows
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+def _levels(depth: int, start: float) -> list[tuple[float, float]]:
+    return [(start + index, (index + 1) / 10) for index in range(depth)]
+
+
+def _row(ts: int, source_timestamp_ms: int, last_update_id: int, depth: int) -> SnapshotRow:
+    return (
+        ts,
+        source_timestamp_ms,
+        last_update_id,
+        _levels(depth, 100.0),
+        _levels(depth, 200.0),
+    )
+
+
+def _field_array(table: pa.Table, column: str, field: str) -> pa.Array:
+    book = table.column(column).chunk(0)
+    if not isinstance(book, pa.FixedSizeListArray):
+        raise TypeError(f'{column} must be a FixedSizeListArray')
+    values = book.values
+    if not isinstance(values, pa.StructArray):
+        raise TypeError(f'{column} values must be a StructArray')
+    return values.field(field)
+
+
+def test_depth_snapshot_series_cover_depth20_and_depth200() -> None:
+    assert DEPTH_SNAPSHOT_SERIES == ('depth20_snapshots', 'depth200_snapshots')
+    assert set(DEPTH_SNAPSHOT_PARTITIONS.get_partition_keys()) == set(DEPTH_SNAPSHOT_SERIES)
+
+    depth20 = spec_for_depth_snapshot_series('depth20_snapshots')
+    depth200 = spec_for_depth_snapshot_series('depth200_snapshots')
+
+    assert depth20.table_name == 'binance_spot_depth20_snapshots'
+    assert depth20.depth == 20
+    assert depth200.table_name == 'binance_spot_depth200_snapshots'
+    assert depth200.depth == 200
+
+
+def test_build_depth_snapshot_frame_shapes_fixed_size_books_and_zero_copy_buffers() -> None:
+    spec = DepthSnapshotSpec('test_depth_snapshots', 'test_table', 2)
+    rows = [
+        _row(2, 20, 200, spec.depth),
+        _row(1, 10, 100, spec.depth),
+        _row(2, 22, 202, spec.depth),
+    ]
+
+    build = build_depth_snapshot_frame(FakeClickHouseClient(rows), 'origo', spec)
+    frame = build.df
+    table = frame.to_arrow()
+
+    assert frame.columns == ['ts', 'source_timestamp_ms', 'last_update_id', 'bids', 'asks']
+    assert frame['ts'].to_list() == [1, 2]
+    assert frame['source_timestamp_ms'].to_list() == [10, 22]
+    assert build.source_rows == 3
+    assert build.dropped_duplicate_ts == 1
+    assert frame.n_chunks() == 1
+
+    bids = table.column('bids').chunk(0)
+    asks = table.column('asks').chunk(0)
+    assert isinstance(bids, pa.FixedSizeListArray)
+    assert isinstance(asks, pa.FixedSizeListArray)
+    assert bids.type.list_size == spec.depth
+    assert asks.type.list_size == spec.depth
+
+    ts_view = table.column('ts').chunk(0).to_numpy(zero_copy_only=True)
+    bid_prices = _field_array(table, 'bids', 'price').to_numpy(zero_copy_only=True)
+    bid_quantities = _field_array(table, 'bids', 'qty').to_numpy(zero_copy_only=True)
+
+    assert ts_view.tolist() == [1, 2]
+    assert bid_prices.reshape(frame.height, spec.depth).tolist() == [[100.0, 101.0], [100.0, 101.0]]
+    assert bid_quantities.reshape(frame.height, spec.depth).tolist() == [[0.1, 0.2], [0.1, 0.2]]
+
+
+def test_build_depth_snapshot_frame_rejects_empty_source() -> None:
+    spec = DepthSnapshotSpec('test_depth_snapshots', 'test_table', 2)
+
+    with pytest.raises(RuntimeError, match='No source rows found in test_table'):
+        build_depth_snapshot_frame(FakeClickHouseClient([]), 'origo', spec)
+
+
+def test_build_depth_snapshot_frame_rejects_wrong_book_depth() -> None:
+    spec = DepthSnapshotSpec('test_depth_snapshots', 'test_table', 2)
+    bad_rows = [(1, 10, 100, _levels(1, 100.0), _levels(2, 200.0))]
+
+    with pytest.raises(RuntimeError, match='Expected 2 bids levels at ts=1, got 1'):
+        build_depth_snapshot_frame(FakeClickHouseClient(bad_rows), 'origo', spec)
+
+
+def test_asset_publishes_depth_snapshot_arrow_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = FakeClickHouseClient([_row(1, 10, 100, 20), _row(2, 20, 200, 20)])
+
+    def client_factory(settings: object) -> FakeClickHouseClient:
+        return fake_client
+
+    monkeypatch.setenv('LOCAL_ARROW_DIR', str(tmp_path))
+    monkeypatch.setenv('CLICKHOUSE_PASSWORD', 'test-password')
+    monkeypatch.setattr(depth_store, 'make_clickhouse_client', client_factory)
+
+    result = materialize([build_depth_snapshot_store_arrow], partition_key='depth20_snapshots')
+
+    assert result.success
+    assert fake_client.disconnected
+    assert 'binance_spot_depth20_snapshots' in fake_client.queries[0]
+
+    latest = series_store_dir('depth20_snapshots') / LATEST_NAME
+    assert latest.is_symlink()
+
+    table = pa_ipc.open_file(pa.memory_map(str(latest), 'r')).read_all()
+    assert table.num_rows == 2
+    assert table.column_names == ['ts', 'source_timestamp_ms', 'last_update_id', 'bids', 'asks']
+    assert table.column('ts').chunk(0).to_numpy(zero_copy_only=True).tolist() == [1, 2]
+    assert isinstance(table.column('bids').chunk(0), pa.FixedSizeListArray)
+
+
+def test_asset_publishes_single_record_batch_ipc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = FakeClickHouseClient([_row(index, index, index, 20) for index in range(200_000)])
+
+    def client_factory(settings: object) -> FakeClickHouseClient:
+        return fake_client
+
+    monkeypatch.setenv('LOCAL_ARROW_DIR', str(tmp_path))
+    monkeypatch.setenv('CLICKHOUSE_PASSWORD', 'test-password')
+    monkeypatch.setattr(depth_store, 'make_clickhouse_client', client_factory)
+
+    result = materialize([build_depth_snapshot_store_arrow], partition_key='depth20_snapshots')
+
+    assert result.success
+    reader = pa_ipc.open_file(
+        pa.memory_map(str(series_store_dir('depth20_snapshots') / LATEST_NAME), 'r')
+    )
+    assert reader.num_record_batches == 1
+    assert reader.read_all().column('ts').num_chunks == 1
+
+
+def test_definitions_wires_depth_snapshot_arrow_job(origo_definitions_module: object) -> None:
+    job = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow_job')
+    asset_def = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow')
+
+    assert job.name == 'build_depth_snapshot_store_arrow_job'
+    assert asset_def.partitions_def.get_partition_keys() == list(DEPTH_SNAPSHOT_SERIES)


### PR DESCRIPTION
Closes #256

## What does this PR change?

Adds a manual Dagster job that publishes raw Binance spot depth20/depth200 snapshot tables into `/opt/arrow/<series>/latest.arrow` as single-record-batch, uncompressed Arrow IPC files with fixed-size nested bid/ask book columns.

PRD: #255

## Tests

- `/tmp/tdw-control-plane-pytest/bin/python -m pytest tests/origo_source_native/test_build_depth_snapshot_store_arrow.py -q`
- `/tmp/tdw-control-plane-pytest/bin/python -m pytest tests/origo_source_native -q --maxfail=1`
- `pyright --pythonpath /tmp/tdw-control-plane-pytest/bin/python tdw_control_plane/assets/build_depth_snapshot_store_arrow.py`
- `/tmp/tdw-control-plane-pytest/bin/python -m ruff check tools tests/tools`
- `/tmp/tdw-control-plane-pytest/bin/python tools/version_gate.py --pr-title "feat(origo): publish spot depth snapshots to Arrow" --base-pyproject /tmp/tdw-base-pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/tdw-base-CHANGELOG.md --head-changelog CHANGELOG.md`
- `/tmp/tdw-control-plane-pytest/bin/python tools/slice_gate.py --pr-title "feat(origo): publish spot depth snapshots to Arrow" --pr-body-file /tmp/tdw-pr-body.md --pr-files-file /tmp/tdw-pr-files.txt --template .github/ISSUE_TEMPLATE/slice.yml --repo Vaquum/tdw-control-plane`
- `/tmp/tdw-control-plane-pytest/bin/python tools/fail_loud_gate.py --base-budget /tmp/tdw-base-fail-loud-budget.json`
- `/tmp/tdw-control-plane-pytest/bin/python tools/typing_gate.py --pyright-json /tmp/tdw-pyright.json --base-budget /tmp/tdw-base-typing-budget.json`

## LLM Review

- Codex CLI approved PRD #255 and slice #256.
- Claude CLI approved PRD #255 and slice #256.
- Codex CLI approved the staged diff.
- Claude CLI approved the staged diff.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable)
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked the slice issue to auto-close on merge
