### PR TITLE
feat(origo): auto-update spot depth Arrow snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.20.0 on June 15, 2026
+- Auto-update Binance spot depth20 and depth200 Arrow snapshots after their source refresh jobs succeed.
+
 # v1.19.0 on June 15, 2026
 - Publish Binance spot depth20 and depth200 raw snapshots as mmap-ready Arrow IPC files under `/opt/arrow`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.20.0 on June 15, 2026
-- Auto-update Binance spot depth20 and depth200 Arrow snapshots after their source refresh jobs succeed.
+- Auto-update Binance spot depth20 and depth200 Arrow snapshots as minute Arrow chunks after their source refresh jobs succeed.
 
 # v1.19.0 on June 15, 2026
 - Publish Binance spot depth20 and depth200 raw snapshots as mmap-ready Arrow IPC files under `/opt/arrow`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.19.0"
+version = "1.20.0"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
+++ b/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
@@ -1,12 +1,27 @@
+import hashlib
+import io
+import json
+import os
+import time
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import cast
 
 import polars as pl
 import pyarrow as pa
-from dagster import AssetExecutionContext, Config, RunRequest, StaticPartitionsDefinition, asset
+from dagster import (
+    AssetExecutionContext,
+    Config,
+    RunConfig,
+    RunRequest,
+    StaticPartitionsDefinition,
+    asset,
+)
 
-from tdw_control_plane.assets.build_bar_store_arrow import BarSeriesBuild, publish_series
+from tdw_control_plane.assets.build_bar_store_arrow import BarSeriesBuild, series_store_dir
 from tdw_control_plane.assets.create_binance_spot_depth20_snapshots_table_origo import (
     ClickHouseClient,
     get_clickhouse_settings,
@@ -23,12 +38,15 @@ DEPTH_SNAPSHOT_SERIES: tuple[str, ...] = ('depth20_snapshots', 'depth200_snapsho
 DEPTH_SNAPSHOT_PARTITIONS = StaticPartitionsDefinition(list(DEPTH_SNAPSHOT_SERIES))
 DEPTH20_SOURCE_JOB_NAME = 'refresh_binance_spot_depth20_data_source_job'
 DEPTH200_SOURCE_JOB_NAME = 'refresh_binance_spot_depth200_data_source_job'
+LATEST_MANIFEST_NAME = 'latest.json'
+VERSION_HEX = 16
 
 BookLevel = tuple[float, float]
 
 
 class DepthSnapshotStoreConfig(Config):
     dry_run: bool = False
+    source_partition_key: str | None = None
 
 
 @dataclass(frozen=True)
@@ -45,6 +63,13 @@ class DepthSnapshotRow:
     last_update_id: int
     bids: tuple[BookLevel, ...]
     asks: tuple[BookLevel, ...]
+
+
+@dataclass(frozen=True)
+class DepthSnapshotChunkPublish:
+    status: str
+    version: str | None
+    chunk: str | None
 
 
 _DEPTH_SNAPSHOT_SPECS: tuple[DepthSnapshotSpec, ...] = (
@@ -68,11 +93,41 @@ def spec_for_depth_snapshot_series(series: str) -> DepthSnapshotSpec:
 def depth_snapshot_store_partition_run_request(
     source_job_name: str,
     source_run_id: str,
+    source_partition_key: str,
 ) -> RunRequest:
     series = _SOURCE_JOB_TO_SERIES.get(source_job_name)
     if series is None:
         raise ValueError(f'Unknown depth snapshot source job: {source_job_name}')
-    return RunRequest(partition_key=series, run_key=f'{series}:{source_run_id}')
+    return RunRequest(
+        partition_key=series,
+        run_key=f'{series}:{source_run_id}',
+        run_config=RunConfig(
+            ops={
+                'build_depth_snapshot_store_arrow': DepthSnapshotStoreConfig(
+                    source_partition_key=source_partition_key
+                )
+            }
+        ),
+    )
+
+
+def minute_start_from_partition_key(partition_key: str) -> datetime:
+    parsed = datetime.fromisoformat(partition_key)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(second=0, microsecond=0)
+
+
+def _clickhouse_datetime64(value: datetime) -> str:
+    utc_value = value.astimezone(timezone.utc)
+    return utc_value.strftime('%Y-%m-%d %H:%M:%S.000')
+
+
+def depth_snapshot_chunk_relative_path(minute_start: datetime) -> Path:
+    utc_minute = minute_start.astimezone(timezone.utc).replace(second=0, microsecond=0)
+    return (
+        Path('chunks') / utc_minute.strftime('%Y/%m/%d/%H') / f'{utc_minute:%Y%m%dT%H%M%SZ}.arrow'
+    )
 
 
 def _snapshot_rows(result: object, spec: DepthSnapshotSpec) -> tuple[DepthSnapshotRow, ...]:
@@ -192,7 +247,9 @@ def build_depth_snapshot_frame(
     client: ClickHouseClient,
     database: str,
     spec: DepthSnapshotSpec,
+    minute_start: datetime,
 ) -> BarSeriesBuild:
+    minute_end = minute_start + timedelta(minutes=1)
     result = client.execute(
         f"""
         SELECT
@@ -202,6 +259,8 @@ def build_depth_snapshot_frame(
             bids,
             asks
         FROM {database}.{spec.table_name} FINAL
+        WHERE datetime >= toDateTime64('{_clickhouse_datetime64(minute_start)}', 3)
+          AND datetime < toDateTime64('{_clickhouse_datetime64(minute_end)}', 3)
         ORDER BY ts ASC, source_timestamp_ms ASC
         """
     )
@@ -218,14 +277,65 @@ def build_depth_snapshot_frame(
     )
 
 
+def _ipc_payload(df: pl.DataFrame) -> bytes:
+    sink = io.BytesIO()
+    df.write_ipc(sink, compression='uncompressed', record_batch_size=max(df.height, 1))
+    return sink.getvalue()
+
+
+def _fsync_file(handle: io.BufferedWriter) -> None:
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+def _atomic_write_bytes(target: Path, payload: bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.parent / f'.{target.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}'
+    with open(tmp, 'wb') as handle:
+        handle.write(payload)
+        _fsync_file(handle)
+    os.replace(tmp, target)
+
+
+def publish_depth_snapshot_chunk(
+    series: str,
+    source_partition_key: str,
+    build: BarSeriesBuild,
+) -> DepthSnapshotChunkPublish:
+    payload = _ipc_payload(build.df)
+    version = hashlib.sha256(payload).hexdigest()[:VERSION_HEX]
+    minute_start = minute_start_from_partition_key(source_partition_key)
+    relative_chunk = depth_snapshot_chunk_relative_path(minute_start)
+    directory = series_store_dir(series)
+    chunk = directory / relative_chunk
+    _atomic_write_bytes(chunk, payload)
+
+    manifest = {
+        'series': series,
+        'source_partition_key': source_partition_key,
+        'chunk': relative_chunk.as_posix(),
+        'rows': build.df.height,
+        'source_rows': build.source_rows,
+        'dropped_duplicate_ts': build.dropped_duplicate_ts,
+        'version': version,
+        'updated_at_unix_ns': time.time_ns(),
+    }
+    _atomic_write_bytes(
+        directory / LATEST_MANIFEST_NAME,
+        json.dumps(manifest, sort_keys=True).encode('utf-8') + b'\n',
+    )
+    return DepthSnapshotChunkPublish('published', version, relative_chunk.as_posix())
+
+
 @asset(
     name='build_depth_snapshot_store_arrow',
     partitions_def=DEPTH_SNAPSHOT_PARTITIONS,
     group_name='binance_depth_snapshot_store',
     description=(
         'Projects raw Binance spot depth20/depth200 ClickHouse snapshots into '
-        'versioned, mmap-ready Arrow IPC files under LOCAL_ARROW_DIR. Each partition '
-        'writes one uncompressed record batch with fixed-size nested bid/ask book columns.'
+        'minute chunk Arrow IPC files under LOCAL_ARROW_DIR. Each successful source '
+        'partition writes one uncompressed record batch with fixed-size nested bid/ask '
+        'book columns and atomically flips latest.json.'
     ),
 )
 def build_depth_snapshot_store_arrow(
@@ -233,12 +343,17 @@ def build_depth_snapshot_store_arrow(
     config: DepthSnapshotStoreConfig,
 ) -> dict[str, object]:
     series = context.partition_key
+    source_partition_key = config.source_partition_key
+    if source_partition_key is None:
+        raise RuntimeError('Depth snapshot Arrow chunks require source_partition_key config.')
+
+    minute_start = minute_start_from_partition_key(source_partition_key)
     spec = spec_for_depth_snapshot_series(series)
     settings = get_clickhouse_settings()
     client = make_clickhouse_client(settings)
 
     try:
-        build = build_depth_snapshot_frame(client, settings.database, spec)
+        build = build_depth_snapshot_frame(client, settings.database, spec, minute_start)
         if build.dropped_duplicate_ts > 0:
             context.log.warning(
                 f'{series}: dropped {build.dropped_duplicate_ts} row(s) with duplicate ts to keep '
@@ -249,25 +364,27 @@ def build_depth_snapshot_store_arrow(
             return {
                 'status': 'dry_run',
                 'series': series,
+                'source_partition_key': source_partition_key,
                 'rows': build.df.height,
                 'source_rows': build.source_rows,
                 'dropped_duplicate_ts': build.dropped_duplicate_ts,
             }
 
-        outcome = publish_series(series, build)
+        outcome = publish_depth_snapshot_chunk(series, source_partition_key, build)
         context.log.info(
-            f'{series}: {outcome.status} version={outcome.version} rows={build.df.height} '
-            f'reaped={len(outcome.reaped)}'
+            f'{series}: {outcome.status} chunk={outcome.chunk} version={outcome.version} '
+            f'rows={build.df.height}'
         )
         return {
             'status': 'success',
             'series': series,
+            'source_partition_key': source_partition_key,
             'rows': build.df.height,
             'source_rows': build.source_rows,
             'dropped_duplicate_ts': build.dropped_duplicate_ts,
             'version': outcome.version,
+            'chunk': outcome.chunk,
             'outcome': outcome.status,
-            'reaped': len(outcome.reaped),
         }
     finally:
         client.disconnect()

--- a/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
+++ b/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import polars as pl
 import pyarrow as pa
-from dagster import AssetExecutionContext, Config, StaticPartitionsDefinition, asset
+from dagster import AssetExecutionContext, Config, RunRequest, StaticPartitionsDefinition, asset
 
 from tdw_control_plane.assets.build_bar_store_arrow import BarSeriesBuild, publish_series
 from tdw_control_plane.assets.create_binance_spot_depth20_snapshots_table_origo import (
@@ -21,6 +21,8 @@ from tdw_control_plane.assets.create_binance_spot_depth200_snapshots_table_origo
 
 DEPTH_SNAPSHOT_SERIES: tuple[str, ...] = ('depth20_snapshots', 'depth200_snapshots')
 DEPTH_SNAPSHOT_PARTITIONS = StaticPartitionsDefinition(list(DEPTH_SNAPSHOT_SERIES))
+DEPTH20_SOURCE_JOB_NAME = 'refresh_binance_spot_depth20_data_source_job'
+DEPTH200_SOURCE_JOB_NAME = 'refresh_binance_spot_depth200_data_source_job'
 
 BookLevel = tuple[float, float]
 
@@ -50,12 +52,27 @@ _DEPTH_SNAPSHOT_SPECS: tuple[DepthSnapshotSpec, ...] = (
     DepthSnapshotSpec('depth200_snapshots', DEPTH200_SNAPSHOTS_TABLE_NAME, 200),
 )
 
+_SOURCE_JOB_TO_SERIES: dict[str, str] = {
+    DEPTH20_SOURCE_JOB_NAME: 'depth20_snapshots',
+    DEPTH200_SOURCE_JOB_NAME: 'depth200_snapshots',
+}
+
 
 def spec_for_depth_snapshot_series(series: str) -> DepthSnapshotSpec:
     for spec in _DEPTH_SNAPSHOT_SPECS:
         if spec.series == series:
             return spec
     raise ValueError(f'Unknown depth snapshot series: {series}')
+
+
+def depth_snapshot_store_partition_run_request(
+    source_job_name: str,
+    source_run_id: str,
+) -> RunRequest:
+    series = _SOURCE_JOB_TO_SERIES.get(source_job_name)
+    if series is None:
+        raise ValueError(f'Unknown depth snapshot source job: {source_job_name}')
+    return RunRequest(partition_key=series, run_key=f'{series}:{source_run_id}')
 
 
 def _snapshot_rows(result: object, spec: DepthSnapshotSpec) -> tuple[DepthSnapshotRow, ...]:

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -84,16 +84,26 @@ from .assets.create_binance_trades_complete_view import (
 from .assets.create_binance_trades_monthly_summary import create_binance_trades_monthly_summary
 from .assets.create_binance_trades_daily_summary import create_binance_trades_daily_summary
 from .assets.create_binance_trades_hourly_summary import create_binance_trades_hourly_summary
-from .assets.create_binance_trades_hour_of_day_summary import create_binance_trades_hour_of_day_summary
-from .assets.create_binance_trades_day_of_month_summary import create_binance_trades_day_of_month_summary
-from .assets.create_binance_trades_week_of_year_summary import create_binance_trades_week_of_year_summary
-from .assets.create_binance_trades_month_of_year_summary import create_binance_trades_month_of_year_summary
+from .assets.create_binance_trades_hour_of_day_summary import (
+    create_binance_trades_hour_of_day_summary,
+)
+from .assets.create_binance_trades_day_of_month_summary import (
+    create_binance_trades_day_of_month_summary,
+)
+from .assets.create_binance_trades_week_of_year_summary import (
+    create_binance_trades_week_of_year_summary,
+)
+from .assets.create_binance_trades_month_of_year_summary import (
+    create_binance_trades_month_of_year_summary,
+)
 from .assets.create_binance_agg_trades_table import create_binance_agg_trades_table
 from .assets.monthly_agg_trades_to_tdw import insert_monthly_binance_agg_trades_to_tdw
 from .assets.create_binance_futures_trades_table import create_binance_futures_trades_table
 from .assets.monthly_futures_trades_to_tdw import insert_monthly_binance_futures_trades_to_tdw
 from .assets.monthly_futures_agg_trades_to_tdw import create_binance_futures_agg_trades_table
-from .assets.monthly_futures_agg_trades_to_tdw import insert_monthly_binance_futures_agg_trades_to_tdw
+from .assets.monthly_futures_agg_trades_to_tdw import (
+    insert_monthly_binance_futures_agg_trades_to_tdw,
+)
 from .assets.create_origo_database import create_origo_database
 from .assets.create_binance_trades_table_origo import (
     create_binance_daily_spot_trades_table_origo,
@@ -206,11 +216,11 @@ from .assets.build_depth_snapshot_store_arrow import (
     depth_snapshot_store_partition_run_request,
 )
 
-CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
-CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
-CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
-CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
+CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', 'clickhouse')
+CLICKHOUSE_PORT = int(os.environ.get('CLICKHOUSE_PORT', 9000))
+CLICKHOUSE_USER = os.environ.get('CLICKHOUSE_USER', 'default')
+CLICKHOUSE_PASSWORD = os.environ.get('CLICKHOUSE_PASSWORD')
+CLICKHOUSE_DATABASE = os.environ.get('CLICKHOUSE_DATABASE', 'tdw')
 MAX_DAILY_BACKFILL_RUNS_PER_TICK = 14
 MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS = 14
 
@@ -226,70 +236,69 @@ class _AssetEventLike(Protocol):
 # Database Maintenance Jobs
 
 create_tdw_database_job = define_asset_job(
-    name="create_tdw_database_job",
-    selection=["create_tdw_database"])
+    name='create_tdw_database_job', selection=['create_tdw_database']
+)
 
 create_origo_database_job = define_asset_job(
-    name="create_origo_database_job",
-    selection=["create_origo_database"]
+    name='create_origo_database_job', selection=['create_origo_database']
 )
 
 create_binance_trades_table_job = define_asset_job(
-    name="create_binance_trades_table_job",
-    selection=["create_binance_trades_table"])
+    name='create_binance_trades_table_job', selection=['create_binance_trades_table']
+)
 
 create_binance_daily_trades_table_job = define_asset_job(
-    name="create_binance_daily_trades_table_job",
-    selection=["create_binance_daily_trades_table"])
+    name='create_binance_daily_trades_table_job', selection=['create_binance_daily_trades_table']
+)
 
 create_binance_daily_spot_trades_table_origo_job = define_asset_job(
-    name="create_binance_daily_spot_trades_table_origo_job",
-    selection=["create_binance_daily_spot_trades_table_origo"]
+    name='create_binance_daily_spot_trades_table_origo_job',
+    selection=['create_binance_daily_spot_trades_table_origo'],
 )
 
 create_binance_daily_futures_trades_table_origo_job = define_asset_job(
-    name="create_binance_daily_futures_trades_table_origo_job",
-    selection=["create_binance_daily_futures_trades_table_origo"]
+    name='create_binance_daily_futures_trades_table_origo_job',
+    selection=['create_binance_daily_futures_trades_table_origo'],
 )
 
 create_binance_spot_klines_table_origo_job = define_asset_job(
-    name="create_binance_spot_klines_table_origo_job",
-    selection=["create_binance_spot_klines_table_origo"]
+    name='create_binance_spot_klines_table_origo_job',
+    selection=['create_binance_spot_klines_table_origo'],
 )
 
 create_binance_spot_dollar_klines_table_origo_job = define_asset_job(
-    name="create_binance_spot_dollar_klines_table_origo_job",
-    selection=["create_binance_spot_dollar_klines_table_origo"]
+    name='create_binance_spot_dollar_klines_table_origo_job',
+    selection=['create_binance_spot_dollar_klines_table_origo'],
 )
 
 create_binance_spot_volume_klines_table_origo_job = define_asset_job(
-    name="create_binance_spot_volume_klines_table_origo_job",
-    selection=["create_binance_spot_volume_klines_table_origo"]
+    name='create_binance_spot_volume_klines_table_origo_job',
+    selection=['create_binance_spot_volume_klines_table_origo'],
 )
 
 create_binance_spot_tick_klines_table_origo_job = define_asset_job(
-    name="create_binance_spot_tick_klines_table_origo_job",
-    selection=["create_binance_spot_tick_klines_table_origo"]
+    name='create_binance_spot_tick_klines_table_origo_job',
+    selection=['create_binance_spot_tick_klines_table_origo'],
 )
 
 create_binance_spot_dollar_imbalance_klines_table_origo_job = define_asset_job(
-    name="create_binance_spot_dollar_imbalance_klines_table_origo_job",
-    selection=["create_binance_spot_dollar_imbalance_klines_table_origo"]
+    name='create_binance_spot_dollar_imbalance_klines_table_origo_job',
+    selection=['create_binance_spot_dollar_imbalance_klines_table_origo'],
 )
 
 create_binance_futures_klines_table_origo_job = define_asset_job(
-    name="create_binance_futures_klines_table_origo_job",
-    selection=["create_binance_futures_klines_table_origo"]
+    name='create_binance_futures_klines_table_origo_job',
+    selection=['create_binance_futures_klines_table_origo'],
 )
 
 create_binance_spot_depth20_snapshots_table_origo_job = define_asset_job(
-    name="create_binance_spot_depth20_snapshots_table_origo_job",
-    selection=["create_binance_spot_depth20_snapshots_table_origo"]
+    name='create_binance_spot_depth20_snapshots_table_origo_job',
+    selection=['create_binance_spot_depth20_snapshots_table_origo'],
 )
 
 create_binance_spot_depth20_1m_table_origo_job = define_asset_job(
-    name="create_binance_spot_depth20_1m_table_origo_job",
-    selection=["create_binance_spot_depth20_1m_table_origo"]
+    name='create_binance_spot_depth20_1m_table_origo_job',
+    selection=['create_binance_spot_depth20_1m_table_origo'],
 )
 
 create_binance_spot_depth200_snapshots_table_origo_job = define_asset_job(
@@ -308,43 +317,47 @@ create_binance_spot_latest_tables_origo_job = define_asset_job(
 )
 
 create_aligned_1m_exchange_table_origo_job = define_asset_job(
-    name="create_aligned_1m_exchange_table_origo_job",
-    selection=["create_aligned_1m_exchange_table_origo"]
+    name='create_aligned_1m_exchange_table_origo_job',
+    selection=['create_aligned_1m_exchange_table_origo'],
 )
 
 create_binance_trades_complete_view_job = define_asset_job(
-    name="create_binance_trades_complete_view_job",
-    selection=["create_binance_trades_complete_view"])
+    name='create_binance_trades_complete_view_job',
+    selection=['create_binance_trades_complete_view'],
+)
 
 create_binance_agg_trades_table_job = define_asset_job(
-    name="create_binance_agg_trades_table_job",
-    selection=["create_binance_agg_trades_table"])
+    name='create_binance_agg_trades_table_job', selection=['create_binance_agg_trades_table']
+)
 
 create_binance_futures_trades_table_job = define_asset_job(
-    name="create_binance_futures_trades_table_job",
-    selection=["create_binance_futures_trades_table"])
+    name='create_binance_futures_trades_table_job',
+    selection=['create_binance_futures_trades_table'],
+)
 
 create_binance_futures_agg_trades_table_job = define_asset_job(
-    name="create_binance_futures_agg_trades_table_job",
-    selection=["create_binance_futures_agg_trades_table"])
+    name='create_binance_futures_agg_trades_table_job',
+    selection=['create_binance_futures_agg_trades_table'],
+)
 
 # Data Insertion Jobs
 
 insert_monthly_binance_trades_job = define_asset_job(
-    name="insert_monthly_trades_to_tdw_job",
-    selection=["insert_monthly_binance_trades_to_tdw"])
+    name='insert_monthly_trades_to_tdw_job', selection=['insert_monthly_binance_trades_to_tdw']
+)
 
 refresh_binance_spot_data_source_job = define_asset_job(
-    name="refresh_binance_spot_data_source_job",
+    name='refresh_binance_spot_data_source_job',
     selection=[
-        "insert_daily_binance_spot_trades_to_origo",
-        "refresh_binance_spot_klines_origo",
-        "refresh_binance_spot_dollar_klines_origo",
-        "refresh_binance_spot_volume_klines_origo",
-        "refresh_binance_spot_tick_klines_origo",
-        "refresh_binance_spot_dollar_imbalance_klines_origo",
-        "refresh_aligned_1m_exchange_from_binance_spot_origo",
-    ])
+        'insert_daily_binance_spot_trades_to_origo',
+        'refresh_binance_spot_klines_origo',
+        'refresh_binance_spot_dollar_klines_origo',
+        'refresh_binance_spot_volume_klines_origo',
+        'refresh_binance_spot_tick_klines_origo',
+        'refresh_binance_spot_dollar_imbalance_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_spot_origo',
+    ],
+)
 
 backfill_binance_spot_dollar_klines_origo_job = define_asset_job(
     name='backfill_binance_spot_dollar_klines_origo_job',
@@ -367,12 +380,13 @@ _BINANCE_SPOT_DEPTH200_DATA_SOURCE_SELECTION = [
 ]
 
 refresh_binance_futures_data_source_job = define_asset_job(
-    name="refresh_binance_futures_data_source_job",
+    name='refresh_binance_futures_data_source_job',
     selection=[
-        "insert_daily_binance_futures_trades_to_origo",
-        "refresh_binance_futures_klines_origo",
-        "refresh_aligned_1m_exchange_from_binance_futures_origo",
-    ])
+        'insert_daily_binance_futures_trades_to_origo',
+        'refresh_binance_futures_klines_origo',
+        'refresh_aligned_1m_exchange_from_binance_futures_origo',
+    ],
+)
 
 refresh_binance_spot_depth20_data_source_job = define_asset_job(
     name='refresh_binance_spot_depth20_data_source_job',
@@ -417,89 +431,101 @@ reconcile_binance_spot_depth200_partition_state_origo_job = define_asset_job(
 )
 
 insert_daily_binance_trades_tdw_job = define_asset_job(
-    name="insert_daily_trades_to_tdw_job",
-    selection=["insert_daily_binance_trades_to_tdw"])
+    name='insert_daily_trades_to_tdw_job', selection=['insert_daily_binance_trades_to_tdw']
+)
 
 publish_binance_spot_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_klines_to_huggingface_job",
-    selection=["publish_binance_spot_klines_to_huggingface"])
+    name='publish_binance_spot_klines_to_huggingface_job',
+    selection=['publish_binance_spot_klines_to_huggingface'],
+)
 
 publish_binance_spot_15m_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_15m_klines_to_huggingface_job",
-    selection=["publish_binance_spot_15m_klines_to_huggingface"])
+    name='publish_binance_spot_15m_klines_to_huggingface_job',
+    selection=['publish_binance_spot_15m_klines_to_huggingface'],
+)
 
 publish_binance_spot_30m_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_30m_klines_to_huggingface_job",
-    selection=["publish_binance_spot_30m_klines_to_huggingface"])
+    name='publish_binance_spot_30m_klines_to_huggingface_job',
+    selection=['publish_binance_spot_30m_klines_to_huggingface'],
+)
 
 publish_binance_spot_1h_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_1h_klines_to_huggingface_job",
-    selection=["publish_binance_spot_1h_klines_to_huggingface"])
+    name='publish_binance_spot_1h_klines_to_huggingface_job',
+    selection=['publish_binance_spot_1h_klines_to_huggingface'],
+)
 
 publish_binance_spot_2h_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_2h_klines_to_huggingface_job",
-    selection=["publish_binance_spot_2h_klines_to_huggingface"])
+    name='publish_binance_spot_2h_klines_to_huggingface_job',
+    selection=['publish_binance_spot_2h_klines_to_huggingface'],
+)
 
 publish_binance_spot_4h_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_4h_klines_to_huggingface_job",
-    selection=["publish_binance_spot_4h_klines_to_huggingface"])
+    name='publish_binance_spot_4h_klines_to_huggingface_job',
+    selection=['publish_binance_spot_4h_klines_to_huggingface'],
+)
 
 publish_binance_spot_1M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_1M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_1M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_1M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_1M_dollar_klines_to_huggingface'],
+)
 
 publish_binance_spot_15M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_15M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_15M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_15M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_15M_dollar_klines_to_huggingface'],
+)
 
 publish_binance_spot_30M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_30M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_30M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_30M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_30M_dollar_klines_to_huggingface'],
+)
 
 publish_binance_spot_60M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_60M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_60M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_60M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_60M_dollar_klines_to_huggingface'],
+)
 
 publish_binance_spot_120M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_120M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_120M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_120M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_120M_dollar_klines_to_huggingface'],
+)
 
 publish_binance_spot_240M_dollar_klines_to_huggingface_job = define_asset_job(
-    name="publish_binance_spot_240M_dollar_klines_to_huggingface_job",
-    selection=["publish_binance_spot_240M_dollar_klines_to_huggingface"])
+    name='publish_binance_spot_240M_dollar_klines_to_huggingface_job',
+    selection=['publish_binance_spot_240M_dollar_klines_to_huggingface'],
+)
 
 # Local Parquet Mirror Jobs
 
 publish_binance_spot_klines_to_mount_job = define_asset_job(
-    name="publish_binance_spot_klines_to_mount_job",
+    name='publish_binance_spot_klines_to_mount_job',
     selection=MOUNT_EXPORT_ASSETS,
     executor_def=in_process_executor,
 )
 
 backfill_binance_spot_klines_to_mount_job = define_asset_job(
-    name="backfill_binance_spot_klines_to_mount_job",
+    name='backfill_binance_spot_klines_to_mount_job',
     selection=MOUNT_EXPORT_ASSETS,
     executor_def=in_process_executor,
     config=RunConfig(
         ops={
-            f"export_{spec.name}_to_mount": MountExportConfig(mode="backfill")
+            f'export_{spec.name}_to_mount': MountExportConfig(mode='backfill')
             for spec in MOUNT_EXPORT_SPECS
         }
     ),
 )
 
 publish_binance_spot_klines_to_mount_schedule = ScheduleDefinition(
-    name="publish_binance_spot_klines_to_mount_schedule",
+    name='publish_binance_spot_klines_to_mount_schedule',
     job=publish_binance_spot_klines_to_mount_job,
-    cron_schedule="* * * * *",
-    execution_timezone="UTC",
+    cron_schedule='* * * * *',
+    execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
 
 # Local Arrow Bar Store Jobs
 
 build_bar_store_arrow_job = define_asset_job(
-    name="build_bar_store_arrow_job",
+    name='build_bar_store_arrow_job',
     selection=[build_bar_store_arrow],
     executor_def=in_process_executor,
 )
@@ -511,53 +537,64 @@ build_depth_snapshot_store_arrow_job = define_asset_job(
 )
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
-    name="insert_monthly_agg_trades_to_tdw_job",
-    selection=["insert_monthly_binance_agg_trades_to_tdw"])
+    name='insert_monthly_agg_trades_to_tdw_job',
+    selection=['insert_monthly_binance_agg_trades_to_tdw'],
+)
 
 roll_forward_monthly_binance_trades_job = define_asset_job(
-    name="roll_forward_monthly_binance_trades_job",
+    name='roll_forward_monthly_binance_trades_job',
     selection=[
-        "insert_monthly_binance_trades_to_tdw",
-        "cleanup_binance_daily_trades_for_finalized_month",
-    ])
+        'insert_monthly_binance_trades_to_tdw',
+        'cleanup_binance_daily_trades_for_finalized_month',
+    ],
+)
 
 insert_monthly_binance_futures_trades_job = define_asset_job(
-    name="insert_monthly_futures_trades_to_tdw_job",
-    selection=["insert_monthly_binance_futures_trades_to_tdw"])
+    name='insert_monthly_futures_trades_to_tdw_job',
+    selection=['insert_monthly_binance_futures_trades_to_tdw'],
+)
 
 insert_monthly_binance_futures_agg_trades_job = define_asset_job(
-    name="insert_monthly_futures_agg_trades_to_tdw_job",
-    selection=["insert_monthly_binance_futures_agg_trades_to_tdw"])
+    name='insert_monthly_futures_agg_trades_to_tdw_job',
+    selection=['insert_monthly_binance_futures_agg_trades_to_tdw'],
+)
 
 # summary Table Creation Jobs
 
 create_binance_trades_monthly_summary_job = define_asset_job(
-    name="create_binance_trades_monthly_summary_job",
-    selection=["create_binance_trades_monthly_summary"])
+    name='create_binance_trades_monthly_summary_job',
+    selection=['create_binance_trades_monthly_summary'],
+)
 
 create_binance_trades_daily_summary_job = define_asset_job(
-    name="create_binance_trades_daily_summary_job",
-    selection=["create_binance_trades_daily_summary"])
+    name='create_binance_trades_daily_summary_job',
+    selection=['create_binance_trades_daily_summary'],
+)
 
 create_binance_trades_hourly_summary_job = define_asset_job(
-    name="create_binance_trades_hourly_summary_job",
-    selection=["create_binance_trades_hourly_summary"])
+    name='create_binance_trades_hourly_summary_job',
+    selection=['create_binance_trades_hourly_summary'],
+)
 
 create_binance_trades_hour_of_day_summary_job = define_asset_job(
-    name="create_binance_trades_hour_of_day_summary_job",
-    selection=["create_binance_trades_hour_of_day_summary"])
+    name='create_binance_trades_hour_of_day_summary_job',
+    selection=['create_binance_trades_hour_of_day_summary'],
+)
 
 create_binance_trades_day_of_month_summary_job = define_asset_job(
-    name="create_binance_trades_day_of_month_summary_job",
-    selection=["create_binance_trades_day_of_month_summary"])
+    name='create_binance_trades_day_of_month_summary_job',
+    selection=['create_binance_trades_day_of_month_summary'],
+)
 
 create_binance_trades_week_of_year_summary_job = define_asset_job(
-    name="create_binance_trades_week_of_year_summary_job",
-    selection=["create_binance_trades_week_of_year_summary"])
+    name='create_binance_trades_week_of_year_summary_job',
+    selection=['create_binance_trades_week_of_year_summary'],
+)
 
 create_binance_trades_month_of_year_summary_job = define_asset_job(
-    name="create_binance_trades_month_of_year_summary_job",
-    selection=["create_binance_trades_month_of_year_summary"])
+    name='create_binance_trades_month_of_year_summary_job',
+    selection=['create_binance_trades_month_of_year_summary'],
+)
 
 
 def _get_clickhouse_client():
@@ -573,7 +610,7 @@ def _get_clickhouse_client():
 def _get_clickhouse_password():
     if not CLICKHOUSE_PASSWORD:
         raise RuntimeError(
-            "CLICKHOUSE_PASSWORD environment variable must be set before using ClickHouse-dependent schedules."
+            'CLICKHOUSE_PASSWORD environment variable must be set before using ClickHouse-dependent schedules.'
         )
 
     return CLICKHOUSE_PASSWORD
@@ -667,7 +704,7 @@ def _existing_days_in_range(table_name: str, start_date: str, end_date: str) -> 
 
 
 def _next_daily_overlay_start_day():
-    latest_monthly_day = _latest_day_in_table("binance_trades")
+    latest_monthly_day = _latest_day_in_table('binance_trades')
     if latest_monthly_day is None:
         return None
 
@@ -675,7 +712,7 @@ def _next_daily_overlay_start_day():
 
 
 def _binance_archive_available(file_url: str) -> bool:
-    checksum_url = f"{file_url}.CHECKSUM"
+    checksum_url = f'{file_url}.CHECKSUM'
     try:
         response = requests.get(checksum_url, timeout=30)
         return response.status_code == 200
@@ -738,7 +775,9 @@ def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunR
     execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
-def binance_spot_depth200_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest | SkipReason:
+def binance_spot_depth200_1m_schedule(
+    context: ScheduleEvaluationContext,
+) -> RunRequest | SkipReason:
     minute_start = _last_completed_minute(context.scheduled_execution_time)
     partition_key = depth200_minute_partitions.get_partition_key_for_timestamp(
         minute_start.timestamp()
@@ -769,31 +808,31 @@ def binance_spot_latest_1m_schedule(context: ScheduleEvaluationContext) -> RunRe
 
 @schedule(
     job=insert_daily_binance_trades_tdw_job,
-    cron_schedule="0 */4 * * *",
-    execution_timezone="UTC",
+    cron_schedule='0 */4 * * *',
+    execution_timezone='UTC',
 )
 def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
     scheduled_time = _scheduled_time(context)
     end_date = (scheduled_time - timedelta(days=1)).date()
 
-    if not _table_exists("binance_daily_trades"):
-        return SkipReason("tdw.binance_daily_trades does not exist yet.")
+    if not _table_exists('binance_daily_trades'):
+        return SkipReason('tdw.binance_daily_trades does not exist yet.')
 
-    if not _table_exists("binance_trades"):
-        return SkipReason("tdw.binance_trades does not exist yet.")
+    if not _table_exists('binance_trades'):
+        return SkipReason('tdw.binance_trades does not exist yet.')
 
     start_day = _next_daily_overlay_start_day()
     if start_day is None or start_day > end_date:
-        return SkipReason("No missing daily overlay partitions need to be materialized.")
+        return SkipReason('No missing daily overlay partitions need to be materialized.')
 
     backfill_gap_days = (end_date - start_day).days + 1
     if backfill_gap_days > MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS:
         return SkipReason(
-            "Daily overlay gap is larger than the automated backfill threshold; trigger a manual backfill."
+            'Daily overlay gap is larger than the automated backfill threshold; trigger a manual backfill.'
         )
 
     existing_days = _existing_days_in_range(
-        "binance_daily_trades",
+        'binance_daily_trades',
         start_day.isoformat(),
         end_date.isoformat(),
     )
@@ -804,52 +843,54 @@ def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
         if current_day not in existing_days:
             target_date = current_day.isoformat()
             file_url = (
-                "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
-                f"BTCUSDT-trades-{target_date}.zip"
+                'https://data.binance.vision/data/spot/daily/trades/BTCUSDT/'
+                f'BTCUSDT-trades-{target_date}.zip'
             )
             if _binance_archive_available(file_url):
                 run_requests.append(
                     RunRequest(
                         partition_key=target_date,
-                        run_key=f"binance_daily_trades::{target_date}",
+                        run_key=f'binance_daily_trades::{target_date}',
                     )
                 )
         current_day += timedelta(days=1)
 
     if not run_requests:
-        return SkipReason("No available Binance daily archives were found for missing overlay days.")
+        return SkipReason(
+            'No available Binance daily archives were found for missing overlay days.'
+        )
 
     return run_requests
 
 
 @schedule(
     job=roll_forward_monthly_binance_trades_job,
-    cron_schedule="0 9 * * *",
-    execution_timezone="UTC",
+    cron_schedule='0 9 * * *',
+    execution_timezone='UTC',
 )
 def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
     scheduled_time = _scheduled_time(context)
     current_month_start = scheduled_time.date().replace(day=1)
     previous_month_date = current_month_start - timedelta(days=1)
     previous_month_start = previous_month_date.replace(day=1).isoformat()
-    previous_month_label = previous_month_date.strftime("%Y-%m")
+    previous_month_label = previous_month_date.strftime('%Y-%m')
 
-    if not _table_exists("binance_trades"):
-        return SkipReason("tdw.binance_trades does not exist yet.")
+    if not _table_exists('binance_trades'):
+        return SkipReason('tdw.binance_trades does not exist yet.')
 
-    if _count_rows_for_month("binance_trades", previous_month_start) > 0:
-        return SkipReason(f"Monthly Binance trades for {previous_month_start} are already loaded.")
+    if _count_rows_for_month('binance_trades', previous_month_start) > 0:
+        return SkipReason(f'Monthly Binance trades for {previous_month_start} are already loaded.')
 
     file_url = (
-        "https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/"
-        f"BTCUSDT-trades-{previous_month_label}.zip"
+        'https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/'
+        f'BTCUSDT-trades-{previous_month_label}.zip'
     )
     if not _binance_archive_available(file_url):
-        return SkipReason(f"Monthly Binance archive {previous_month_label} is not available yet.")
+        return SkipReason(f'Monthly Binance archive {previous_month_label} is not available yet.')
 
     return RunRequest(
         partition_key=previous_month_start,
-        run_key=f"binance_trades::{previous_month_start}",
+        run_key=f'binance_trades::{previous_month_start}',
     )
 
 
@@ -859,17 +900,15 @@ def _publish_binance_spot_klines_to_hf_run_request(
     run_key_prefix: str,
 ) -> RunRequest | SkipReason:
     if not asset_event.dagster_event:
-        return SkipReason(
-            "No Dagster event was attached to the Origo spot trades materialization."
-        )
+        return SkipReason('No Dagster event was attached to the Origo spot trades materialization.')
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason("Origo spot trades materialization did not include a partition key.")
+        return SkipReason('Origo spot trades materialization did not include a partition key.')
 
     return RunRequest(
         partition_key=partition_key,
-        run_key=f"{run_key_prefix}::{partition_key}",
+        run_key=f'{run_key_prefix}::{partition_key}',
     )
 
 
@@ -880,21 +919,21 @@ def _publish_binance_spot_dollar_klines_to_hf_run_request(
 ) -> RunRequest | SkipReason:
     if not asset_event.dagster_event:
         return SkipReason(
-            "No Dagster event was attached to the Origo dollar klines materialization."
+            'No Dagster event was attached to the Origo dollar klines materialization.'
         )
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason("Origo dollar klines materialization did not include a partition key.")
+        return SkipReason('Origo dollar klines materialization did not include a partition key.')
 
     return RunRequest(
         partition_key=partition_key,
-        run_key=f"{run_key_prefix}::{partition_key}",
+        run_key=f'{run_key_prefix}::{partition_key}',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_klines_to_huggingface_job,
 )
 def publish_binance_spot_klines_to_huggingface_sensor(
@@ -903,12 +942,12 @@ def publish_binance_spot_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_klines_to_hf",
+        run_key_prefix='publish_binance_spot_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_15m_klines_to_huggingface_job,
 )
 def publish_binance_spot_15m_klines_to_huggingface_sensor(
@@ -917,12 +956,12 @@ def publish_binance_spot_15m_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_15m_klines_to_hf",
+        run_key_prefix='publish_binance_spot_15m_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_30m_klines_to_huggingface_job,
 )
 def publish_binance_spot_30m_klines_to_huggingface_sensor(
@@ -931,12 +970,12 @@ def publish_binance_spot_30m_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_30m_klines_to_hf",
+        run_key_prefix='publish_binance_spot_30m_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_1h_klines_to_huggingface_job,
 )
 def publish_binance_spot_1h_klines_to_huggingface_sensor(
@@ -945,12 +984,12 @@ def publish_binance_spot_1h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_1h_klines_to_hf",
+        run_key_prefix='publish_binance_spot_1h_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_2h_klines_to_huggingface_job,
 )
 def publish_binance_spot_2h_klines_to_huggingface_sensor(
@@ -959,12 +998,12 @@ def publish_binance_spot_2h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_2h_klines_to_hf",
+        run_key_prefix='publish_binance_spot_2h_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
     job=publish_binance_spot_4h_klines_to_huggingface_job,
 )
 def publish_binance_spot_4h_klines_to_huggingface_sensor(
@@ -973,12 +1012,12 @@ def publish_binance_spot_4h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_4h_klines_to_hf",
+        run_key_prefix='publish_binance_spot_4h_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_1M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_1M_dollar_klines_to_huggingface_sensor(
@@ -987,12 +1026,12 @@ def publish_binance_spot_1M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_1M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_1M_dollar_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_15M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_15M_dollar_klines_to_huggingface_sensor(
@@ -1001,12 +1040,12 @@ def publish_binance_spot_15M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_15M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_15M_dollar_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_30M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_30M_dollar_klines_to_huggingface_sensor(
@@ -1015,12 +1054,12 @@ def publish_binance_spot_30M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_30M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_30M_dollar_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_60M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_60M_dollar_klines_to_huggingface_sensor(
@@ -1029,12 +1068,12 @@ def publish_binance_spot_60M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_60M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_60M_dollar_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_120M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_120M_dollar_klines_to_huggingface_sensor(
@@ -1043,12 +1082,12 @@ def publish_binance_spot_120M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_120M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_120M_dollar_klines_to_hf',
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
+    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
     job=publish_binance_spot_240M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_240M_dollar_klines_to_huggingface_sensor(
@@ -1057,7 +1096,7 @@ def publish_binance_spot_240M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix="publish_binance_spot_240M_dollar_klines_to_hf",
+        run_key_prefix='publish_binance_spot_240M_dollar_klines_to_hf',
     )
 
 
@@ -1073,9 +1112,13 @@ def _bar_store_on_mirror_success(context: RunStatusSensorContext) -> list[RunReq
 
 
 def _depth_snapshot_store_on_source_success(context: RunStatusSensorContext) -> RunRequest:
+    source_partition_key = context.dagster_run.tags.get('dagster/partition')
+    if source_partition_key is None:
+        raise RuntimeError('Depth snapshot source run must have a dagster/partition tag.')
     return depth_snapshot_store_partition_run_request(
         context.dagster_run.job_name,
         context.dagster_run.run_id,
+        source_partition_key,
     )
 
 
@@ -1083,7 +1126,7 @@ def _depth_snapshot_store_on_source_success(context: RunStatusSensorContext) -> 
 # decorator: the decorator factory is partially typed in the dagster stubs (would add a
 # pyright error), while the class constructor types cleanly.
 bar_store_source_sensor = RunStatusSensorDefinition(
-    name="bar_store_source_sensor",
+    name='bar_store_source_sensor',
     run_status=DagsterRunStatus.SUCCESS,
     run_status_sensor_fn=_bar_store_on_mirror_success,
     monitored_jobs=[publish_binance_spot_klines_to_mount_job],
@@ -1105,78 +1148,79 @@ depth_snapshot_store_source_sensor = RunStatusSensorDefinition(
 
 
 defs = Definitions(
-    assets=[create_tdw_database,
-            create_origo_database,
-            create_binance_trades_table,
-            create_binance_daily_trades_table,
-            create_binance_daily_spot_trades_table_origo,
-            create_binance_daily_futures_trades_table_origo,
-            create_binance_spot_klines_table_origo,
-            create_binance_spot_dollar_klines_table_origo,
-            create_binance_spot_volume_klines_table_origo,
-            create_binance_spot_tick_klines_table_origo,
-            create_binance_spot_dollar_imbalance_klines_table_origo,
-            create_binance_futures_klines_table_origo,
-            create_binance_spot_depth20_snapshots_table_origo,
-            create_binance_spot_depth20_1m_table_origo,
-            create_binance_spot_depth200_snapshots_table_origo,
-            create_binance_spot_depth200_1m_table_origo,
-            create_binance_spot_latest_tables_origo,
-            create_aligned_1m_exchange_table_origo,
-            create_binance_trades_complete_view,
-            insert_monthly_binance_trades_to_tdw,
-            insert_daily_binance_spot_trades_to_origo,
-            insert_daily_binance_futures_trades_to_origo,
-            refresh_binance_spot_klines_origo,
-            refresh_binance_spot_dollar_klines_origo,
-            refresh_binance_spot_volume_klines_origo,
-            refresh_binance_spot_tick_klines_origo,
-            refresh_binance_spot_dollar_imbalance_klines_origo,
-            refresh_binance_futures_klines_origo,
-            sync_binance_spot_depth20_snapshots_to_origo,
-            refresh_binance_spot_depth20_1m_origo,
-            reconcile_binance_spot_depth20_partition_state_origo,
-            sync_binance_spot_depth200_snapshots_to_origo,
-            refresh_binance_spot_depth200_1m_origo,
-            reconcile_binance_spot_depth200_partition_state_origo,
-            sync_binance_spot_trades_latest_origo,
-            refresh_binance_spot_klines_latest_origo,
-            refresh_binance_spot_dollar_klines_latest_origo,
-            refresh_binance_spot_latest_cuts_origo,
-            cleanup_binance_spot_latest_origo,
-            refresh_aligned_1m_exchange_from_binance_spot_origo,
-            refresh_aligned_1m_exchange_from_binance_futures_origo,
-            insert_daily_binance_trades_to_tdw,
-            publish_binance_spot_klines_to_huggingface,
-            publish_binance_spot_15m_klines_to_huggingface,
-            publish_binance_spot_30m_klines_to_huggingface,
-            publish_binance_spot_1h_klines_to_huggingface,
-            publish_binance_spot_2h_klines_to_huggingface,
-            publish_binance_spot_4h_klines_to_huggingface,
-            publish_binance_spot_1M_dollar_klines_to_huggingface,
-            publish_binance_spot_15M_dollar_klines_to_huggingface,
-            publish_binance_spot_30M_dollar_klines_to_huggingface,
-            publish_binance_spot_60M_dollar_klines_to_huggingface,
-            publish_binance_spot_120M_dollar_klines_to_huggingface,
-            publish_binance_spot_240M_dollar_klines_to_huggingface,
-            *MOUNT_EXPORT_ASSETS,
-            build_bar_store_arrow,
-            build_depth_snapshot_store_arrow,
-            cleanup_binance_daily_trades_for_finalized_month,
-            create_binance_trades_monthly_summary,
-            create_binance_trades_daily_summary,
-            create_binance_trades_hourly_summary,
-            create_binance_trades_hour_of_day_summary,
-            create_binance_trades_day_of_month_summary,
-            create_binance_trades_week_of_year_summary,
-            create_binance_trades_month_of_year_summary,
-            create_binance_agg_trades_table,
-            insert_monthly_binance_agg_trades_to_tdw,
-            create_binance_futures_trades_table,
-            insert_monthly_binance_futures_trades_to_tdw,
-            create_binance_futures_agg_trades_table,
-            insert_monthly_binance_futures_agg_trades_to_tdw],
-    
+    assets=[
+        create_tdw_database,
+        create_origo_database,
+        create_binance_trades_table,
+        create_binance_daily_trades_table,
+        create_binance_daily_spot_trades_table_origo,
+        create_binance_daily_futures_trades_table_origo,
+        create_binance_spot_klines_table_origo,
+        create_binance_spot_dollar_klines_table_origo,
+        create_binance_spot_volume_klines_table_origo,
+        create_binance_spot_tick_klines_table_origo,
+        create_binance_spot_dollar_imbalance_klines_table_origo,
+        create_binance_futures_klines_table_origo,
+        create_binance_spot_depth20_snapshots_table_origo,
+        create_binance_spot_depth20_1m_table_origo,
+        create_binance_spot_depth200_snapshots_table_origo,
+        create_binance_spot_depth200_1m_table_origo,
+        create_binance_spot_latest_tables_origo,
+        create_aligned_1m_exchange_table_origo,
+        create_binance_trades_complete_view,
+        insert_monthly_binance_trades_to_tdw,
+        insert_daily_binance_spot_trades_to_origo,
+        insert_daily_binance_futures_trades_to_origo,
+        refresh_binance_spot_klines_origo,
+        refresh_binance_spot_dollar_klines_origo,
+        refresh_binance_spot_volume_klines_origo,
+        refresh_binance_spot_tick_klines_origo,
+        refresh_binance_spot_dollar_imbalance_klines_origo,
+        refresh_binance_futures_klines_origo,
+        sync_binance_spot_depth20_snapshots_to_origo,
+        refresh_binance_spot_depth20_1m_origo,
+        reconcile_binance_spot_depth20_partition_state_origo,
+        sync_binance_spot_depth200_snapshots_to_origo,
+        refresh_binance_spot_depth200_1m_origo,
+        reconcile_binance_spot_depth200_partition_state_origo,
+        sync_binance_spot_trades_latest_origo,
+        refresh_binance_spot_klines_latest_origo,
+        refresh_binance_spot_dollar_klines_latest_origo,
+        refresh_binance_spot_latest_cuts_origo,
+        cleanup_binance_spot_latest_origo,
+        refresh_aligned_1m_exchange_from_binance_spot_origo,
+        refresh_aligned_1m_exchange_from_binance_futures_origo,
+        insert_daily_binance_trades_to_tdw,
+        publish_binance_spot_klines_to_huggingface,
+        publish_binance_spot_15m_klines_to_huggingface,
+        publish_binance_spot_30m_klines_to_huggingface,
+        publish_binance_spot_1h_klines_to_huggingface,
+        publish_binance_spot_2h_klines_to_huggingface,
+        publish_binance_spot_4h_klines_to_huggingface,
+        publish_binance_spot_1M_dollar_klines_to_huggingface,
+        publish_binance_spot_15M_dollar_klines_to_huggingface,
+        publish_binance_spot_30M_dollar_klines_to_huggingface,
+        publish_binance_spot_60M_dollar_klines_to_huggingface,
+        publish_binance_spot_120M_dollar_klines_to_huggingface,
+        publish_binance_spot_240M_dollar_klines_to_huggingface,
+        *MOUNT_EXPORT_ASSETS,
+        build_bar_store_arrow,
+        build_depth_snapshot_store_arrow,
+        cleanup_binance_daily_trades_for_finalized_month,
+        create_binance_trades_monthly_summary,
+        create_binance_trades_daily_summary,
+        create_binance_trades_hourly_summary,
+        create_binance_trades_hour_of_day_summary,
+        create_binance_trades_day_of_month_summary,
+        create_binance_trades_week_of_year_summary,
+        create_binance_trades_month_of_year_summary,
+        create_binance_agg_trades_table,
+        insert_monthly_binance_agg_trades_to_tdw,
+        create_binance_futures_trades_table,
+        insert_monthly_binance_futures_trades_to_tdw,
+        create_binance_futures_agg_trades_table,
+        insert_monthly_binance_futures_agg_trades_to_tdw,
+    ],
     schedules=[
         daily_binance_spot_pipeline_schedule,
         daily_binance_futures_pipeline_schedule,
@@ -1187,7 +1231,6 @@ defs = Definitions(
         monthly_tdw_rollforward_schedule,
         publish_binance_spot_klines_to_mount_schedule,
     ],
-
     sensors=[
         publish_binance_spot_klines_to_huggingface_sensor,
         publish_binance_spot_15m_klines_to_huggingface_sensor,
@@ -1204,68 +1247,70 @@ defs = Definitions(
         bar_store_source_sensor,
         depth_snapshot_store_source_sensor,
     ],
-
-    jobs=[create_tdw_database_job,
-          create_origo_database_job,
-          create_binance_trades_table_job,
-          create_binance_daily_trades_table_job,
-          create_binance_daily_spot_trades_table_origo_job,
-          create_binance_daily_futures_trades_table_origo_job,
-          create_binance_spot_klines_table_origo_job,
-          create_binance_spot_dollar_klines_table_origo_job,
-          create_binance_spot_volume_klines_table_origo_job,
-          create_binance_spot_tick_klines_table_origo_job,
-          create_binance_spot_dollar_imbalance_klines_table_origo_job,
-          create_binance_futures_klines_table_origo_job,
-          create_binance_spot_depth20_snapshots_table_origo_job,
-          create_binance_spot_depth20_1m_table_origo_job,
-          create_binance_spot_depth200_snapshots_table_origo_job,
-          create_binance_spot_depth200_1m_table_origo_job,
-          create_binance_spot_latest_tables_origo_job,
-          create_aligned_1m_exchange_table_origo_job,
-          create_binance_trades_complete_view_job,
-          insert_monthly_binance_trades_job,
-          refresh_binance_spot_data_source_job,
-          backfill_binance_spot_dollar_klines_origo_job,
-          backfill_binance_spot_trades_origo_job,
-          refresh_binance_futures_data_source_job,
-          refresh_binance_spot_depth20_data_source_job,
-          refresh_binance_spot_depth200_data_source_job,
-          refresh_binance_spot_latest_data_source_job,
-          backfill_binance_spot_depth20_data_source_job,
-          backfill_binance_spot_depth200_data_source_job,
-          reconcile_binance_spot_depth20_partition_state_origo_job,
-          reconcile_binance_spot_depth200_partition_state_origo_job,
-          insert_daily_binance_trades_tdw_job,
-          publish_binance_spot_klines_to_huggingface_job,
-          publish_binance_spot_15m_klines_to_huggingface_job,
-          publish_binance_spot_30m_klines_to_huggingface_job,
-          publish_binance_spot_1h_klines_to_huggingface_job,
-          publish_binance_spot_2h_klines_to_huggingface_job,
-          publish_binance_spot_4h_klines_to_huggingface_job,
-          publish_binance_spot_1M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_15M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_30M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_60M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_120M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_240M_dollar_klines_to_huggingface_job,
-          publish_binance_spot_klines_to_mount_job,
-          backfill_binance_spot_klines_to_mount_job,
-          build_bar_store_arrow_job,
-          build_depth_snapshot_store_arrow_job,
-          roll_forward_monthly_binance_trades_job,
-          create_binance_trades_monthly_summary_job,
-          create_binance_trades_daily_summary_job,
-          create_binance_trades_hourly_summary_job,
-          create_binance_trades_hour_of_day_summary_job,
-          create_binance_trades_day_of_month_summary_job,
-          create_binance_trades_week_of_year_summary_job,
-          create_binance_trades_month_of_year_summary_job,
-          create_binance_agg_trades_table_job,
-          insert_monthly_binance_agg_trades_job,
-          create_binance_futures_trades_table_job,
-          insert_monthly_binance_futures_trades_job,
-          create_binance_futures_agg_trades_table_job,
-          insert_monthly_binance_futures_agg_trades_job])
+    jobs=[
+        create_tdw_database_job,
+        create_origo_database_job,
+        create_binance_trades_table_job,
+        create_binance_daily_trades_table_job,
+        create_binance_daily_spot_trades_table_origo_job,
+        create_binance_daily_futures_trades_table_origo_job,
+        create_binance_spot_klines_table_origo_job,
+        create_binance_spot_dollar_klines_table_origo_job,
+        create_binance_spot_volume_klines_table_origo_job,
+        create_binance_spot_tick_klines_table_origo_job,
+        create_binance_spot_dollar_imbalance_klines_table_origo_job,
+        create_binance_futures_klines_table_origo_job,
+        create_binance_spot_depth20_snapshots_table_origo_job,
+        create_binance_spot_depth20_1m_table_origo_job,
+        create_binance_spot_depth200_snapshots_table_origo_job,
+        create_binance_spot_depth200_1m_table_origo_job,
+        create_binance_spot_latest_tables_origo_job,
+        create_aligned_1m_exchange_table_origo_job,
+        create_binance_trades_complete_view_job,
+        insert_monthly_binance_trades_job,
+        refresh_binance_spot_data_source_job,
+        backfill_binance_spot_dollar_klines_origo_job,
+        backfill_binance_spot_trades_origo_job,
+        refresh_binance_futures_data_source_job,
+        refresh_binance_spot_depth20_data_source_job,
+        refresh_binance_spot_depth200_data_source_job,
+        refresh_binance_spot_latest_data_source_job,
+        backfill_binance_spot_depth20_data_source_job,
+        backfill_binance_spot_depth200_data_source_job,
+        reconcile_binance_spot_depth20_partition_state_origo_job,
+        reconcile_binance_spot_depth200_partition_state_origo_job,
+        insert_daily_binance_trades_tdw_job,
+        publish_binance_spot_klines_to_huggingface_job,
+        publish_binance_spot_15m_klines_to_huggingface_job,
+        publish_binance_spot_30m_klines_to_huggingface_job,
+        publish_binance_spot_1h_klines_to_huggingface_job,
+        publish_binance_spot_2h_klines_to_huggingface_job,
+        publish_binance_spot_4h_klines_to_huggingface_job,
+        publish_binance_spot_1M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_15M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_30M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_60M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_120M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_240M_dollar_klines_to_huggingface_job,
+        publish_binance_spot_klines_to_mount_job,
+        backfill_binance_spot_klines_to_mount_job,
+        build_bar_store_arrow_job,
+        build_depth_snapshot_store_arrow_job,
+        roll_forward_monthly_binance_trades_job,
+        create_binance_trades_monthly_summary_job,
+        create_binance_trades_daily_summary_job,
+        create_binance_trades_hourly_summary_job,
+        create_binance_trades_hour_of_day_summary_job,
+        create_binance_trades_day_of_month_summary_job,
+        create_binance_trades_week_of_year_summary_job,
+        create_binance_trades_month_of_year_summary_job,
+        create_binance_agg_trades_table_job,
+        insert_monthly_binance_agg_trades_job,
+        create_binance_futures_trades_table_job,
+        insert_monthly_binance_futures_trades_job,
+        create_binance_futures_agg_trades_table_job,
+        insert_monthly_binance_futures_agg_trades_job,
+    ],
+)
 
 # TODO: Put everything in to same order in all segments of the code

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -201,7 +201,10 @@ from .assets.build_bar_store_arrow import (
     build_bar_store_arrow,
     bar_store_partition_run_requests,
 )
-from .assets.build_depth_snapshot_store_arrow import build_depth_snapshot_store_arrow
+from .assets.build_depth_snapshot_store_arrow import (
+    build_depth_snapshot_store_arrow,
+    depth_snapshot_store_partition_run_request,
+)
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
@@ -1069,6 +1072,13 @@ def _bar_store_on_mirror_success(context: RunStatusSensorContext) -> list[RunReq
     return bar_store_partition_run_requests(context.dagster_run.run_id)
 
 
+def _depth_snapshot_store_on_source_success(context: RunStatusSensorContext) -> RunRequest:
+    return depth_snapshot_store_partition_run_request(
+        context.dagster_run.job_name,
+        context.dagster_run.run_id,
+    )
+
+
 # Built as a RunStatusSensorDefinition (class) rather than the @run_status_sensor
 # decorator: the decorator factory is partially typed in the dagster stubs (would add a
 # pyright error), while the class constructor types cleanly.
@@ -1078,6 +1088,18 @@ bar_store_source_sensor = RunStatusSensorDefinition(
     run_status_sensor_fn=_bar_store_on_mirror_success,
     monitored_jobs=[publish_binance_spot_klines_to_mount_job],
     request_job=build_bar_store_arrow_job,
+    default_status=DefaultSensorStatus.RUNNING,
+)
+
+depth_snapshot_store_source_sensor = RunStatusSensorDefinition(
+    name='depth_snapshot_store_source_sensor',
+    run_status=DagsterRunStatus.SUCCESS,
+    run_status_sensor_fn=_depth_snapshot_store_on_source_success,
+    monitored_jobs=[
+        refresh_binance_spot_depth20_data_source_job,
+        refresh_binance_spot_depth200_data_source_job,
+    ],
+    request_job=build_depth_snapshot_store_arrow_job,
     default_status=DefaultSensorStatus.RUNNING,
 )
 
@@ -1180,6 +1202,7 @@ defs = Definitions(
         publish_binance_spot_120M_dollar_klines_to_huggingface_sensor,
         publish_binance_spot_240M_dollar_klines_to_huggingface_sensor,
         bar_store_source_sensor,
+        depth_snapshot_store_source_sensor,
     ],
 
     jobs=[create_tdw_database_job,

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -84,26 +84,16 @@ from .assets.create_binance_trades_complete_view import (
 from .assets.create_binance_trades_monthly_summary import create_binance_trades_monthly_summary
 from .assets.create_binance_trades_daily_summary import create_binance_trades_daily_summary
 from .assets.create_binance_trades_hourly_summary import create_binance_trades_hourly_summary
-from .assets.create_binance_trades_hour_of_day_summary import (
-    create_binance_trades_hour_of_day_summary,
-)
-from .assets.create_binance_trades_day_of_month_summary import (
-    create_binance_trades_day_of_month_summary,
-)
-from .assets.create_binance_trades_week_of_year_summary import (
-    create_binance_trades_week_of_year_summary,
-)
-from .assets.create_binance_trades_month_of_year_summary import (
-    create_binance_trades_month_of_year_summary,
-)
+from .assets.create_binance_trades_hour_of_day_summary import create_binance_trades_hour_of_day_summary
+from .assets.create_binance_trades_day_of_month_summary import create_binance_trades_day_of_month_summary
+from .assets.create_binance_trades_week_of_year_summary import create_binance_trades_week_of_year_summary
+from .assets.create_binance_trades_month_of_year_summary import create_binance_trades_month_of_year_summary
 from .assets.create_binance_agg_trades_table import create_binance_agg_trades_table
 from .assets.monthly_agg_trades_to_tdw import insert_monthly_binance_agg_trades_to_tdw
 from .assets.create_binance_futures_trades_table import create_binance_futures_trades_table
 from .assets.monthly_futures_trades_to_tdw import insert_monthly_binance_futures_trades_to_tdw
 from .assets.monthly_futures_agg_trades_to_tdw import create_binance_futures_agg_trades_table
-from .assets.monthly_futures_agg_trades_to_tdw import (
-    insert_monthly_binance_futures_agg_trades_to_tdw,
-)
+from .assets.monthly_futures_agg_trades_to_tdw import insert_monthly_binance_futures_agg_trades_to_tdw
 from .assets.create_origo_database import create_origo_database
 from .assets.create_binance_trades_table_origo import (
     create_binance_daily_spot_trades_table_origo,
@@ -216,11 +206,11 @@ from .assets.build_depth_snapshot_store_arrow import (
     depth_snapshot_store_partition_run_request,
 )
 
-CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', 'clickhouse')
-CLICKHOUSE_PORT = int(os.environ.get('CLICKHOUSE_PORT', 9000))
-CLICKHOUSE_USER = os.environ.get('CLICKHOUSE_USER', 'default')
-CLICKHOUSE_PASSWORD = os.environ.get('CLICKHOUSE_PASSWORD')
-CLICKHOUSE_DATABASE = os.environ.get('CLICKHOUSE_DATABASE', 'tdw')
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 MAX_DAILY_BACKFILL_RUNS_PER_TICK = 14
 MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS = 14
 
@@ -236,69 +226,70 @@ class _AssetEventLike(Protocol):
 # Database Maintenance Jobs
 
 create_tdw_database_job = define_asset_job(
-    name='create_tdw_database_job', selection=['create_tdw_database']
-)
+    name="create_tdw_database_job",
+    selection=["create_tdw_database"])
 
 create_origo_database_job = define_asset_job(
-    name='create_origo_database_job', selection=['create_origo_database']
+    name="create_origo_database_job",
+    selection=["create_origo_database"]
 )
 
 create_binance_trades_table_job = define_asset_job(
-    name='create_binance_trades_table_job', selection=['create_binance_trades_table']
-)
+    name="create_binance_trades_table_job",
+    selection=["create_binance_trades_table"])
 
 create_binance_daily_trades_table_job = define_asset_job(
-    name='create_binance_daily_trades_table_job', selection=['create_binance_daily_trades_table']
-)
+    name="create_binance_daily_trades_table_job",
+    selection=["create_binance_daily_trades_table"])
 
 create_binance_daily_spot_trades_table_origo_job = define_asset_job(
-    name='create_binance_daily_spot_trades_table_origo_job',
-    selection=['create_binance_daily_spot_trades_table_origo'],
+    name="create_binance_daily_spot_trades_table_origo_job",
+    selection=["create_binance_daily_spot_trades_table_origo"]
 )
 
 create_binance_daily_futures_trades_table_origo_job = define_asset_job(
-    name='create_binance_daily_futures_trades_table_origo_job',
-    selection=['create_binance_daily_futures_trades_table_origo'],
+    name="create_binance_daily_futures_trades_table_origo_job",
+    selection=["create_binance_daily_futures_trades_table_origo"]
 )
 
 create_binance_spot_klines_table_origo_job = define_asset_job(
-    name='create_binance_spot_klines_table_origo_job',
-    selection=['create_binance_spot_klines_table_origo'],
+    name="create_binance_spot_klines_table_origo_job",
+    selection=["create_binance_spot_klines_table_origo"]
 )
 
 create_binance_spot_dollar_klines_table_origo_job = define_asset_job(
-    name='create_binance_spot_dollar_klines_table_origo_job',
-    selection=['create_binance_spot_dollar_klines_table_origo'],
+    name="create_binance_spot_dollar_klines_table_origo_job",
+    selection=["create_binance_spot_dollar_klines_table_origo"]
 )
 
 create_binance_spot_volume_klines_table_origo_job = define_asset_job(
-    name='create_binance_spot_volume_klines_table_origo_job',
-    selection=['create_binance_spot_volume_klines_table_origo'],
+    name="create_binance_spot_volume_klines_table_origo_job",
+    selection=["create_binance_spot_volume_klines_table_origo"]
 )
 
 create_binance_spot_tick_klines_table_origo_job = define_asset_job(
-    name='create_binance_spot_tick_klines_table_origo_job',
-    selection=['create_binance_spot_tick_klines_table_origo'],
+    name="create_binance_spot_tick_klines_table_origo_job",
+    selection=["create_binance_spot_tick_klines_table_origo"]
 )
 
 create_binance_spot_dollar_imbalance_klines_table_origo_job = define_asset_job(
-    name='create_binance_spot_dollar_imbalance_klines_table_origo_job',
-    selection=['create_binance_spot_dollar_imbalance_klines_table_origo'],
+    name="create_binance_spot_dollar_imbalance_klines_table_origo_job",
+    selection=["create_binance_spot_dollar_imbalance_klines_table_origo"]
 )
 
 create_binance_futures_klines_table_origo_job = define_asset_job(
-    name='create_binance_futures_klines_table_origo_job',
-    selection=['create_binance_futures_klines_table_origo'],
+    name="create_binance_futures_klines_table_origo_job",
+    selection=["create_binance_futures_klines_table_origo"]
 )
 
 create_binance_spot_depth20_snapshots_table_origo_job = define_asset_job(
-    name='create_binance_spot_depth20_snapshots_table_origo_job',
-    selection=['create_binance_spot_depth20_snapshots_table_origo'],
+    name="create_binance_spot_depth20_snapshots_table_origo_job",
+    selection=["create_binance_spot_depth20_snapshots_table_origo"]
 )
 
 create_binance_spot_depth20_1m_table_origo_job = define_asset_job(
-    name='create_binance_spot_depth20_1m_table_origo_job',
-    selection=['create_binance_spot_depth20_1m_table_origo'],
+    name="create_binance_spot_depth20_1m_table_origo_job",
+    selection=["create_binance_spot_depth20_1m_table_origo"]
 )
 
 create_binance_spot_depth200_snapshots_table_origo_job = define_asset_job(
@@ -317,47 +308,43 @@ create_binance_spot_latest_tables_origo_job = define_asset_job(
 )
 
 create_aligned_1m_exchange_table_origo_job = define_asset_job(
-    name='create_aligned_1m_exchange_table_origo_job',
-    selection=['create_aligned_1m_exchange_table_origo'],
+    name="create_aligned_1m_exchange_table_origo_job",
+    selection=["create_aligned_1m_exchange_table_origo"]
 )
 
 create_binance_trades_complete_view_job = define_asset_job(
-    name='create_binance_trades_complete_view_job',
-    selection=['create_binance_trades_complete_view'],
-)
+    name="create_binance_trades_complete_view_job",
+    selection=["create_binance_trades_complete_view"])
 
 create_binance_agg_trades_table_job = define_asset_job(
-    name='create_binance_agg_trades_table_job', selection=['create_binance_agg_trades_table']
-)
+    name="create_binance_agg_trades_table_job",
+    selection=["create_binance_agg_trades_table"])
 
 create_binance_futures_trades_table_job = define_asset_job(
-    name='create_binance_futures_trades_table_job',
-    selection=['create_binance_futures_trades_table'],
-)
+    name="create_binance_futures_trades_table_job",
+    selection=["create_binance_futures_trades_table"])
 
 create_binance_futures_agg_trades_table_job = define_asset_job(
-    name='create_binance_futures_agg_trades_table_job',
-    selection=['create_binance_futures_agg_trades_table'],
-)
+    name="create_binance_futures_agg_trades_table_job",
+    selection=["create_binance_futures_agg_trades_table"])
 
 # Data Insertion Jobs
 
 insert_monthly_binance_trades_job = define_asset_job(
-    name='insert_monthly_trades_to_tdw_job', selection=['insert_monthly_binance_trades_to_tdw']
-)
+    name="insert_monthly_trades_to_tdw_job",
+    selection=["insert_monthly_binance_trades_to_tdw"])
 
 refresh_binance_spot_data_source_job = define_asset_job(
-    name='refresh_binance_spot_data_source_job',
+    name="refresh_binance_spot_data_source_job",
     selection=[
-        'insert_daily_binance_spot_trades_to_origo',
-        'refresh_binance_spot_klines_origo',
-        'refresh_binance_spot_dollar_klines_origo',
-        'refresh_binance_spot_volume_klines_origo',
-        'refresh_binance_spot_tick_klines_origo',
-        'refresh_binance_spot_dollar_imbalance_klines_origo',
-        'refresh_aligned_1m_exchange_from_binance_spot_origo',
-    ],
-)
+        "insert_daily_binance_spot_trades_to_origo",
+        "refresh_binance_spot_klines_origo",
+        "refresh_binance_spot_dollar_klines_origo",
+        "refresh_binance_spot_volume_klines_origo",
+        "refresh_binance_spot_tick_klines_origo",
+        "refresh_binance_spot_dollar_imbalance_klines_origo",
+        "refresh_aligned_1m_exchange_from_binance_spot_origo",
+    ])
 
 backfill_binance_spot_dollar_klines_origo_job = define_asset_job(
     name='backfill_binance_spot_dollar_klines_origo_job',
@@ -380,13 +367,12 @@ _BINANCE_SPOT_DEPTH200_DATA_SOURCE_SELECTION = [
 ]
 
 refresh_binance_futures_data_source_job = define_asset_job(
-    name='refresh_binance_futures_data_source_job',
+    name="refresh_binance_futures_data_source_job",
     selection=[
-        'insert_daily_binance_futures_trades_to_origo',
-        'refresh_binance_futures_klines_origo',
-        'refresh_aligned_1m_exchange_from_binance_futures_origo',
-    ],
-)
+        "insert_daily_binance_futures_trades_to_origo",
+        "refresh_binance_futures_klines_origo",
+        "refresh_aligned_1m_exchange_from_binance_futures_origo",
+    ])
 
 refresh_binance_spot_depth20_data_source_job = define_asset_job(
     name='refresh_binance_spot_depth20_data_source_job',
@@ -431,101 +417,89 @@ reconcile_binance_spot_depth200_partition_state_origo_job = define_asset_job(
 )
 
 insert_daily_binance_trades_tdw_job = define_asset_job(
-    name='insert_daily_trades_to_tdw_job', selection=['insert_daily_binance_trades_to_tdw']
-)
+    name="insert_daily_trades_to_tdw_job",
+    selection=["insert_daily_binance_trades_to_tdw"])
 
 publish_binance_spot_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_klines_to_huggingface_job',
-    selection=['publish_binance_spot_klines_to_huggingface'],
-)
+    name="publish_binance_spot_klines_to_huggingface_job",
+    selection=["publish_binance_spot_klines_to_huggingface"])
 
 publish_binance_spot_15m_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_15m_klines_to_huggingface_job',
-    selection=['publish_binance_spot_15m_klines_to_huggingface'],
-)
+    name="publish_binance_spot_15m_klines_to_huggingface_job",
+    selection=["publish_binance_spot_15m_klines_to_huggingface"])
 
 publish_binance_spot_30m_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_30m_klines_to_huggingface_job',
-    selection=['publish_binance_spot_30m_klines_to_huggingface'],
-)
+    name="publish_binance_spot_30m_klines_to_huggingface_job",
+    selection=["publish_binance_spot_30m_klines_to_huggingface"])
 
 publish_binance_spot_1h_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_1h_klines_to_huggingface_job',
-    selection=['publish_binance_spot_1h_klines_to_huggingface'],
-)
+    name="publish_binance_spot_1h_klines_to_huggingface_job",
+    selection=["publish_binance_spot_1h_klines_to_huggingface"])
 
 publish_binance_spot_2h_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_2h_klines_to_huggingface_job',
-    selection=['publish_binance_spot_2h_klines_to_huggingface'],
-)
+    name="publish_binance_spot_2h_klines_to_huggingface_job",
+    selection=["publish_binance_spot_2h_klines_to_huggingface"])
 
 publish_binance_spot_4h_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_4h_klines_to_huggingface_job',
-    selection=['publish_binance_spot_4h_klines_to_huggingface'],
-)
+    name="publish_binance_spot_4h_klines_to_huggingface_job",
+    selection=["publish_binance_spot_4h_klines_to_huggingface"])
 
 publish_binance_spot_1M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_1M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_1M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_1M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_1M_dollar_klines_to_huggingface"])
 
 publish_binance_spot_15M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_15M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_15M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_15M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_15M_dollar_klines_to_huggingface"])
 
 publish_binance_spot_30M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_30M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_30M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_30M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_30M_dollar_klines_to_huggingface"])
 
 publish_binance_spot_60M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_60M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_60M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_60M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_60M_dollar_klines_to_huggingface"])
 
 publish_binance_spot_120M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_120M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_120M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_120M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_120M_dollar_klines_to_huggingface"])
 
 publish_binance_spot_240M_dollar_klines_to_huggingface_job = define_asset_job(
-    name='publish_binance_spot_240M_dollar_klines_to_huggingface_job',
-    selection=['publish_binance_spot_240M_dollar_klines_to_huggingface'],
-)
+    name="publish_binance_spot_240M_dollar_klines_to_huggingface_job",
+    selection=["publish_binance_spot_240M_dollar_klines_to_huggingface"])
 
 # Local Parquet Mirror Jobs
 
 publish_binance_spot_klines_to_mount_job = define_asset_job(
-    name='publish_binance_spot_klines_to_mount_job',
+    name="publish_binance_spot_klines_to_mount_job",
     selection=MOUNT_EXPORT_ASSETS,
     executor_def=in_process_executor,
 )
 
 backfill_binance_spot_klines_to_mount_job = define_asset_job(
-    name='backfill_binance_spot_klines_to_mount_job',
+    name="backfill_binance_spot_klines_to_mount_job",
     selection=MOUNT_EXPORT_ASSETS,
     executor_def=in_process_executor,
     config=RunConfig(
         ops={
-            f'export_{spec.name}_to_mount': MountExportConfig(mode='backfill')
+            f"export_{spec.name}_to_mount": MountExportConfig(mode="backfill")
             for spec in MOUNT_EXPORT_SPECS
         }
     ),
 )
 
 publish_binance_spot_klines_to_mount_schedule = ScheduleDefinition(
-    name='publish_binance_spot_klines_to_mount_schedule',
+    name="publish_binance_spot_klines_to_mount_schedule",
     job=publish_binance_spot_klines_to_mount_job,
-    cron_schedule='* * * * *',
-    execution_timezone='UTC',
+    cron_schedule="* * * * *",
+    execution_timezone="UTC",
     default_status=DefaultScheduleStatus.RUNNING,
 )
 
 # Local Arrow Bar Store Jobs
 
 build_bar_store_arrow_job = define_asset_job(
-    name='build_bar_store_arrow_job',
+    name="build_bar_store_arrow_job",
     selection=[build_bar_store_arrow],
     executor_def=in_process_executor,
 )
@@ -537,64 +511,53 @@ build_depth_snapshot_store_arrow_job = define_asset_job(
 )
 
 insert_monthly_binance_agg_trades_job = define_asset_job(
-    name='insert_monthly_agg_trades_to_tdw_job',
-    selection=['insert_monthly_binance_agg_trades_to_tdw'],
-)
+    name="insert_monthly_agg_trades_to_tdw_job",
+    selection=["insert_monthly_binance_agg_trades_to_tdw"])
 
 roll_forward_monthly_binance_trades_job = define_asset_job(
-    name='roll_forward_monthly_binance_trades_job',
+    name="roll_forward_monthly_binance_trades_job",
     selection=[
-        'insert_monthly_binance_trades_to_tdw',
-        'cleanup_binance_daily_trades_for_finalized_month',
-    ],
-)
+        "insert_monthly_binance_trades_to_tdw",
+        "cleanup_binance_daily_trades_for_finalized_month",
+    ])
 
 insert_monthly_binance_futures_trades_job = define_asset_job(
-    name='insert_monthly_futures_trades_to_tdw_job',
-    selection=['insert_monthly_binance_futures_trades_to_tdw'],
-)
+    name="insert_monthly_futures_trades_to_tdw_job",
+    selection=["insert_monthly_binance_futures_trades_to_tdw"])
 
 insert_monthly_binance_futures_agg_trades_job = define_asset_job(
-    name='insert_monthly_futures_agg_trades_to_tdw_job',
-    selection=['insert_monthly_binance_futures_agg_trades_to_tdw'],
-)
+    name="insert_monthly_futures_agg_trades_to_tdw_job",
+    selection=["insert_monthly_binance_futures_agg_trades_to_tdw"])
 
 # summary Table Creation Jobs
 
 create_binance_trades_monthly_summary_job = define_asset_job(
-    name='create_binance_trades_monthly_summary_job',
-    selection=['create_binance_trades_monthly_summary'],
-)
+    name="create_binance_trades_monthly_summary_job",
+    selection=["create_binance_trades_monthly_summary"])
 
 create_binance_trades_daily_summary_job = define_asset_job(
-    name='create_binance_trades_daily_summary_job',
-    selection=['create_binance_trades_daily_summary'],
-)
+    name="create_binance_trades_daily_summary_job",
+    selection=["create_binance_trades_daily_summary"])
 
 create_binance_trades_hourly_summary_job = define_asset_job(
-    name='create_binance_trades_hourly_summary_job',
-    selection=['create_binance_trades_hourly_summary'],
-)
+    name="create_binance_trades_hourly_summary_job",
+    selection=["create_binance_trades_hourly_summary"])
 
 create_binance_trades_hour_of_day_summary_job = define_asset_job(
-    name='create_binance_trades_hour_of_day_summary_job',
-    selection=['create_binance_trades_hour_of_day_summary'],
-)
+    name="create_binance_trades_hour_of_day_summary_job",
+    selection=["create_binance_trades_hour_of_day_summary"])
 
 create_binance_trades_day_of_month_summary_job = define_asset_job(
-    name='create_binance_trades_day_of_month_summary_job',
-    selection=['create_binance_trades_day_of_month_summary'],
-)
+    name="create_binance_trades_day_of_month_summary_job",
+    selection=["create_binance_trades_day_of_month_summary"])
 
 create_binance_trades_week_of_year_summary_job = define_asset_job(
-    name='create_binance_trades_week_of_year_summary_job',
-    selection=['create_binance_trades_week_of_year_summary'],
-)
+    name="create_binance_trades_week_of_year_summary_job",
+    selection=["create_binance_trades_week_of_year_summary"])
 
 create_binance_trades_month_of_year_summary_job = define_asset_job(
-    name='create_binance_trades_month_of_year_summary_job',
-    selection=['create_binance_trades_month_of_year_summary'],
-)
+    name="create_binance_trades_month_of_year_summary_job",
+    selection=["create_binance_trades_month_of_year_summary"])
 
 
 def _get_clickhouse_client():
@@ -610,7 +573,7 @@ def _get_clickhouse_client():
 def _get_clickhouse_password():
     if not CLICKHOUSE_PASSWORD:
         raise RuntimeError(
-            'CLICKHOUSE_PASSWORD environment variable must be set before using ClickHouse-dependent schedules.'
+            "CLICKHOUSE_PASSWORD environment variable must be set before using ClickHouse-dependent schedules."
         )
 
     return CLICKHOUSE_PASSWORD
@@ -704,7 +667,7 @@ def _existing_days_in_range(table_name: str, start_date: str, end_date: str) -> 
 
 
 def _next_daily_overlay_start_day():
-    latest_monthly_day = _latest_day_in_table('binance_trades')
+    latest_monthly_day = _latest_day_in_table("binance_trades")
     if latest_monthly_day is None:
         return None
 
@@ -712,7 +675,7 @@ def _next_daily_overlay_start_day():
 
 
 def _binance_archive_available(file_url: str) -> bool:
-    checksum_url = f'{file_url}.CHECKSUM'
+    checksum_url = f"{file_url}.CHECKSUM"
     try:
         response = requests.get(checksum_url, timeout=30)
         return response.status_code == 200
@@ -775,9 +738,7 @@ def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunR
     execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
-def binance_spot_depth200_1m_schedule(
-    context: ScheduleEvaluationContext,
-) -> RunRequest | SkipReason:
+def binance_spot_depth200_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest | SkipReason:
     minute_start = _last_completed_minute(context.scheduled_execution_time)
     partition_key = depth200_minute_partitions.get_partition_key_for_timestamp(
         minute_start.timestamp()
@@ -808,31 +769,31 @@ def binance_spot_latest_1m_schedule(context: ScheduleEvaluationContext) -> RunRe
 
 @schedule(
     job=insert_daily_binance_trades_tdw_job,
-    cron_schedule='0 */4 * * *',
-    execution_timezone='UTC',
+    cron_schedule="0 */4 * * *",
+    execution_timezone="UTC",
 )
 def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
     scheduled_time = _scheduled_time(context)
     end_date = (scheduled_time - timedelta(days=1)).date()
 
-    if not _table_exists('binance_daily_trades'):
-        return SkipReason('tdw.binance_daily_trades does not exist yet.')
+    if not _table_exists("binance_daily_trades"):
+        return SkipReason("tdw.binance_daily_trades does not exist yet.")
 
-    if not _table_exists('binance_trades'):
-        return SkipReason('tdw.binance_trades does not exist yet.')
+    if not _table_exists("binance_trades"):
+        return SkipReason("tdw.binance_trades does not exist yet.")
 
     start_day = _next_daily_overlay_start_day()
     if start_day is None or start_day > end_date:
-        return SkipReason('No missing daily overlay partitions need to be materialized.')
+        return SkipReason("No missing daily overlay partitions need to be materialized.")
 
     backfill_gap_days = (end_date - start_day).days + 1
     if backfill_gap_days > MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS:
         return SkipReason(
-            'Daily overlay gap is larger than the automated backfill threshold; trigger a manual backfill.'
+            "Daily overlay gap is larger than the automated backfill threshold; trigger a manual backfill."
         )
 
     existing_days = _existing_days_in_range(
-        'binance_daily_trades',
+        "binance_daily_trades",
         start_day.isoformat(),
         end_date.isoformat(),
     )
@@ -843,54 +804,52 @@ def daily_tdw_pipeline_schedule(context: ScheduleEvaluationContext):
         if current_day not in existing_days:
             target_date = current_day.isoformat()
             file_url = (
-                'https://data.binance.vision/data/spot/daily/trades/BTCUSDT/'
-                f'BTCUSDT-trades-{target_date}.zip'
+                "https://data.binance.vision/data/spot/daily/trades/BTCUSDT/"
+                f"BTCUSDT-trades-{target_date}.zip"
             )
             if _binance_archive_available(file_url):
                 run_requests.append(
                     RunRequest(
                         partition_key=target_date,
-                        run_key=f'binance_daily_trades::{target_date}',
+                        run_key=f"binance_daily_trades::{target_date}",
                     )
                 )
         current_day += timedelta(days=1)
 
     if not run_requests:
-        return SkipReason(
-            'No available Binance daily archives were found for missing overlay days.'
-        )
+        return SkipReason("No available Binance daily archives were found for missing overlay days.")
 
     return run_requests
 
 
 @schedule(
     job=roll_forward_monthly_binance_trades_job,
-    cron_schedule='0 9 * * *',
-    execution_timezone='UTC',
+    cron_schedule="0 9 * * *",
+    execution_timezone="UTC",
 )
 def monthly_tdw_rollforward_schedule(context: ScheduleEvaluationContext):
     scheduled_time = _scheduled_time(context)
     current_month_start = scheduled_time.date().replace(day=1)
     previous_month_date = current_month_start - timedelta(days=1)
     previous_month_start = previous_month_date.replace(day=1).isoformat()
-    previous_month_label = previous_month_date.strftime('%Y-%m')
+    previous_month_label = previous_month_date.strftime("%Y-%m")
 
-    if not _table_exists('binance_trades'):
-        return SkipReason('tdw.binance_trades does not exist yet.')
+    if not _table_exists("binance_trades"):
+        return SkipReason("tdw.binance_trades does not exist yet.")
 
-    if _count_rows_for_month('binance_trades', previous_month_start) > 0:
-        return SkipReason(f'Monthly Binance trades for {previous_month_start} are already loaded.')
+    if _count_rows_for_month("binance_trades", previous_month_start) > 0:
+        return SkipReason(f"Monthly Binance trades for {previous_month_start} are already loaded.")
 
     file_url = (
-        'https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/'
-        f'BTCUSDT-trades-{previous_month_label}.zip'
+        "https://data.binance.vision/data/spot/monthly/trades/BTCUSDT/"
+        f"BTCUSDT-trades-{previous_month_label}.zip"
     )
     if not _binance_archive_available(file_url):
-        return SkipReason(f'Monthly Binance archive {previous_month_label} is not available yet.')
+        return SkipReason(f"Monthly Binance archive {previous_month_label} is not available yet.")
 
     return RunRequest(
         partition_key=previous_month_start,
-        run_key=f'binance_trades::{previous_month_start}',
+        run_key=f"binance_trades::{previous_month_start}",
     )
 
 
@@ -900,15 +859,17 @@ def _publish_binance_spot_klines_to_hf_run_request(
     run_key_prefix: str,
 ) -> RunRequest | SkipReason:
     if not asset_event.dagster_event:
-        return SkipReason('No Dagster event was attached to the Origo spot trades materialization.')
+        return SkipReason(
+            "No Dagster event was attached to the Origo spot trades materialization."
+        )
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason('Origo spot trades materialization did not include a partition key.')
+        return SkipReason("Origo spot trades materialization did not include a partition key.")
 
     return RunRequest(
         partition_key=partition_key,
-        run_key=f'{run_key_prefix}::{partition_key}',
+        run_key=f"{run_key_prefix}::{partition_key}",
     )
 
 
@@ -919,21 +880,21 @@ def _publish_binance_spot_dollar_klines_to_hf_run_request(
 ) -> RunRequest | SkipReason:
     if not asset_event.dagster_event:
         return SkipReason(
-            'No Dagster event was attached to the Origo dollar klines materialization.'
+            "No Dagster event was attached to the Origo dollar klines materialization."
         )
 
     partition_key = asset_event.dagster_event.partition
     if partition_key is None:
-        return SkipReason('Origo dollar klines materialization did not include a partition key.')
+        return SkipReason("Origo dollar klines materialization did not include a partition key.")
 
     return RunRequest(
         partition_key=partition_key,
-        run_key=f'{run_key_prefix}::{partition_key}',
+        run_key=f"{run_key_prefix}::{partition_key}",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_klines_to_huggingface_job,
 )
 def publish_binance_spot_klines_to_huggingface_sensor(
@@ -942,12 +903,12 @@ def publish_binance_spot_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_klines_to_hf',
+        run_key_prefix="publish_binance_spot_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_15m_klines_to_huggingface_job,
 )
 def publish_binance_spot_15m_klines_to_huggingface_sensor(
@@ -956,12 +917,12 @@ def publish_binance_spot_15m_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_15m_klines_to_hf',
+        run_key_prefix="publish_binance_spot_15m_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_30m_klines_to_huggingface_job,
 )
 def publish_binance_spot_30m_klines_to_huggingface_sensor(
@@ -970,12 +931,12 @@ def publish_binance_spot_30m_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_30m_klines_to_hf',
+        run_key_prefix="publish_binance_spot_30m_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_1h_klines_to_huggingface_job,
 )
 def publish_binance_spot_1h_klines_to_huggingface_sensor(
@@ -984,12 +945,12 @@ def publish_binance_spot_1h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_1h_klines_to_hf',
+        run_key_prefix="publish_binance_spot_1h_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_2h_klines_to_huggingface_job,
 )
 def publish_binance_spot_2h_klines_to_huggingface_sensor(
@@ -998,12 +959,12 @@ def publish_binance_spot_2h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_2h_klines_to_hf',
+        run_key_prefix="publish_binance_spot_2h_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_klines_origo"),
     job=publish_binance_spot_4h_klines_to_huggingface_job,
 )
 def publish_binance_spot_4h_klines_to_huggingface_sensor(
@@ -1012,12 +973,12 @@ def publish_binance_spot_4h_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_4h_klines_to_hf',
+        run_key_prefix="publish_binance_spot_4h_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_1M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_1M_dollar_klines_to_huggingface_sensor(
@@ -1026,12 +987,12 @@ def publish_binance_spot_1M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_1M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_1M_dollar_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_15M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_15M_dollar_klines_to_huggingface_sensor(
@@ -1040,12 +1001,12 @@ def publish_binance_spot_15M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_15M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_15M_dollar_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_30M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_30M_dollar_klines_to_huggingface_sensor(
@@ -1054,12 +1015,12 @@ def publish_binance_spot_30M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_30M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_30M_dollar_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_60M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_60M_dollar_klines_to_huggingface_sensor(
@@ -1068,12 +1029,12 @@ def publish_binance_spot_60M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_60M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_60M_dollar_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_120M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_120M_dollar_klines_to_huggingface_sensor(
@@ -1082,12 +1043,12 @@ def publish_binance_spot_120M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_120M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_120M_dollar_klines_to_hf",
     )
 
 
 @asset_sensor(
-    asset_key=AssetKey('refresh_binance_spot_dollar_klines_origo'),
+    asset_key=AssetKey("refresh_binance_spot_dollar_klines_origo"),
     job=publish_binance_spot_240M_dollar_klines_to_huggingface_job,
 )
 def publish_binance_spot_240M_dollar_klines_to_huggingface_sensor(
@@ -1096,7 +1057,7 @@ def publish_binance_spot_240M_dollar_klines_to_huggingface_sensor(
 ) -> RunRequest | SkipReason:
     return _publish_binance_spot_dollar_klines_to_hf_run_request(
         asset_event,
-        run_key_prefix='publish_binance_spot_240M_dollar_klines_to_hf',
+        run_key_prefix="publish_binance_spot_240M_dollar_klines_to_hf",
     )
 
 
@@ -1126,7 +1087,7 @@ def _depth_snapshot_store_on_source_success(context: RunStatusSensorContext) -> 
 # decorator: the decorator factory is partially typed in the dagster stubs (would add a
 # pyright error), while the class constructor types cleanly.
 bar_store_source_sensor = RunStatusSensorDefinition(
-    name='bar_store_source_sensor',
+    name="bar_store_source_sensor",
     run_status=DagsterRunStatus.SUCCESS,
     run_status_sensor_fn=_bar_store_on_mirror_success,
     monitored_jobs=[publish_binance_spot_klines_to_mount_job],
@@ -1148,79 +1109,78 @@ depth_snapshot_store_source_sensor = RunStatusSensorDefinition(
 
 
 defs = Definitions(
-    assets=[
-        create_tdw_database,
-        create_origo_database,
-        create_binance_trades_table,
-        create_binance_daily_trades_table,
-        create_binance_daily_spot_trades_table_origo,
-        create_binance_daily_futures_trades_table_origo,
-        create_binance_spot_klines_table_origo,
-        create_binance_spot_dollar_klines_table_origo,
-        create_binance_spot_volume_klines_table_origo,
-        create_binance_spot_tick_klines_table_origo,
-        create_binance_spot_dollar_imbalance_klines_table_origo,
-        create_binance_futures_klines_table_origo,
-        create_binance_spot_depth20_snapshots_table_origo,
-        create_binance_spot_depth20_1m_table_origo,
-        create_binance_spot_depth200_snapshots_table_origo,
-        create_binance_spot_depth200_1m_table_origo,
-        create_binance_spot_latest_tables_origo,
-        create_aligned_1m_exchange_table_origo,
-        create_binance_trades_complete_view,
-        insert_monthly_binance_trades_to_tdw,
-        insert_daily_binance_spot_trades_to_origo,
-        insert_daily_binance_futures_trades_to_origo,
-        refresh_binance_spot_klines_origo,
-        refresh_binance_spot_dollar_klines_origo,
-        refresh_binance_spot_volume_klines_origo,
-        refresh_binance_spot_tick_klines_origo,
-        refresh_binance_spot_dollar_imbalance_klines_origo,
-        refresh_binance_futures_klines_origo,
-        sync_binance_spot_depth20_snapshots_to_origo,
-        refresh_binance_spot_depth20_1m_origo,
-        reconcile_binance_spot_depth20_partition_state_origo,
-        sync_binance_spot_depth200_snapshots_to_origo,
-        refresh_binance_spot_depth200_1m_origo,
-        reconcile_binance_spot_depth200_partition_state_origo,
-        sync_binance_spot_trades_latest_origo,
-        refresh_binance_spot_klines_latest_origo,
-        refresh_binance_spot_dollar_klines_latest_origo,
-        refresh_binance_spot_latest_cuts_origo,
-        cleanup_binance_spot_latest_origo,
-        refresh_aligned_1m_exchange_from_binance_spot_origo,
-        refresh_aligned_1m_exchange_from_binance_futures_origo,
-        insert_daily_binance_trades_to_tdw,
-        publish_binance_spot_klines_to_huggingface,
-        publish_binance_spot_15m_klines_to_huggingface,
-        publish_binance_spot_30m_klines_to_huggingface,
-        publish_binance_spot_1h_klines_to_huggingface,
-        publish_binance_spot_2h_klines_to_huggingface,
-        publish_binance_spot_4h_klines_to_huggingface,
-        publish_binance_spot_1M_dollar_klines_to_huggingface,
-        publish_binance_spot_15M_dollar_klines_to_huggingface,
-        publish_binance_spot_30M_dollar_klines_to_huggingface,
-        publish_binance_spot_60M_dollar_klines_to_huggingface,
-        publish_binance_spot_120M_dollar_klines_to_huggingface,
-        publish_binance_spot_240M_dollar_klines_to_huggingface,
-        *MOUNT_EXPORT_ASSETS,
-        build_bar_store_arrow,
-        build_depth_snapshot_store_arrow,
-        cleanup_binance_daily_trades_for_finalized_month,
-        create_binance_trades_monthly_summary,
-        create_binance_trades_daily_summary,
-        create_binance_trades_hourly_summary,
-        create_binance_trades_hour_of_day_summary,
-        create_binance_trades_day_of_month_summary,
-        create_binance_trades_week_of_year_summary,
-        create_binance_trades_month_of_year_summary,
-        create_binance_agg_trades_table,
-        insert_monthly_binance_agg_trades_to_tdw,
-        create_binance_futures_trades_table,
-        insert_monthly_binance_futures_trades_to_tdw,
-        create_binance_futures_agg_trades_table,
-        insert_monthly_binance_futures_agg_trades_to_tdw,
-    ],
+    assets=[create_tdw_database,
+            create_origo_database,
+            create_binance_trades_table,
+            create_binance_daily_trades_table,
+            create_binance_daily_spot_trades_table_origo,
+            create_binance_daily_futures_trades_table_origo,
+            create_binance_spot_klines_table_origo,
+            create_binance_spot_dollar_klines_table_origo,
+            create_binance_spot_volume_klines_table_origo,
+            create_binance_spot_tick_klines_table_origo,
+            create_binance_spot_dollar_imbalance_klines_table_origo,
+            create_binance_futures_klines_table_origo,
+            create_binance_spot_depth20_snapshots_table_origo,
+            create_binance_spot_depth20_1m_table_origo,
+            create_binance_spot_depth200_snapshots_table_origo,
+            create_binance_spot_depth200_1m_table_origo,
+            create_binance_spot_latest_tables_origo,
+            create_aligned_1m_exchange_table_origo,
+            create_binance_trades_complete_view,
+            insert_monthly_binance_trades_to_tdw,
+            insert_daily_binance_spot_trades_to_origo,
+            insert_daily_binance_futures_trades_to_origo,
+            refresh_binance_spot_klines_origo,
+            refresh_binance_spot_dollar_klines_origo,
+            refresh_binance_spot_volume_klines_origo,
+            refresh_binance_spot_tick_klines_origo,
+            refresh_binance_spot_dollar_imbalance_klines_origo,
+            refresh_binance_futures_klines_origo,
+            sync_binance_spot_depth20_snapshots_to_origo,
+            refresh_binance_spot_depth20_1m_origo,
+            reconcile_binance_spot_depth20_partition_state_origo,
+            sync_binance_spot_depth200_snapshots_to_origo,
+            refresh_binance_spot_depth200_1m_origo,
+            reconcile_binance_spot_depth200_partition_state_origo,
+            sync_binance_spot_trades_latest_origo,
+            refresh_binance_spot_klines_latest_origo,
+            refresh_binance_spot_dollar_klines_latest_origo,
+            refresh_binance_spot_latest_cuts_origo,
+            cleanup_binance_spot_latest_origo,
+            refresh_aligned_1m_exchange_from_binance_spot_origo,
+            refresh_aligned_1m_exchange_from_binance_futures_origo,
+            insert_daily_binance_trades_to_tdw,
+            publish_binance_spot_klines_to_huggingface,
+            publish_binance_spot_15m_klines_to_huggingface,
+            publish_binance_spot_30m_klines_to_huggingface,
+            publish_binance_spot_1h_klines_to_huggingface,
+            publish_binance_spot_2h_klines_to_huggingface,
+            publish_binance_spot_4h_klines_to_huggingface,
+            publish_binance_spot_1M_dollar_klines_to_huggingface,
+            publish_binance_spot_15M_dollar_klines_to_huggingface,
+            publish_binance_spot_30M_dollar_klines_to_huggingface,
+            publish_binance_spot_60M_dollar_klines_to_huggingface,
+            publish_binance_spot_120M_dollar_klines_to_huggingface,
+            publish_binance_spot_240M_dollar_klines_to_huggingface,
+            *MOUNT_EXPORT_ASSETS,
+            build_bar_store_arrow,
+            build_depth_snapshot_store_arrow,
+            cleanup_binance_daily_trades_for_finalized_month,
+            create_binance_trades_monthly_summary,
+            create_binance_trades_daily_summary,
+            create_binance_trades_hourly_summary,
+            create_binance_trades_hour_of_day_summary,
+            create_binance_trades_day_of_month_summary,
+            create_binance_trades_week_of_year_summary,
+            create_binance_trades_month_of_year_summary,
+            create_binance_agg_trades_table,
+            insert_monthly_binance_agg_trades_to_tdw,
+            create_binance_futures_trades_table,
+            insert_monthly_binance_futures_trades_to_tdw,
+            create_binance_futures_agg_trades_table,
+            insert_monthly_binance_futures_agg_trades_to_tdw],
+
     schedules=[
         daily_binance_spot_pipeline_schedule,
         daily_binance_futures_pipeline_schedule,
@@ -1231,6 +1191,7 @@ defs = Definitions(
         monthly_tdw_rollforward_schedule,
         publish_binance_spot_klines_to_mount_schedule,
     ],
+
     sensors=[
         publish_binance_spot_klines_to_huggingface_sensor,
         publish_binance_spot_15m_klines_to_huggingface_sensor,
@@ -1247,70 +1208,68 @@ defs = Definitions(
         bar_store_source_sensor,
         depth_snapshot_store_source_sensor,
     ],
-    jobs=[
-        create_tdw_database_job,
-        create_origo_database_job,
-        create_binance_trades_table_job,
-        create_binance_daily_trades_table_job,
-        create_binance_daily_spot_trades_table_origo_job,
-        create_binance_daily_futures_trades_table_origo_job,
-        create_binance_spot_klines_table_origo_job,
-        create_binance_spot_dollar_klines_table_origo_job,
-        create_binance_spot_volume_klines_table_origo_job,
-        create_binance_spot_tick_klines_table_origo_job,
-        create_binance_spot_dollar_imbalance_klines_table_origo_job,
-        create_binance_futures_klines_table_origo_job,
-        create_binance_spot_depth20_snapshots_table_origo_job,
-        create_binance_spot_depth20_1m_table_origo_job,
-        create_binance_spot_depth200_snapshots_table_origo_job,
-        create_binance_spot_depth200_1m_table_origo_job,
-        create_binance_spot_latest_tables_origo_job,
-        create_aligned_1m_exchange_table_origo_job,
-        create_binance_trades_complete_view_job,
-        insert_monthly_binance_trades_job,
-        refresh_binance_spot_data_source_job,
-        backfill_binance_spot_dollar_klines_origo_job,
-        backfill_binance_spot_trades_origo_job,
-        refresh_binance_futures_data_source_job,
-        refresh_binance_spot_depth20_data_source_job,
-        refresh_binance_spot_depth200_data_source_job,
-        refresh_binance_spot_latest_data_source_job,
-        backfill_binance_spot_depth20_data_source_job,
-        backfill_binance_spot_depth200_data_source_job,
-        reconcile_binance_spot_depth20_partition_state_origo_job,
-        reconcile_binance_spot_depth200_partition_state_origo_job,
-        insert_daily_binance_trades_tdw_job,
-        publish_binance_spot_klines_to_huggingface_job,
-        publish_binance_spot_15m_klines_to_huggingface_job,
-        publish_binance_spot_30m_klines_to_huggingface_job,
-        publish_binance_spot_1h_klines_to_huggingface_job,
-        publish_binance_spot_2h_klines_to_huggingface_job,
-        publish_binance_spot_4h_klines_to_huggingface_job,
-        publish_binance_spot_1M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_15M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_30M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_60M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_120M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_240M_dollar_klines_to_huggingface_job,
-        publish_binance_spot_klines_to_mount_job,
-        backfill_binance_spot_klines_to_mount_job,
-        build_bar_store_arrow_job,
-        build_depth_snapshot_store_arrow_job,
-        roll_forward_monthly_binance_trades_job,
-        create_binance_trades_monthly_summary_job,
-        create_binance_trades_daily_summary_job,
-        create_binance_trades_hourly_summary_job,
-        create_binance_trades_hour_of_day_summary_job,
-        create_binance_trades_day_of_month_summary_job,
-        create_binance_trades_week_of_year_summary_job,
-        create_binance_trades_month_of_year_summary_job,
-        create_binance_agg_trades_table_job,
-        insert_monthly_binance_agg_trades_job,
-        create_binance_futures_trades_table_job,
-        insert_monthly_binance_futures_trades_job,
-        create_binance_futures_agg_trades_table_job,
-        insert_monthly_binance_futures_agg_trades_job,
-    ],
-)
+
+    jobs=[create_tdw_database_job,
+          create_origo_database_job,
+          create_binance_trades_table_job,
+          create_binance_daily_trades_table_job,
+          create_binance_daily_spot_trades_table_origo_job,
+          create_binance_daily_futures_trades_table_origo_job,
+          create_binance_spot_klines_table_origo_job,
+          create_binance_spot_dollar_klines_table_origo_job,
+          create_binance_spot_volume_klines_table_origo_job,
+          create_binance_spot_tick_klines_table_origo_job,
+          create_binance_spot_dollar_imbalance_klines_table_origo_job,
+          create_binance_futures_klines_table_origo_job,
+          create_binance_spot_depth20_snapshots_table_origo_job,
+          create_binance_spot_depth20_1m_table_origo_job,
+          create_binance_spot_depth200_snapshots_table_origo_job,
+          create_binance_spot_depth200_1m_table_origo_job,
+          create_binance_spot_latest_tables_origo_job,
+          create_aligned_1m_exchange_table_origo_job,
+          create_binance_trades_complete_view_job,
+          insert_monthly_binance_trades_job,
+          refresh_binance_spot_data_source_job,
+          backfill_binance_spot_dollar_klines_origo_job,
+          backfill_binance_spot_trades_origo_job,
+          refresh_binance_futures_data_source_job,
+          refresh_binance_spot_depth20_data_source_job,
+          refresh_binance_spot_depth200_data_source_job,
+          refresh_binance_spot_latest_data_source_job,
+          backfill_binance_spot_depth20_data_source_job,
+          backfill_binance_spot_depth200_data_source_job,
+          reconcile_binance_spot_depth20_partition_state_origo_job,
+          reconcile_binance_spot_depth200_partition_state_origo_job,
+          insert_daily_binance_trades_tdw_job,
+          publish_binance_spot_klines_to_huggingface_job,
+          publish_binance_spot_15m_klines_to_huggingface_job,
+          publish_binance_spot_30m_klines_to_huggingface_job,
+          publish_binance_spot_1h_klines_to_huggingface_job,
+          publish_binance_spot_2h_klines_to_huggingface_job,
+          publish_binance_spot_4h_klines_to_huggingface_job,
+          publish_binance_spot_1M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_15M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_30M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_60M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_120M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_240M_dollar_klines_to_huggingface_job,
+          publish_binance_spot_klines_to_mount_job,
+          backfill_binance_spot_klines_to_mount_job,
+          build_bar_store_arrow_job,
+          build_depth_snapshot_store_arrow_job,
+          roll_forward_monthly_binance_trades_job,
+          create_binance_trades_monthly_summary_job,
+          create_binance_trades_daily_summary_job,
+          create_binance_trades_hourly_summary_job,
+          create_binance_trades_hour_of_day_summary_job,
+          create_binance_trades_day_of_month_summary_job,
+          create_binance_trades_week_of_year_summary_job,
+          create_binance_trades_month_of_year_summary_job,
+          create_binance_agg_trades_table_job,
+          insert_monthly_binance_agg_trades_job,
+          create_binance_futures_trades_table_job,
+          insert_monthly_binance_futures_trades_job,
+          create_binance_futures_agg_trades_table_job,
+          insert_monthly_binance_futures_agg_trades_job])
 
 # TODO: Put everything in to same order in all segments of the code

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -295,3 +295,8 @@ def test_definitions_wires_depth_snapshot_arrow_sensor_to_depth_source_jobs(
     assert arrow_job.name == 'build_depth_snapshot_store_arrow_job'
     assert depth20_job.name == DEPTH20_SOURCE_JOB_NAME
     assert depth200_job.name == DEPTH200_SOURCE_JOB_NAME
+    assert sensor.job_name == arrow_job.name
+    assert {job.name for job in sensor._monitored_jobs} == {
+        DEPTH20_SOURCE_JOB_NAME,
+        DEPTH200_SOURCE_JOB_NAME,
+    }

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -14,11 +14,14 @@ os.environ.setdefault('CLICKHOUSE_PASSWORD', 'import-guard')
 import tdw_control_plane.assets.build_depth_snapshot_store_arrow as depth_store
 from tdw_control_plane.assets.build_bar_store_arrow import LATEST_NAME, series_store_dir
 from tdw_control_plane.assets.build_depth_snapshot_store_arrow import (
+    DEPTH20_SOURCE_JOB_NAME,
+    DEPTH200_SOURCE_JOB_NAME,
     DEPTH_SNAPSHOT_PARTITIONS,
     DEPTH_SNAPSHOT_SERIES,
     DepthSnapshotSpec,
     build_depth_snapshot_frame,
     build_depth_snapshot_store_arrow,
+    depth_snapshot_store_partition_run_request,
     spec_for_depth_snapshot_series,
 )
 
@@ -183,9 +186,36 @@ def test_asset_publishes_single_record_batch_ipc(
     assert reader.read_all().column('ts').num_chunks == 1
 
 
+def test_depth_snapshot_partition_run_request_maps_source_jobs() -> None:
+    depth20 = depth_snapshot_store_partition_run_request(DEPTH20_SOURCE_JOB_NAME, 'run-20')
+    depth200 = depth_snapshot_store_partition_run_request(DEPTH200_SOURCE_JOB_NAME, 'run-200')
+
+    assert depth20.partition_key == 'depth20_snapshots'
+    assert depth20.run_key == 'depth20_snapshots:run-20'
+    assert depth200.partition_key == 'depth200_snapshots'
+    assert depth200.run_key == 'depth200_snapshots:run-200'
+
+    with pytest.raises(ValueError, match='Unknown depth snapshot source job: other_job'):
+        depth_snapshot_store_partition_run_request('other_job', 'run-other')
+
+
 def test_definitions_wires_depth_snapshot_arrow_job(origo_definitions_module: object) -> None:
     job = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow_job')
     asset_def = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow')
 
     assert job.name == 'build_depth_snapshot_store_arrow_job'
     assert asset_def.partitions_def.get_partition_keys() == list(DEPTH_SNAPSHOT_SERIES)
+
+
+def test_definitions_wires_depth_snapshot_arrow_sensor_to_depth_source_jobs(
+    origo_definitions_module: object,
+) -> None:
+    sensor = getattr(origo_definitions_module, 'depth_snapshot_store_source_sensor')
+    arrow_job = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow_job')
+    depth20_job = getattr(origo_definitions_module, 'refresh_binance_spot_depth20_data_source_job')
+    depth200_job = getattr(origo_definitions_module, 'refresh_binance_spot_depth200_data_source_job')
+
+    assert sensor.name == 'depth_snapshot_store_source_sensor'
+    assert arrow_job.name == 'build_depth_snapshot_store_arrow_job'
+    assert depth20_job.name == DEPTH20_SOURCE_JOB_NAME
+    assert depth200_job.name == DEPTH200_SOURCE_JOB_NAME

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -12,18 +13,23 @@ from dagster import materialize
 os.environ.setdefault('CLICKHOUSE_PASSWORD', 'import-guard')
 
 import tdw_control_plane.assets.build_depth_snapshot_store_arrow as depth_store
-from tdw_control_plane.assets.build_bar_store_arrow import LATEST_NAME, series_store_dir
+from tdw_control_plane.assets.build_bar_store_arrow import series_store_dir
 from tdw_control_plane.assets.build_depth_snapshot_store_arrow import (
     DEPTH20_SOURCE_JOB_NAME,
     DEPTH200_SOURCE_JOB_NAME,
     DEPTH_SNAPSHOT_PARTITIONS,
     DEPTH_SNAPSHOT_SERIES,
     DepthSnapshotSpec,
+    LATEST_MANIFEST_NAME,
     build_depth_snapshot_frame,
     build_depth_snapshot_store_arrow,
+    depth_snapshot_chunk_relative_path,
     depth_snapshot_store_partition_run_request,
+    minute_start_from_partition_key,
     spec_for_depth_snapshot_series,
 )
+
+SOURCE_PARTITION_KEY = '2026-06-14T12:57:00+0000'
 
 SnapshotRow = tuple[int, int, int, list[tuple[float, float]], list[tuple[float, float]]]
 
@@ -92,10 +98,19 @@ def test_build_depth_snapshot_frame_shapes_fixed_size_books_and_zero_copy_buffer
         _row(2, 22, 202, spec.depth),
     ]
 
-    build = build_depth_snapshot_frame(FakeClickHouseClient(rows), 'origo', spec)
+    client = FakeClickHouseClient(rows)
+    build = build_depth_snapshot_frame(
+        client,
+        'origo',
+        spec,
+        minute_start_from_partition_key(SOURCE_PARTITION_KEY),
+    )
     frame = build.df
     table = frame.to_arrow()
 
+    assert 'WHERE datetime >=' in client.queries[0]
+    assert '2026-06-14 12:57:00.000' in client.queries[0]
+    assert '2026-06-14 12:58:00.000' in client.queries[0]
     assert frame.columns == ['ts', 'source_timestamp_ms', 'last_update_id', 'bids', 'asks']
     assert frame['ts'].to_list() == [1, 2]
     assert frame['source_timestamp_ms'].to_list() == [10, 22]
@@ -123,7 +138,12 @@ def test_build_depth_snapshot_frame_rejects_empty_source() -> None:
     spec = DepthSnapshotSpec('test_depth_snapshots', 'test_table', 2)
 
     with pytest.raises(RuntimeError, match='No source rows found in test_table'):
-        build_depth_snapshot_frame(FakeClickHouseClient([]), 'origo', spec)
+        build_depth_snapshot_frame(
+            FakeClickHouseClient([]),
+            'origo',
+            spec,
+            minute_start_from_partition_key(SOURCE_PARTITION_KEY),
+        )
 
 
 def test_build_depth_snapshot_frame_rejects_wrong_book_depth() -> None:
@@ -131,7 +151,12 @@ def test_build_depth_snapshot_frame_rejects_wrong_book_depth() -> None:
     bad_rows = [(1, 10, 100, _levels(1, 100.0), _levels(2, 200.0))]
 
     with pytest.raises(RuntimeError, match='Expected 2 bids levels at ts=1, got 1'):
-        build_depth_snapshot_frame(FakeClickHouseClient(bad_rows), 'origo', spec)
+        build_depth_snapshot_frame(
+            FakeClickHouseClient(bad_rows),
+            'origo',
+            spec,
+            minute_start_from_partition_key(SOURCE_PARTITION_KEY),
+        )
 
 
 def test_asset_publishes_depth_snapshot_arrow_file(
@@ -147,16 +172,33 @@ def test_asset_publishes_depth_snapshot_arrow_file(
     monkeypatch.setenv('CLICKHOUSE_PASSWORD', 'test-password')
     monkeypatch.setattr(depth_store, 'make_clickhouse_client', client_factory)
 
-    result = materialize([build_depth_snapshot_store_arrow], partition_key='depth20_snapshots')
+    result = materialize(
+        [build_depth_snapshot_store_arrow],
+        partition_key='depth20_snapshots',
+        run_config={
+            'ops': {
+                'build_depth_snapshot_store_arrow': {
+                    'config': {'source_partition_key': SOURCE_PARTITION_KEY}
+                }
+            }
+        },
+    )
 
     assert result.success
     assert fake_client.disconnected
     assert 'binance_spot_depth20_snapshots' in fake_client.queries[0]
 
-    latest = series_store_dir('depth20_snapshots') / LATEST_NAME
-    assert latest.is_symlink()
+    manifest_path = series_store_dir('depth20_snapshots') / LATEST_MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    chunk = series_store_dir('depth20_snapshots') / manifest['chunk']
 
-    table = pa_ipc.open_file(pa.memory_map(str(latest), 'r')).read_all()
+    assert manifest['series'] == 'depth20_snapshots'
+    assert manifest['source_partition_key'] == SOURCE_PARTITION_KEY
+    assert chunk == series_store_dir('depth20_snapshots') / depth_snapshot_chunk_relative_path(
+        minute_start_from_partition_key(SOURCE_PARTITION_KEY)
+    )
+
+    table = pa_ipc.open_file(pa.memory_map(str(chunk), 'r')).read_all()
     assert table.num_rows == 2
     assert table.column_names == ['ts', 'source_timestamp_ms', 'last_update_id', 'bids', 'asks']
     assert table.column('ts').chunk(0).to_numpy(zero_copy_only=True).tolist() == [1, 2]
@@ -176,27 +218,59 @@ def test_asset_publishes_single_record_batch_ipc(
     monkeypatch.setenv('CLICKHOUSE_PASSWORD', 'test-password')
     monkeypatch.setattr(depth_store, 'make_clickhouse_client', client_factory)
 
-    result = materialize([build_depth_snapshot_store_arrow], partition_key='depth20_snapshots')
+    result = materialize(
+        [build_depth_snapshot_store_arrow],
+        partition_key='depth20_snapshots',
+        run_config={
+            'ops': {
+                'build_depth_snapshot_store_arrow': {
+                    'config': {'source_partition_key': SOURCE_PARTITION_KEY}
+                }
+            }
+        },
+    )
 
     assert result.success
+    manifest_path = series_store_dir('depth20_snapshots') / LATEST_MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
     reader = pa_ipc.open_file(
-        pa.memory_map(str(series_store_dir('depth20_snapshots') / LATEST_NAME), 'r')
+        pa.memory_map(str(series_store_dir('depth20_snapshots') / manifest['chunk']), 'r')
     )
     assert reader.num_record_batches == 1
     assert reader.read_all().column('ts').num_chunks == 1
 
 
 def test_depth_snapshot_partition_run_request_maps_source_jobs() -> None:
-    depth20 = depth_snapshot_store_partition_run_request(DEPTH20_SOURCE_JOB_NAME, 'run-20')
-    depth200 = depth_snapshot_store_partition_run_request(DEPTH200_SOURCE_JOB_NAME, 'run-200')
+    depth20 = depth_snapshot_store_partition_run_request(
+        DEPTH20_SOURCE_JOB_NAME,
+        'run-20',
+        SOURCE_PARTITION_KEY,
+    )
+    depth200 = depth_snapshot_store_partition_run_request(
+        DEPTH200_SOURCE_JOB_NAME,
+        'run-200',
+        SOURCE_PARTITION_KEY,
+    )
 
     assert depth20.partition_key == 'depth20_snapshots'
     assert depth20.run_key == 'depth20_snapshots:run-20'
+    assert (
+        depth20.run_config['ops']['build_depth_snapshot_store_arrow']['config'][
+            'source_partition_key'
+        ]
+        == SOURCE_PARTITION_KEY
+    )
     assert depth200.partition_key == 'depth200_snapshots'
     assert depth200.run_key == 'depth200_snapshots:run-200'
+    assert (
+        depth200.run_config['ops']['build_depth_snapshot_store_arrow']['config'][
+            'source_partition_key'
+        ]
+        == SOURCE_PARTITION_KEY
+    )
 
     with pytest.raises(ValueError, match='Unknown depth snapshot source job: other_job'):
-        depth_snapshot_store_partition_run_request('other_job', 'run-other')
+        depth_snapshot_store_partition_run_request('other_job', 'run-other', SOURCE_PARTITION_KEY)
 
 
 def test_definitions_wires_depth_snapshot_arrow_job(origo_definitions_module: object) -> None:
@@ -213,7 +287,9 @@ def test_definitions_wires_depth_snapshot_arrow_sensor_to_depth_source_jobs(
     sensor = getattr(origo_definitions_module, 'depth_snapshot_store_source_sensor')
     arrow_job = getattr(origo_definitions_module, 'build_depth_snapshot_store_arrow_job')
     depth20_job = getattr(origo_definitions_module, 'refresh_binance_spot_depth20_data_source_job')
-    depth200_job = getattr(origo_definitions_module, 'refresh_binance_spot_depth200_data_source_job')
+    depth200_job = getattr(
+        origo_definitions_module, 'refresh_binance_spot_depth200_data_source_job'
+    )
 
     assert sensor.name == 'depth_snapshot_store_source_sensor'
     assert arrow_job.name == 'build_depth_snapshot_store_arrow_job'


### PR DESCRIPTION
Closes #258.

## Summary
- auto-trigger depth Arrow updates after successful depth20/depth200 source refresh jobs
- pass the upstream minute partition into the Arrow run
- publish one mmap-ready Arrow IPC chunk per source minute under `chunks/`, then atomically update `latest.json`
- avoid full-table scans and full-file rewrites on the live minute cadence

## Validation
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --extra dev python -m pytest tests/origo_source_native/test_build_depth_snapshot_store_arrow.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --extra dev python -m pytest tests/origo_source_native -q --maxfail=1`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --extra dev --with pyright==1.1.408 pyright --outputjson > /tmp/tdw-pyright-output.json`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --extra dev python tools/typing_gate.py --pyright-json /tmp/tdw-pyright-output.json --base-budget /tmp/tdw-base-typing-budget.json`
- `python3 tools/fail_loud_gate.py --base-budget /tmp/tdw-base-fail-loud-budget.json`
- `python3 tools/version_gate.py --pr-title "feat(origo): auto-update spot depth Arrow snapshots" --base-pyproject /tmp/tdw-base-pyproject.toml --head-pyproject pyproject.toml --base-changelog /tmp/tdw-base-CHANGELOG.md --head-changelog CHANGELOG.md`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --with ruff==0.15.11 ruff check tools tests/tools`
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-auto-venv uv run --with PyYAML python tools/slice_gate.py --pr-title "feat(origo): auto-update spot depth Arrow snapshots" --pr-body-file /tmp/pr259-body.md --pr-files-file /tmp/pr259-files.txt --template .github/ISSUE_TEMPLATE/slice.yml --repo Vaquum/tdw-control-plane`
- `git diff --check`
