### PR TITLE
fix(origo): reconcile spot depth live gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.20.1 on June 16, 2026
+- Reconcile Binance spot depth20/depth200 live gaps across source history, ClickHouse projections, and Arrow chunks.
+
 # v1.20.0 on June 15, 2026
 - Auto-update Binance spot depth20 and depth200 Arrow snapshots as minute Arrow chunks after their source refresh jobs succeed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickstart_etl"
-version = "1.20.0"
+version = "1.20.1"
 description = "Trades Warehouse Control Plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
+++ b/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
@@ -297,6 +297,17 @@ def _atomic_write_bytes(target: Path, payload: bytes) -> None:
     os.replace(tmp, target)
 
 
+def _latest_manifest_minute(manifest_path: Path) -> datetime | None:
+    if not manifest_path.exists():
+        return None
+
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    source_partition_key = manifest.get('source_partition_key')
+    if not isinstance(source_partition_key, str):
+        raise RuntimeError(f'{manifest_path} does not contain source_partition_key.')
+    return minute_start_from_partition_key(source_partition_key)
+
+
 def publish_depth_snapshot_chunk(
     series: str,
     source_partition_key: str,
@@ -309,6 +320,11 @@ def publish_depth_snapshot_chunk(
     directory = series_store_dir(series)
     chunk = directory / relative_chunk
     _atomic_write_bytes(chunk, payload)
+    manifest_path = directory / LATEST_MANIFEST_NAME
+
+    latest_minute = _latest_manifest_minute(manifest_path)
+    if latest_minute is not None and minute_start < latest_minute:
+        return DepthSnapshotChunkPublish('skipped_not_newer', version, relative_chunk.as_posix())
 
     manifest = {
         'series': series,
@@ -321,7 +337,7 @@ def publish_depth_snapshot_chunk(
         'updated_at_unix_ns': time.time_ns(),
     }
     _atomic_write_bytes(
-        directory / LATEST_MANIFEST_NAME,
+        manifest_path,
         json.dumps(manifest, sort_keys=True).encode('utf-8') + b'\n',
     )
     return DepthSnapshotChunkPublish('published', version, relative_chunk.as_posix())

--- a/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
+++ b/tdw_control_plane/assets/build_depth_snapshot_store_arrow.py
@@ -1,3 +1,4 @@
+import fcntl
 import hashlib
 import io
 import json
@@ -322,24 +323,27 @@ def publish_depth_snapshot_chunk(
     _atomic_write_bytes(chunk, payload)
     manifest_path = directory / LATEST_MANIFEST_NAME
 
-    latest_minute = _latest_manifest_minute(manifest_path)
-    if latest_minute is not None and minute_start < latest_minute:
-        return DepthSnapshotChunkPublish('skipped_not_newer', version, relative_chunk.as_posix())
+    lock_path = directory / f'.{series}.lock'
+    with open(lock_path, 'w', encoding='utf-8') as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        latest_minute = _latest_manifest_minute(manifest_path)
+        if latest_minute is not None and minute_start < latest_minute:
+            return DepthSnapshotChunkPublish('skipped_not_newer', version, relative_chunk.as_posix())
 
-    manifest = {
-        'series': series,
-        'source_partition_key': source_partition_key,
-        'chunk': relative_chunk.as_posix(),
-        'rows': build.df.height,
-        'source_rows': build.source_rows,
-        'dropped_duplicate_ts': build.dropped_duplicate_ts,
-        'version': version,
-        'updated_at_unix_ns': time.time_ns(),
-    }
-    _atomic_write_bytes(
-        manifest_path,
-        json.dumps(manifest, sort_keys=True).encode('utf-8') + b'\n',
-    )
+        manifest = {
+            'series': series,
+            'source_partition_key': source_partition_key,
+            'chunk': relative_chunk.as_posix(),
+            'rows': build.df.height,
+            'source_rows': build.source_rows,
+            'dropped_duplicate_ts': build.dropped_duplicate_ts,
+            'version': version,
+            'updated_at_unix_ns': time.time_ns(),
+        }
+        _atomic_write_bytes(
+            manifest_path,
+            json.dumps(manifest, sort_keys=True).encode('utf-8') + b'\n',
+        )
     return DepthSnapshotChunkPublish('published', version, relative_chunk.as_posix())
 
 

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -787,20 +787,23 @@ def _depth_source_history_url(base_url: str, minute_start: datetime) -> str:
 
 
 def _depth_source_has_rows(spec: DepthLiveReconciliationSpec, minute_start: datetime) -> bool:
-    response = requests.get(
-        _depth_source_history_url(_required_env_value(spec.base_url_env), minute_start),
-        headers={
-            'Accept': 'application/x-ndjson',
-            'Authorization': f'Bearer {_required_env_value(spec.auth_token_env)}',
-        },
-        timeout=30,
-        stream=True,
-    )
     try:
-        response.raise_for_status()
-        return any(line for line in response.iter_lines())
-    finally:
-        response.close()
+        response = requests.get(
+            _depth_source_history_url(_required_env_value(spec.base_url_env), minute_start),
+            headers={
+                'Accept': 'application/x-ndjson',
+                'Authorization': f'Bearer {_required_env_value(spec.auth_token_env)}',
+            },
+            timeout=30,
+            stream=True,
+        )
+        try:
+            response.raise_for_status()
+            return any(line for line in response.iter_lines())
+        finally:
+            response.close()
+    except requests.RequestException:
+        return False
 
 
 def _depth_snapshot_rows(

--- a/tdw_control_plane/definitions.py
+++ b/tdw_control_plane/definitions.py
@@ -7,7 +7,9 @@
 # 5. Add the job to the jobs list
 # 6. If applicable, add a schedule for the job and add it to the schedules list
 
+import json
 import os
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
@@ -26,6 +28,7 @@ from dagster import (
     ScheduleDefinition,
     ScheduleEvaluationContext,
     SkipReason,
+    TimeWindowPartitionsDefinition,
     asset_sensor,
     build_schedule_from_partitioned_job,
     define_asset_job,
@@ -120,15 +123,23 @@ from .assets.create_binance_futures_klines_table_origo import (
     create_binance_futures_klines_table_origo,
 )
 from .assets.create_binance_spot_depth20_1m_table_origo import (
+    DEPTH20_1M_TABLE_NAME,
     create_binance_spot_depth20_1m_table_origo,
 )
 from .assets.create_binance_spot_depth20_snapshots_table_origo import (
+    ClickHouseClient as DepthClickHouseClient,
+    SNAPSHOTS_TABLE_NAME as DEPTH20_SNAPSHOTS_TABLE_NAME,
+    clickhouse_scalar_int as depth_clickhouse_scalar_int,
     create_binance_spot_depth20_snapshots_table_origo,
+    get_clickhouse_settings as get_depth_clickhouse_settings,
+    make_clickhouse_client as make_depth_clickhouse_client,
 )
 from .assets.create_binance_spot_depth200_1m_table_origo import (
+    DEPTH200_1M_TABLE_NAME,
     create_binance_spot_depth200_1m_table_origo,
 )
 from .assets.create_binance_spot_depth200_snapshots_table_origo import (
+    SNAPSHOTS_TABLE_NAME as DEPTH200_SNAPSHOTS_TABLE_NAME,
     create_binance_spot_depth200_snapshots_table_origo,
 )
 from .assets.refresh_binance_spot_klines_origo import refresh_binance_spot_klines_origo
@@ -200,10 +211,15 @@ from .assets.publish_binance_spot_klines_to_mount import (
 from .assets.build_bar_store_arrow import (
     build_bar_store_arrow,
     bar_store_partition_run_requests,
+    series_store_dir,
 )
 from .assets.build_depth_snapshot_store_arrow import (
+    DepthSnapshotStoreConfig,
+    LATEST_MANIFEST_NAME,
     build_depth_snapshot_store_arrow,
+    depth_snapshot_chunk_relative_path,
     depth_snapshot_store_partition_run_request,
+    minute_start_from_partition_key,
 )
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
@@ -213,6 +229,7 @@ CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD")
 CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "tdw")
 MAX_DAILY_BACKFILL_RUNS_PER_TICK = 14
 MAX_AUTOMATED_DAILY_BACKFILL_GAP_DAYS = 14
+DEPTH_SOURCE_LOOKBACK_MINUTES = 15
 
 
 class _DagsterEventLike(Protocol):
@@ -221,6 +238,49 @@ class _DagsterEventLike(Protocol):
 
 class _AssetEventLike(Protocol):
     dagster_event: _DagsterEventLike | None
+
+
+@dataclass(frozen=True)
+class DepthLiveStoreStatus:
+    snapshot_rows: int
+    projection_rows: int
+    arrow_chunk_exists: bool
+    latest_manifest_minute: datetime | None
+
+
+@dataclass(frozen=True)
+class DepthLiveReconciliationSpec:
+    label: str
+    partitions: TimeWindowPartitionsDefinition
+    run_key_prefix: str
+    snapshot_table_name: str
+    projection_table_name: str
+    series: str
+    base_url_env: str
+    auth_token_env: str
+
+
+DEPTH20_LIVE_RECONCILIATION_SPEC = DepthLiveReconciliationSpec(
+    label='Depth20',
+    partitions=depth20_minute_partitions,
+    run_key_prefix='binance_spot_depth20',
+    snapshot_table_name=DEPTH20_SNAPSHOTS_TABLE_NAME,
+    projection_table_name=DEPTH20_1M_TABLE_NAME,
+    series='depth20_snapshots',
+    base_url_env='BINANCE_SPOT_DEPTH20_BASE_URL',
+    auth_token_env='BINANCE_SPOT_DEPTH20_AUTH_TOKEN',
+)
+
+DEPTH200_LIVE_RECONCILIATION_SPEC = DepthLiveReconciliationSpec(
+    label='Depth200',
+    partitions=depth200_minute_partitions,
+    run_key_prefix='binance_spot_depth200',
+    snapshot_table_name=DEPTH200_SNAPSHOTS_TABLE_NAME,
+    projection_table_name=DEPTH200_1M_TABLE_NAME,
+    series='depth200_snapshots',
+    base_url_env='BINANCE_SPOT_DEPTH200_BASE_URL',
+    auth_token_env='BINANCE_SPOT_DEPTH200_AUTH_TOKEN',
+)
 
 
 # Database Maintenance Jobs
@@ -404,6 +464,16 @@ backfill_binance_spot_depth20_data_source_job = define_asset_job(
 backfill_binance_spot_depth200_data_source_job = define_asset_job(
     name='backfill_binance_spot_depth200_data_source_job',
     selection=_BINANCE_SPOT_DEPTH200_DATA_SOURCE_SELECTION,
+)
+
+repair_binance_spot_depth20_projection_job = define_asset_job(
+    name='repair_binance_spot_depth20_projection_job',
+    selection=['refresh_binance_spot_depth20_1m_origo'],
+)
+
+repair_binance_spot_depth200_projection_job = define_asset_job(
+    name='repair_binance_spot_depth200_projection_job',
+    selection=['refresh_binance_spot_depth200_1m_origo'],
 )
 
 reconcile_binance_spot_depth20_partition_state_origo_job = define_asset_job(
@@ -696,6 +766,225 @@ def _last_completed_minute(scheduled_time: datetime | None) -> datetime:
     )
 
 
+def _required_env_value(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f'{name} environment variable must be set.')
+    return value
+
+
+def _depth_clickhouse_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _depth_clickhouse_datetime64(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.000')
+
+
+def _depth_source_history_url(base_url: str, minute_start: datetime) -> str:
+    unix_seconds = int(minute_start.timestamp())
+    return f'{base_url.rstrip("/")}/history?from={unix_seconds}&to={unix_seconds}'
+
+
+def _depth_source_has_rows(spec: DepthLiveReconciliationSpec, minute_start: datetime) -> bool:
+    response = requests.get(
+        _depth_source_history_url(_required_env_value(spec.base_url_env), minute_start),
+        headers={
+            'Accept': 'application/x-ndjson',
+            'Authorization': f'Bearer {_required_env_value(spec.auth_token_env)}',
+        },
+        timeout=30,
+        stream=True,
+    )
+    try:
+        response.raise_for_status()
+        return any(line for line in response.iter_lines())
+    finally:
+        response.close()
+
+
+def _depth_snapshot_rows(
+    client: DepthClickHouseClient,
+    database: str,
+    spec: DepthLiveReconciliationSpec,
+    minute_start: datetime,
+) -> int:
+    minute_end = minute_start + timedelta(minutes=1)
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{spec.snapshot_table_name} FINAL
+        WHERE datetime >= toDateTime64('{_depth_clickhouse_datetime64(minute_start)}', 3)
+          AND datetime < toDateTime64('{_depth_clickhouse_datetime64(minute_end)}', 3)
+        """
+    )
+    return depth_clickhouse_scalar_int(result)
+
+
+def _depth_projection_rows(
+    client: DepthClickHouseClient,
+    database: str,
+    spec: DepthLiveReconciliationSpec,
+    minute_start: datetime,
+) -> int:
+    result = client.execute(
+        f"""
+        SELECT count()
+        FROM {database}.{spec.projection_table_name} FINAL
+        WHERE datetime = toDateTime('{_depth_clickhouse_datetime(minute_start)}')
+        """
+    )
+    return depth_clickhouse_scalar_int(result)
+
+
+def _depth_arrow_chunk_exists(spec: DepthLiveReconciliationSpec, minute_start: datetime) -> bool:
+    chunk_path = series_store_dir(spec.series) / depth_snapshot_chunk_relative_path(minute_start)
+    return chunk_path.is_file()
+
+
+def _depth_latest_manifest_minute(spec: DepthLiveReconciliationSpec) -> datetime | None:
+    manifest_path = series_store_dir(spec.series) / LATEST_MANIFEST_NAME
+    if not manifest_path.exists():
+        return None
+
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    source_partition_key = manifest.get('source_partition_key')
+    if not isinstance(source_partition_key, str):
+        raise RuntimeError(f'{manifest_path} does not contain source_partition_key.')
+    return minute_start_from_partition_key(source_partition_key)
+
+
+def _depth_store_status(
+    client: DepthClickHouseClient,
+    database: str,
+    spec: DepthLiveReconciliationSpec,
+    minute_start: datetime,
+) -> DepthLiveStoreStatus:
+    return DepthLiveStoreStatus(
+        snapshot_rows=_depth_snapshot_rows(client, database, spec, minute_start),
+        projection_rows=_depth_projection_rows(client, database, spec, minute_start),
+        arrow_chunk_exists=_depth_arrow_chunk_exists(spec, minute_start),
+        latest_manifest_minute=_depth_latest_manifest_minute(spec),
+    )
+
+
+def _depth_arrow_is_complete(status: DepthLiveStoreStatus, minute_start: datetime) -> bool:
+    return (
+        status.arrow_chunk_exists
+        and status.latest_manifest_minute is not None
+        and status.latest_manifest_minute >= minute_start
+    )
+
+
+def _depth_candidate_minutes(
+    context: ScheduleEvaluationContext,
+    spec: DepthLiveReconciliationSpec,
+) -> tuple[tuple[datetime, str], ...]:
+    if DEPTH_SOURCE_LOOKBACK_MINUTES < 1:
+        raise RuntimeError('DEPTH_SOURCE_LOOKBACK_MINUTES must be at least 1.')
+
+    last_minute = _last_completed_minute(context.scheduled_execution_time)
+    candidates: list[tuple[datetime, str]] = []
+    for offset in reversed(range(DEPTH_SOURCE_LOOKBACK_MINUTES)):
+        minute_start = last_minute - timedelta(minutes=offset)
+        partition_key = spec.partitions.get_partition_key_for_timestamp(minute_start.timestamp())
+        if spec.partitions.has_partition_key(partition_key):
+            candidates.append((minute_start, partition_key))
+    return tuple(candidates)
+
+
+def _scheduled_run_key_suffix(context: ScheduleEvaluationContext) -> str:
+    return _scheduled_time(context).astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+
+
+def _depth_reconciliation_run_requests(
+    context: ScheduleEvaluationContext,
+    spec: DepthLiveReconciliationSpec,
+) -> list[RunRequest] | SkipReason:
+    settings = get_depth_clickhouse_settings()
+    client = make_depth_clickhouse_client(settings)
+    run_key_suffix = _scheduled_run_key_suffix(context)
+    run_requests: list[RunRequest] = []
+
+    try:
+        for minute_start, partition_key in _depth_candidate_minutes(context, spec):
+            status = _depth_store_status(client, settings.database, spec, minute_start)
+            if status.snapshot_rows == 0 and _depth_source_has_rows(spec, minute_start):
+                run_requests.append(
+                    RunRequest(
+                        partition_key=partition_key,
+                        run_key=f'{spec.run_key_prefix}:source:{partition_key}:{run_key_suffix}',
+                    )
+                )
+    finally:
+        client.disconnect()
+
+    if not run_requests:
+        return SkipReason(f'{spec.label}: no source-available raw depth gaps in lookback.')
+    return run_requests
+
+
+def _depth_projection_reconciliation_run_requests(
+    context: ScheduleEvaluationContext,
+    spec: DepthLiveReconciliationSpec,
+) -> list[RunRequest] | SkipReason:
+    settings = get_depth_clickhouse_settings()
+    client = make_depth_clickhouse_client(settings)
+    run_key_suffix = _scheduled_run_key_suffix(context)
+    run_requests: list[RunRequest] = []
+
+    try:
+        for minute_start, partition_key in _depth_candidate_minutes(context, spec):
+            status = _depth_store_status(client, settings.database, spec, minute_start)
+            if status.snapshot_rows > 0 and status.projection_rows == 0:
+                run_requests.append(
+                    RunRequest(
+                        partition_key=partition_key,
+                        run_key=f'{spec.run_key_prefix}:projection:{partition_key}:{run_key_suffix}',
+                    )
+                )
+    finally:
+        client.disconnect()
+
+    if not run_requests:
+        return SkipReason(f'{spec.label}: no raw-present projection gaps in lookback.')
+    return run_requests
+
+
+def _depth_arrow_reconciliation_run_requests(
+    context: ScheduleEvaluationContext,
+    spec: DepthLiveReconciliationSpec,
+) -> list[RunRequest] | SkipReason:
+    settings = get_depth_clickhouse_settings()
+    client = make_depth_clickhouse_client(settings)
+    run_key_suffix = _scheduled_run_key_suffix(context)
+    run_requests: list[RunRequest] = []
+
+    try:
+        for minute_start, partition_key in _depth_candidate_minutes(context, spec):
+            status = _depth_store_status(client, settings.database, spec, minute_start)
+            if status.snapshot_rows > 0 and not _depth_arrow_is_complete(status, minute_start):
+                run_requests.append(
+                    RunRequest(
+                        partition_key=spec.series,
+                        run_key=f'{spec.run_key_prefix}:arrow:{partition_key}:{run_key_suffix}',
+                        run_config=RunConfig(
+                            ops={
+                                'build_depth_snapshot_store_arrow': DepthSnapshotStoreConfig(
+                                    source_partition_key=partition_key
+                                )
+                            }
+                        ),
+                    )
+                )
+    finally:
+        client.disconnect()
+
+    if not run_requests:
+        return SkipReason(f'{spec.label}: no raw-present Arrow gaps in lookback.')
+    return run_requests
+
+
 daily_binance_spot_pipeline_schedule = build_schedule_from_partitioned_job(
     refresh_binance_spot_data_source_job,
     name='daily_binance_spot_pipeline_schedule',
@@ -718,18 +1007,36 @@ daily_binance_futures_pipeline_schedule = build_schedule_from_partitioned_job(
     execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
-def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest | SkipReason:
-    minute_start = _last_completed_minute(context.scheduled_execution_time)
-    partition_key = depth20_minute_partitions.get_partition_key_for_timestamp(
-        minute_start.timestamp()
-    )
-    if not depth20_minute_partitions.has_partition_key(partition_key):
-        return SkipReason(f'Depth20 partition {partition_key} is before the partition start.')
+def binance_spot_depth20_1m_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_reconciliation_run_requests(context, DEPTH20_LIVE_RECONCILIATION_SPEC)
 
-    return RunRequest(
-        partition_key=partition_key,
-        run_key=f'binance_spot_depth20::{partition_key}',
+
+@schedule(
+    job=repair_binance_spot_depth20_projection_job,
+    cron_schedule='* * * * *',
+    execution_timezone='UTC',
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+def binance_spot_depth20_projection_repair_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_projection_reconciliation_run_requests(
+        context, DEPTH20_LIVE_RECONCILIATION_SPEC
     )
+
+
+@schedule(
+    job=build_depth_snapshot_store_arrow_job,
+    cron_schedule='* * * * *',
+    execution_timezone='UTC',
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+def binance_spot_depth20_arrow_repair_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_arrow_reconciliation_run_requests(context, DEPTH20_LIVE_RECONCILIATION_SPEC)
 
 
 @schedule(
@@ -738,18 +1045,36 @@ def binance_spot_depth20_1m_schedule(context: ScheduleEvaluationContext) -> RunR
     execution_timezone='UTC',
     default_status=DefaultScheduleStatus.RUNNING,
 )
-def binance_spot_depth200_1m_schedule(context: ScheduleEvaluationContext) -> RunRequest | SkipReason:
-    minute_start = _last_completed_minute(context.scheduled_execution_time)
-    partition_key = depth200_minute_partitions.get_partition_key_for_timestamp(
-        minute_start.timestamp()
-    )
-    if not depth200_minute_partitions.has_partition_key(partition_key):
-        return SkipReason(f'Depth200 partition {partition_key} is before the partition start.')
+def binance_spot_depth200_1m_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_reconciliation_run_requests(context, DEPTH200_LIVE_RECONCILIATION_SPEC)
 
-    return RunRequest(
-        partition_key=partition_key,
-        run_key=f'binance_spot_depth200::{partition_key}',
+
+@schedule(
+    job=repair_binance_spot_depth200_projection_job,
+    cron_schedule='* * * * *',
+    execution_timezone='UTC',
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+def binance_spot_depth200_projection_repair_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_projection_reconciliation_run_requests(
+        context, DEPTH200_LIVE_RECONCILIATION_SPEC
     )
+
+
+@schedule(
+    job=build_depth_snapshot_store_arrow_job,
+    cron_schedule='* * * * *',
+    execution_timezone='UTC',
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+def binance_spot_depth200_arrow_repair_schedule(
+    context: ScheduleEvaluationContext,
+) -> list[RunRequest] | SkipReason:
+    return _depth_arrow_reconciliation_run_requests(context, DEPTH200_LIVE_RECONCILIATION_SPEC)
 
 
 @schedule(
@@ -1185,7 +1510,11 @@ defs = Definitions(
         daily_binance_spot_pipeline_schedule,
         daily_binance_futures_pipeline_schedule,
         binance_spot_depth20_1m_schedule,
+        binance_spot_depth20_projection_repair_schedule,
+        binance_spot_depth20_arrow_repair_schedule,
         binance_spot_depth200_1m_schedule,
+        binance_spot_depth200_projection_repair_schedule,
+        binance_spot_depth200_arrow_repair_schedule,
         binance_spot_latest_1m_schedule,
         daily_tdw_pipeline_schedule,
         monthly_tdw_rollforward_schedule,
@@ -1238,6 +1567,8 @@ defs = Definitions(
           refresh_binance_spot_latest_data_source_job,
           backfill_binance_spot_depth20_data_source_job,
           backfill_binance_spot_depth200_data_source_job,
+          repair_binance_spot_depth20_projection_job,
+          repair_binance_spot_depth200_projection_job,
           reconcile_binance_spot_depth20_partition_state_origo_job,
           reconcile_binance_spot_depth200_partition_state_origo_job,
           insert_daily_binance_trades_tdw_job,

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -26,6 +26,7 @@ from tdw_control_plane.assets.build_depth_snapshot_store_arrow import (
     depth_snapshot_chunk_relative_path,
     depth_snapshot_store_partition_run_request,
     minute_start_from_partition_key,
+    publish_depth_snapshot_chunk,
     spec_for_depth_snapshot_series,
 )
 
@@ -238,6 +239,52 @@ def test_asset_publishes_single_record_batch_ipc(
     )
     assert reader.num_record_batches == 1
     assert reader.read_all().column('ts').num_chunks == 1
+
+
+def test_depth_snapshot_publish_keeps_latest_manifest_monotonic_for_backfilled_chunk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    newer_partition_key = '2026-06-14T12:58:00+0000'
+    older_partition_key = '2026-06-14T12:57:00+0000'
+    spec = DepthSnapshotSpec('depth20_snapshots', 'test_table', 20)
+    newer_build = build_depth_snapshot_frame(
+        FakeClickHouseClient([_row(2, 20, 200, spec.depth)]),
+        'origo',
+        spec,
+        minute_start_from_partition_key(newer_partition_key),
+    )
+    older_build = build_depth_snapshot_frame(
+        FakeClickHouseClient([_row(1, 10, 100, spec.depth)]),
+        'origo',
+        spec,
+        minute_start_from_partition_key(older_partition_key),
+    )
+
+    monkeypatch.setenv('LOCAL_ARROW_DIR', str(tmp_path))
+
+    newer_outcome = publish_depth_snapshot_chunk(
+        'depth20_snapshots', newer_partition_key, newer_build
+    )
+    older_outcome = publish_depth_snapshot_chunk(
+        'depth20_snapshots', older_partition_key, older_build
+    )
+    manifest_path = series_store_dir('depth20_snapshots') / LATEST_MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    older_chunk = series_store_dir('depth20_snapshots') / depth_snapshot_chunk_relative_path(
+        minute_start_from_partition_key(older_partition_key)
+    )
+
+    assert newer_outcome.status == 'published'
+    assert older_outcome.status == 'skipped_not_newer'
+    assert older_chunk.exists()
+    assert manifest['source_partition_key'] == newer_partition_key
+    assert (
+        manifest['chunk']
+        == depth_snapshot_chunk_relative_path(
+            minute_start_from_partition_key(newer_partition_key)
+        ).as_posix()
+    )
 
 
 def test_depth_snapshot_partition_run_request_maps_source_jobs() -> None:

--- a/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
+++ b/tests/origo_source_native/test_build_depth_snapshot_store_arrow.py
@@ -4,6 +4,7 @@ import os
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Protocol
 
 import pyarrow as pa
 import pyarrow.ipc as pa_ipc
@@ -33,6 +34,10 @@ from tdw_control_plane.assets.build_depth_snapshot_store_arrow import (
 SOURCE_PARTITION_KEY = '2026-06-14T12:57:00+0000'
 
 SnapshotRow = tuple[int, int, int, list[tuple[float, float]], list[tuple[float, float]]]
+
+
+class _NamedLockFile(Protocol):
+    name: str
 
 
 class FakeClickHouseClient:
@@ -285,6 +290,31 @@ def test_depth_snapshot_publish_keeps_latest_manifest_monotonic_for_backfilled_c
             minute_start_from_partition_key(newer_partition_key)
         ).as_posix()
     )
+
+
+def test_depth_snapshot_publish_locks_latest_manifest_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = DepthSnapshotSpec('depth20_snapshots', 'test_table', 20)
+    build = build_depth_snapshot_frame(
+        FakeClickHouseClient([_row(1, 10, 100, spec.depth)]),
+        'origo',
+        spec,
+        minute_start_from_partition_key(SOURCE_PARTITION_KEY),
+    )
+    lock_calls: list[tuple[str, int]] = []
+
+    def record_lock(lock_file: _NamedLockFile, operation: int) -> None:
+        lock_calls.append((Path(lock_file.name).name, operation))
+
+    monkeypatch.setenv('LOCAL_ARROW_DIR', str(tmp_path))
+    monkeypatch.setattr(depth_store.fcntl, 'flock', record_lock)
+
+    outcome = publish_depth_snapshot_chunk('depth20_snapshots', SOURCE_PARTITION_KEY, build)
+
+    assert outcome.status == 'published'
+    assert lock_calls == [('.depth20_snapshots.lock', depth_store.fcntl.LOCK_EX)]
 
 
 def test_depth_snapshot_partition_run_request_maps_source_jobs() -> None:

--- a/tests/origo_source_native/test_origo_binance_spot_depth200_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth200_data_source_template.py
@@ -5,7 +5,14 @@ from datetime import datetime, timezone
 from math import isclose
 from typing import cast
 
-from dagster import DagsterInstance, DefaultScheduleStatus, build_schedule_context, materialize
+import pytest
+from dagster import (
+    DagsterInstance,
+    DefaultScheduleStatus,
+    RunRequest,
+    build_schedule_context,
+    materialize,
+)
 
 from .helpers import BINANCE_FIXTURE_ROOT, ORIGO_DATABASE
 
@@ -21,9 +28,33 @@ DEPTH200_EXPECTED_COLUMNS = [
     'book_imbalance_200',
 ]
 DEPTH200_FIXTURE_PATH = BINANCE_FIXTURE_ROOT / 'spot/depth200/history'
-DEPTH200_TEST_LEVELS_SQL = (
-    '[' + ','.join(f'({level}.0,{level}.0)' for level in range(1, 201)) + ']'
-)
+DEPTH200_TEST_LEVELS_SQL = '[' + ','.join(f'({level}.0,{level}.0)' for level in range(1, 201)) + ']'
+
+
+class _FakeDepthSettings:
+    database = ORIGO_DATABASE
+
+
+class _FakeDepthClient:
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _patch_depth_clickhouse(origo_definitions_module, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        origo_definitions_module,
+        'get_depth_clickhouse_settings',
+        lambda: _FakeDepthSettings(),
+    )
+    monkeypatch.setattr(
+        origo_definitions_module,
+        'make_depth_clickhouse_client',
+        lambda settings: _FakeDepthClient(),
+    )
 
 
 def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
@@ -259,11 +290,26 @@ def test_binance_spot_depth200_table_creation_jobs_are_registered(
 
 def test_binance_spot_depth200_data_source_job_and_schedule_are_registered(
     origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repository_def = origo_definitions_module.defs.get_repository_def()
     schedule_def = repository_def.get_schedule_def('binance_spot_depth200_1m_schedule')
     job_def = origo_definitions_module.defs.get_job_def(
         'refresh_binance_spot_depth200_data_source_job'
+    )
+
+    def fake_reconciliation_run_requests(context, spec) -> list[RunRequest]:
+        return [
+            RunRequest(
+                partition_key=DEPTH200_SCHEDULE_PARTITION_KEY,
+                run_key=f'binance_spot_depth200:source:{DEPTH200_SCHEDULE_PARTITION_KEY}:20260614T125800Z',
+            )
+        ]
+
+    monkeypatch.setattr(
+        origo_definitions_module,
+        '_depth_reconciliation_run_requests',
+        fake_reconciliation_run_requests,
     )
     context = build_schedule_context(
         scheduled_execution_time=datetime(2026, 6, 14, 12, 58, tzinfo=timezone.utc),
@@ -282,8 +328,149 @@ def test_binance_spot_depth200_data_source_job_and_schedule_are_registered(
     assert job_def.partitions_def.get_first_partition_key() == DEPTH200_FIRST_PARTITION_KEY
     assert len(tick.run_requests) == 1
     assert tick.run_requests[0].partition_key == DEPTH200_SCHEDULE_PARTITION_KEY
-    assert tick.run_requests[0].run_key == f'binance_spot_depth200::{DEPTH200_SCHEDULE_PARTITION_KEY}'
+    assert (
+        tick.run_requests[0].run_key
+        == f'binance_spot_depth200:source:{DEPTH200_SCHEDULE_PARTITION_KEY}:20260614T125800Z'
+    )
     assert tick.run_requests[0].run_config == {}
+
+
+def test_binance_spot_depth200_schedule_requests_source_available_incomplete_lookback_minutes(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def('binance_spot_depth200_1m_schedule')
+    latest_minute = _utc(2026, 6, 14, 13, 0)
+    status_by_minute = {
+        _utc(2026, 6, 14, 12, 57): origo_definitions_module.DepthLiveStoreStatus(
+            60, 1, True, latest_minute
+        ),
+        _utc(2026, 6, 14, 12, 58): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+        _utc(2026, 6, 14, 12, 59): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+        _utc(2026, 6, 14, 13, 0): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+    }
+
+    def fake_store_status(client, database, spec, minute_start):
+        return status_by_minute[minute_start]
+
+    def fake_source_has_rows(spec, minute_start: datetime) -> bool:
+        return minute_start in {_utc(2026, 6, 14, 12, 59), _utc(2026, 6, 14, 13, 0)}
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+    monkeypatch.setattr(origo_definitions_module, '_depth_source_has_rows', fake_source_has_rows)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 6, 14, 13, 1),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == [
+        '2026-06-14T12:59:00+0000',
+        '2026-06-14T13:00:00+0000',
+    ]
+    assert [request.run_key for request in tick.run_requests] == [
+        'binance_spot_depth200:source:2026-06-14T12:59:00+0000:20260614T130100Z',
+        'binance_spot_depth200:source:2026-06-14T13:00:00+0000:20260614T130100Z',
+    ]
+
+
+def test_binance_spot_depth200_projection_repair_schedule_requests_raw_available_gaps(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def(
+        'binance_spot_depth200_projection_repair_schedule'
+    )
+    latest_minute = _utc(2026, 6, 14, 13, 0)
+    projection_gap = _utc(2026, 6, 14, 12, 59)
+
+    def fake_store_status(client, database, spec, minute_start):
+        projection_rows = 0 if minute_start == projection_gap else 1
+        return origo_definitions_module.DepthLiveStoreStatus(
+            60, projection_rows, True, latest_minute
+        )
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 6, 14, 13, 1),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == ['2026-06-14T12:59:00+0000']
+    assert tick.run_requests[0].run_key == (
+        'binance_spot_depth200:projection:2026-06-14T12:59:00+0000:20260614T130100Z'
+    )
+
+
+def test_binance_spot_depth200_projection_repair_job_is_projection_only(
+    origo_definitions_module,
+) -> None:
+    repair_job = origo_definitions_module.defs.get_job_def(
+        'repair_binance_spot_depth200_projection_job'
+    )
+
+    assert set(repair_job.graph.node_dict.keys()) == {'refresh_binance_spot_depth200_1m_origo'}
+
+
+def test_binance_spot_depth200_arrow_repair_schedule_requests_raw_available_gaps(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def('binance_spot_depth200_arrow_repair_schedule')
+    latest_minute = _utc(2026, 6, 14, 12, 58)
+    arrow_gap = _utc(2026, 6, 14, 12, 59)
+
+    def fake_store_status(client, database, spec, minute_start):
+        return origo_definitions_module.DepthLiveStoreStatus(
+            60,
+            1,
+            minute_start != arrow_gap,
+            latest_minute,
+        )
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 6, 14, 13, 1),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == [
+        'depth200_snapshots',
+        'depth200_snapshots',
+    ]
+    assert [request.run_key for request in tick.run_requests] == [
+        'binance_spot_depth200:arrow:2026-06-14T12:59:00+0000:20260614T130100Z',
+        'binance_spot_depth200:arrow:2026-06-14T13:00:00+0000:20260614T130100Z',
+    ]
+    assert [
+        request.run_config['ops']['build_depth_snapshot_store_arrow']['config'][
+            'source_partition_key'
+        ]
+        for request in tick.run_requests
+    ] == ['2026-06-14T12:59:00+0000', '2026-06-14T13:00:00+0000']
 
 
 def test_binance_spot_depth200_backfill_job_is_manual_data_source_only(

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -289,6 +289,26 @@ def test_binance_spot_depth20_schedule_skips_completed_raw_projection_arrow_minu
     assert tick.skip_message == 'Depth20: no source-available raw depth gaps in lookback.'
 
 
+def test_depth_source_has_rows_returns_false_on_request_exception(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_get(*args: object, **kwargs: object) -> object:
+        raise origo_definitions_module.requests.RequestException('source unavailable')
+
+    monkeypatch.setenv('BINANCE_SPOT_DEPTH20_BASE_URL', 'https://source.example')
+    monkeypatch.setenv('BINANCE_SPOT_DEPTH20_AUTH_TOKEN', 'test-token')
+    monkeypatch.setattr(origo_definitions_module.requests, 'get', fail_get)
+
+    assert (
+        origo_definitions_module._depth_source_has_rows(
+            origo_definitions_module.DEPTH20_LIVE_RECONCILIATION_SPEC,
+            _utc(2026, 5, 14, 10, 34),
+        )
+        is False
+    )
+
+
 def test_binance_spot_depth20_projection_repair_schedule_requests_raw_available_gaps(
     origo_definitions_module,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
+++ b/tests/origo_source_native/test_origo_binance_spot_depth20_data_source_template.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from dagster import DagsterInstance, DefaultScheduleStatus, build_schedule_context, materialize
+import pytest
+from dagster import (
+    DagsterInstance,
+    DefaultScheduleStatus,
+    RunRequest,
+    build_schedule_context,
+    materialize,
+)
 
 from .helpers import ORIGO_DATABASE
 
@@ -17,9 +24,33 @@ DEPTH20_EXPECTED_COLUMNS = [
     'book_ask_depth_20_notional',
     'book_imbalance_20',
 ]
-DEPTH20_TEST_LEVELS_SQL = (
-    '[' + ','.join(f'({level}.0,{level}.0)' for level in range(1, 21)) + ']'
-)
+DEPTH20_TEST_LEVELS_SQL = '[' + ','.join(f'({level}.0,{level}.0)' for level in range(1, 21)) + ']'
+
+
+class _FakeDepthSettings:
+    database = ORIGO_DATABASE
+
+
+class _FakeDepthClient:
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _patch_depth_clickhouse(origo_definitions_module, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        origo_definitions_module,
+        'get_depth_clickhouse_settings',
+        lambda: _FakeDepthSettings(),
+    )
+    monkeypatch.setattr(
+        origo_definitions_module,
+        'make_depth_clickhouse_client',
+        lambda settings: _FakeDepthClient(),
+    )
 
 
 def _table_metadata(query_origo, table_name: str) -> tuple[str, str, str]:
@@ -133,10 +164,27 @@ def test_binance_spot_depth20_table_creation_jobs_are_registered(
 
 def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
     origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repository_def = origo_definitions_module.defs.get_repository_def()
     schedule_def = repository_def.get_schedule_def('binance_spot_depth20_1m_schedule')
-    job_def = origo_definitions_module.defs.get_job_def('refresh_binance_spot_depth20_data_source_job')
+    job_def = origo_definitions_module.defs.get_job_def(
+        'refresh_binance_spot_depth20_data_source_job'
+    )
+
+    def fake_reconciliation_run_requests(context, spec) -> list[RunRequest]:
+        return [
+            RunRequest(
+                partition_key=DEPTH20_SCHEDULE_PARTITION_KEY,
+                run_key=f'binance_spot_depth20:source:{DEPTH20_SCHEDULE_PARTITION_KEY}:20260514T103200Z',
+            )
+        ]
+
+    monkeypatch.setattr(
+        origo_definitions_module,
+        '_depth_reconciliation_run_requests',
+        fake_reconciliation_run_requests,
+    )
     context = build_schedule_context(
         scheduled_execution_time=datetime(2026, 5, 14, 10, 32, tzinfo=timezone.utc),
         repository_def=repository_def,
@@ -154,8 +202,179 @@ def test_binance_spot_depth20_data_source_job_and_schedule_are_registered(
     assert job_def.partitions_def.get_first_partition_key() == DEPTH20_FIRST_PARTITION_KEY
     assert len(tick.run_requests) == 1
     assert tick.run_requests[0].partition_key == DEPTH20_SCHEDULE_PARTITION_KEY
-    assert tick.run_requests[0].run_key == f'binance_spot_depth20::{DEPTH20_SCHEDULE_PARTITION_KEY}'
+    assert (
+        tick.run_requests[0].run_key
+        == f'binance_spot_depth20:source:{DEPTH20_SCHEDULE_PARTITION_KEY}:20260514T103200Z'
+    )
     assert tick.run_requests[0].run_config == {}
+
+
+def test_binance_spot_depth20_schedule_requests_source_available_incomplete_lookback_minutes(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def('binance_spot_depth20_1m_schedule')
+    latest_minute = _utc(2026, 5, 14, 10, 34)
+    status_by_minute = {
+        _utc(2026, 5, 14, 10, 31): origo_definitions_module.DepthLiveStoreStatus(
+            60, 1, True, latest_minute
+        ),
+        _utc(2026, 5, 14, 10, 32): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+        _utc(2026, 5, 14, 10, 33): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+        _utc(2026, 5, 14, 10, 34): origo_definitions_module.DepthLiveStoreStatus(
+            0, 0, False, latest_minute
+        ),
+    }
+
+    def fake_store_status(client, database, spec, minute_start):
+        return status_by_minute[minute_start]
+
+    def fake_source_has_rows(spec, minute_start: datetime) -> bool:
+        return minute_start in {_utc(2026, 5, 14, 10, 33), _utc(2026, 5, 14, 10, 34)}
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+    monkeypatch.setattr(origo_definitions_module, '_depth_source_has_rows', fake_source_has_rows)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 5, 14, 10, 35),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == [
+        '2026-05-14T10:33:00+0000',
+        '2026-05-14T10:34:00+0000',
+    ]
+    assert [request.run_key for request in tick.run_requests] == [
+        'binance_spot_depth20:source:2026-05-14T10:33:00+0000:20260514T103500Z',
+        'binance_spot_depth20:source:2026-05-14T10:34:00+0000:20260514T103500Z',
+    ]
+
+
+def test_binance_spot_depth20_schedule_skips_completed_raw_projection_arrow_minutes(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def('binance_spot_depth20_1m_schedule')
+    latest_minute = _utc(2026, 5, 14, 10, 34)
+
+    def fake_store_status(client, database, spec, minute_start):
+        return origo_definitions_module.DepthLiveStoreStatus(60, 1, True, latest_minute)
+
+    def fail_if_source_checked(spec, minute_start: datetime) -> bool:
+        raise AssertionError('completed raw minutes must not query source history')
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+    monkeypatch.setattr(origo_definitions_module, '_depth_source_has_rows', fail_if_source_checked)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 5, 14, 10, 35),
+            repository_def=repository_def,
+        )
+    )
+
+    assert tick.run_requests == []
+    assert tick.skip_message == 'Depth20: no source-available raw depth gaps in lookback.'
+
+
+def test_binance_spot_depth20_projection_repair_schedule_requests_raw_available_gaps(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def(
+        'binance_spot_depth20_projection_repair_schedule'
+    )
+    latest_minute = _utc(2026, 5, 14, 10, 34)
+    projection_gap = _utc(2026, 5, 14, 10, 33)
+
+    def fake_store_status(client, database, spec, minute_start):
+        projection_rows = 0 if minute_start == projection_gap else 1
+        return origo_definitions_module.DepthLiveStoreStatus(
+            60, projection_rows, True, latest_minute
+        )
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 5, 14, 10, 35),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == ['2026-05-14T10:33:00+0000']
+    assert tick.run_requests[0].run_key == (
+        'binance_spot_depth20:projection:2026-05-14T10:33:00+0000:20260514T103500Z'
+    )
+
+
+def test_binance_spot_depth20_projection_repair_job_is_projection_only(
+    origo_definitions_module,
+) -> None:
+    repair_job = origo_definitions_module.defs.get_job_def(
+        'repair_binance_spot_depth20_projection_job'
+    )
+
+    assert set(repair_job.graph.node_dict.keys()) == {'refresh_binance_spot_depth20_1m_origo'}
+
+
+def test_binance_spot_depth20_arrow_repair_schedule_requests_raw_available_gaps(
+    origo_definitions_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_def = origo_definitions_module.defs.get_repository_def()
+    schedule_def = repository_def.get_schedule_def('binance_spot_depth20_arrow_repair_schedule')
+    latest_minute = _utc(2026, 5, 14, 10, 32)
+    arrow_gap = _utc(2026, 5, 14, 10, 33)
+
+    def fake_store_status(client, database, spec, minute_start):
+        return origo_definitions_module.DepthLiveStoreStatus(
+            60,
+            1,
+            minute_start != arrow_gap,
+            latest_minute,
+        )
+
+    _patch_depth_clickhouse(origo_definitions_module, monkeypatch)
+    monkeypatch.setattr(origo_definitions_module, 'DEPTH_SOURCE_LOOKBACK_MINUTES', 4)
+    monkeypatch.setattr(origo_definitions_module, '_depth_store_status', fake_store_status)
+
+    tick = schedule_def.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=_utc(2026, 5, 14, 10, 35),
+            repository_def=repository_def,
+        )
+    )
+
+    assert [request.partition_key for request in tick.run_requests] == [
+        'depth20_snapshots',
+        'depth20_snapshots',
+    ]
+    assert [request.run_key for request in tick.run_requests] == [
+        'binance_spot_depth20:arrow:2026-05-14T10:33:00+0000:20260514T103500Z',
+        'binance_spot_depth20:arrow:2026-05-14T10:34:00+0000:20260514T103500Z',
+    ]
+    assert [
+        request.run_config['ops']['build_depth_snapshot_store_arrow']['config'][
+            'source_partition_key'
+        ]
+        for request in tick.run_requests
+    ] == ['2026-05-14T10:33:00+0000', '2026-05-14T10:34:00+0000']
 
 
 def test_binance_spot_depth20_backfill_job_is_manual_data_source_only(


### PR DESCRIPTION
Closes #261

## Summary
- Adds bounded source-aware reconciliation for depth20 and depth200 raw gaps.
- Adds projection-only repair schedules for raw-present projection gaps.
- Adds Arrow repair schedules for raw-present Arrow chunk/latest gaps.
- Keeps Arrow latest.json monotonic during backfills.

## Validation
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-py311-venv uv run --python 3.11 --extra dev python -m pytest tests/origo_source_native -q --maxfail=1` -> 142 passed.
- `UV_PROJECT_ENVIRONMENT=/tmp/tdw-control-plane-py311-venv uv run --python 3.11 --with ruff==0.15.11 ruff check tools tests/tools` -> passed.
- Focused depth/Arrow tests -> 37 passed.
- Pyright baseline total remained 1212; new touched ranges clean.