### PR TITLE
feat(gates): allow package_root rename when the base root is absent

### DIFF
--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -29,7 +29,7 @@ jobs:
         run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
-        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py -q
+        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py tests/tools/test_budget_source_ratchet.py -q
 
       - name: Compare live ruleset to checked-in snapshot
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.1.0 on July 4, 2026
+- Allow `package_root` to change in the typing and fail-loud budget-source ratchets when the base root directory no longer exists in the head tree (a true package rename); narrowing onto a subtree while the old root exists stays blocked, now with regression tests.
+
 # v2.0.1 on July 4, 2026
 - Rebrand repo metadata to Origo: dist name, description, README, slice template prose, dev image tag, test fixtures dir and container prefix; remove the never-existing `quickstart_etl_tests` ghost path from pyproject, budgets, gates, and the lint contract; delete vestigial `dagster_cloud.yaml`.
 - Pin `default_status=RUNNING` on all 12 HuggingFace asset sensors and add a regression test asserting every sensor defaults to RUNNING.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v2.1.0 on July 4, 2026
-- Allow `package_root` to change in the typing and fail-loud budget-source ratchets when the base root directory no longer exists in the head tree (a true package rename); narrowing onto a subtree while the old root exists stays blocked, now with regression tests.
+- Allow `package_root` to change in the typing and fail-loud budget-source ratchets only when the base root directory no longer exists in the head tree AND every ratchet total is identical to base (a totals-neutral rename); narrowing onto a subtree while the old root exists stays blocked, and no ratchet total can move in the same PR as a root change. Residual risk accepted and documented: a rename-shaped PR can still relocate files outside the scan surface — as any PR always could by moving files out of the root — and operator review remains the backstop for that.
 
 # v2.0.1 on July 4, 2026
 - Rebrand repo metadata to Origo: dist name, description, README, slice template prose, dev image tag, test fixtures dir and container prefix; remove the never-existing `quickstart_etl_tests` ghost path from pyproject, budgets, gates, and the lint contract; delete vestigial `dagster_cloud.yaml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "2.0.1"
+version = "2.1.0"
 description = "Origo control plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/tools/test_budget_source_ratchet.py
+++ b/tests/tools/test_budget_source_ratchet.py
@@ -14,7 +14,7 @@ TYPING_BUDGET: Final[dict[str, object]] = {
     'package_root': 'tools',
     'excludes': [],
     'patterns': {},
-    'pyright_errors': {'total': 0},
+    'pyright_errors': {'total': 5},
     'any_references': {'total': 0},
 }
 
@@ -22,7 +22,7 @@ FAIL_LOUD_BUDGET: Final[dict[str, object]] = {
     'schema_version': 1,
     'package_root': 'tools',
     'excludes': [],
-    'categories': {},
+    'categories': {'bare_except': {'total': 2}},
 }
 
 
@@ -42,6 +42,12 @@ def _budget(template: dict[str, object], package_root: str) -> dict[str, object]
     return budget
 
 
+def _absent_root(tmp_path: Path) -> str:
+    root = f'renamed_away_{tmp_path.name}'
+    assert not (REPO_ROOT / root).is_dir()
+    return root
+
+
 def _root_failures(failures: list[str]) -> list[str]:
     return [failure for failure in failures if 'package_root changed' in failure]
 
@@ -49,7 +55,7 @@ def _root_failures(failures: list[str]) -> list[str]:
 def test_typing_gate_allows_root_rename_when_base_root_absent(tmp_path: Path) -> None:
     typing_gate = _load('typing_gate')
     base_path = tmp_path / 'base_budget.json'
-    base_path.write_text(json.dumps(_budget(TYPING_BUDGET, 'renamed_away_pkg_xyz')))
+    base_path.write_text(json.dumps(_budget(TYPING_BUDGET, _absent_root(tmp_path))))
 
     failures = typing_gate.gate_budget_source(
         str(base_path), False, _budget(TYPING_BUDGET, 'tools')
@@ -70,12 +76,24 @@ def test_typing_gate_blocks_root_change_when_base_root_present(tmp_path: Path) -
     assert len(_root_failures(failures)) == 1
 
 
-def test_fail_loud_gate_allows_root_rename_when_base_root_absent() -> None:
+def test_typing_gate_blocks_root_rename_with_total_change(tmp_path: Path) -> None:
+    typing_gate = _load('typing_gate')
+    base_path = tmp_path / 'base_budget.json'
+    base_path.write_text(json.dumps(_budget(TYPING_BUDGET, _absent_root(tmp_path))))
+    head_budget = _budget(TYPING_BUDGET, 'tools')
+    head_budget['pyright_errors'] = {'total': 4}
+
+    failures = typing_gate.gate_budget_source(str(base_path), False, head_budget)
+
+    assert any('totals-neutral' in failure for failure in _root_failures(failures))
+
+
+def test_fail_loud_gate_allows_root_rename_when_base_root_absent(tmp_path: Path) -> None:
     fail_loud_gate = _load('fail_loud_gate')
 
     failures = fail_loud_gate.gate(
         _budget(FAIL_LOUD_BUDGET, 'tools'),
-        _budget(FAIL_LOUD_BUDGET, 'renamed_away_pkg_xyz'),
+        _budget(FAIL_LOUD_BUDGET, _absent_root(tmp_path)),
     )
 
     assert _root_failures(failures) == []
@@ -90,3 +108,16 @@ def test_fail_loud_gate_blocks_root_change_when_base_root_present() -> None:
     )
 
     assert len(_root_failures(failures)) == 1
+
+
+def test_fail_loud_gate_blocks_root_rename_with_total_change(tmp_path: Path) -> None:
+    fail_loud_gate = _load('fail_loud_gate')
+    head_budget = _budget(FAIL_LOUD_BUDGET, 'tools')
+    head_budget['categories'] = {'bare_except': {'total': 1}}
+
+    failures = fail_loud_gate.gate(
+        head_budget,
+        _budget(FAIL_LOUD_BUDGET, _absent_root(tmp_path)),
+    )
+
+    assert any('totals-neutral' in failure for failure in _root_failures(failures))

--- a/tests/tools/test_budget_source_ratchet.py
+++ b/tests/tools/test_budget_source_ratchet.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+
+TYPING_BUDGET: Final[dict[str, object]] = {
+    'schema_version': 2,
+    'package_root': 'tools',
+    'excludes': [],
+    'patterns': {},
+    'pyright_errors': {'total': 0},
+    'any_references': {'total': 0},
+}
+
+FAIL_LOUD_BUDGET: Final[dict[str, object]] = {
+    'schema_version': 1,
+    'package_root': 'tools',
+    'excludes': [],
+    'categories': {},
+}
+
+
+def _load(module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        module_name, REPO_ROOT / 'tools' / f'{module_name}.py'
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _budget(template: dict[str, object], package_root: str) -> dict[str, object]:
+    budget = copy.deepcopy(template)
+    budget['package_root'] = package_root
+    return budget
+
+
+def _root_failures(failures: list[str]) -> list[str]:
+    return [failure for failure in failures if 'package_root changed' in failure]
+
+
+def test_typing_gate_allows_root_rename_when_base_root_absent(tmp_path: Path) -> None:
+    typing_gate = _load('typing_gate')
+    base_path = tmp_path / 'base_budget.json'
+    base_path.write_text(json.dumps(_budget(TYPING_BUDGET, 'renamed_away_pkg_xyz')))
+
+    failures = typing_gate.gate_budget_source(
+        str(base_path), False, _budget(TYPING_BUDGET, 'tools')
+    )
+
+    assert _root_failures(failures) == []
+
+
+def test_typing_gate_blocks_root_change_when_base_root_present(tmp_path: Path) -> None:
+    typing_gate = _load('typing_gate')
+    base_path = tmp_path / 'base_budget.json'
+    base_path.write_text(json.dumps(_budget(TYPING_BUDGET, 'tools')))
+
+    failures = typing_gate.gate_budget_source(
+        str(base_path), False, _budget(TYPING_BUDGET, 'tests')
+    )
+
+    assert len(_root_failures(failures)) == 1
+
+
+def test_fail_loud_gate_allows_root_rename_when_base_root_absent() -> None:
+    fail_loud_gate = _load('fail_loud_gate')
+
+    failures = fail_loud_gate.gate(
+        _budget(FAIL_LOUD_BUDGET, 'tools'),
+        _budget(FAIL_LOUD_BUDGET, 'renamed_away_pkg_xyz'),
+    )
+
+    assert _root_failures(failures) == []
+
+
+def test_fail_loud_gate_blocks_root_change_when_base_root_present() -> None:
+    fail_loud_gate = _load('fail_loud_gate')
+
+    failures = fail_loud_gate.gate(
+        _budget(FAIL_LOUD_BUDGET, 'tests'),
+        _budget(FAIL_LOUD_BUDGET, 'tools'),
+    )
+
+    assert len(_root_failures(failures)) == 1

--- a/tools/fail_loud_gate.py
+++ b/tools/fail_loud_gate.py
@@ -305,6 +305,20 @@ def _category_total(budget: dict[str, object], cat: str) -> int:
     return _get_int(spec, 'total', f'categories.{cat}.total')
 
 
+def _category_totals(budget: dict[str, object]) -> dict[str, object]:
+    """Every category total in a budget, keyed for equality comparison.
+
+    Used by the root-rename allowance: a package_root change must not be
+    accompanied by any movement in any total.
+    """
+    categories_raw = budget.get('categories')
+    categories = categories_raw if isinstance(categories_raw, dict) else {}
+    return {
+        key: (spec.get('total') if isinstance(spec, dict) else None)
+        for key, spec in categories.items()
+    }
+
+
 def gate(
     budget_head: dict[str, object],
     budget_base: dict[str, object] | None,
@@ -315,16 +329,26 @@ def gate(
     # must preserve every category key, must not raise any total.
     if budget_base is not None:
         base_root = budget_base.get('package_root')
-        if budget_head.get('package_root') != base_root and (
-            not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
-        ):
-            failures.append(
-                f'package_root changed from {base_root!r} '
-                f'(base) to {budget_head.get("package_root")!r} (head). The scan '
-                f'surface cannot be narrowed in the same PR that gates. A root '
-                f'change is only legal when the base root directory no longer '
-                f'exists in the head tree (a true package rename).'
+        if budget_head.get('package_root') != base_root:
+            base_root_present = (
+                not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
             )
+            if base_root_present:
+                failures.append(
+                    f'package_root changed from {base_root!r} '
+                    f'(base) to {budget_head.get("package_root")!r} (head). The scan '
+                    f'surface cannot be narrowed in the same PR that gates. A root '
+                    f'change is only legal when the base root directory no longer '
+                    f'exists in the head tree (a true package rename).'
+                )
+            elif _category_totals(budget_base) != _category_totals(budget_head):
+                failures.append(
+                    f'package_root changed from {base_root!r} '
+                    f'(base) to {budget_head.get("package_root")!r} (head) together '
+                    f'with category-total changes. A root change must be '
+                    f'totals-neutral: every total identical to base. Move ratchet '
+                    f'totals in a separate PR.'
+                )
         base_excl = set(budget_base.get('excludes', []) or [])
         head_excl = set(budget_head.get('excludes', []) or [])
         added = head_excl - base_excl

--- a/tools/fail_loud_gate.py
+++ b/tools/fail_loud_gate.py
@@ -314,11 +314,16 @@ def gate(
     # Structural: head must preserve package_root, must not add excludes,
     # must preserve every category key, must not raise any total.
     if budget_base is not None:
-        if budget_head.get('package_root') != budget_base.get('package_root'):
+        base_root = budget_base.get('package_root')
+        if budget_head.get('package_root') != base_root and (
+            not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
+        ):
             failures.append(
-                f'package_root changed from {budget_base.get("package_root")!r} '
+                f'package_root changed from {base_root!r} '
                 f'(base) to {budget_head.get("package_root")!r} (head). The scan '
-                f'surface cannot be narrowed in the same PR that gates.'
+                f'surface cannot be narrowed in the same PR that gates. A root '
+                f'change is only legal when the base root directory no longer '
+                f'exists in the head tree (a true package rename).'
             )
         base_excl = set(budget_base.get('excludes', []) or [])
         head_excl = set(budget_head.get('excludes', []) or [])

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -632,11 +632,15 @@ def gate_budget_source(
     #   Adding an exclude hides files from the ratchet.
     base_root = base_budget.get('package_root')
     head_root = head_budget.get('package_root')
-    if base_root != head_root:
+    if base_root != head_root and (
+        not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
+    ):
         failures.append(
             f'package_root changed from {base_root!r} (base) to '
             f'{head_root!r} (head). The scan surface cannot be narrowed '
-            f'by the PR it gates.'
+            f'by the PR it gates. A root change is only legal when the '
+            f'base root directory no longer exists in the head tree '
+            f'(a true package rename).'
         )
 
     base_excludes_raw = base_budget.get('excludes', [])

--- a/tools/typing_gate.py
+++ b/tools/typing_gate.py
@@ -564,6 +564,25 @@ def gate_pyright_errors(
 # its own ceiling and pass.
 # -------------------------------------------------------------------
 
+def _ratchet_totals(budget: dict[str, object]) -> dict[str, object]:
+    """Every ratchet total in a budget, keyed for equality comparison.
+
+    Used by the root-rename allowance: a package_root change must not be
+    accompanied by any movement in any total, or a rename-shaped PR could
+    smuggle ratchet changes past review.
+    """
+    patterns_raw = budget.get('patterns')
+    patterns = patterns_raw if isinstance(patterns_raw, dict) else {}
+    totals: dict[str, object] = {}
+    for key, spec in patterns.items():
+        totals[f'patterns.{key}'] = spec.get('total') if isinstance(spec, dict) else None
+    for section in ('pyright_errors', 'any_references'):
+        section_raw = budget.get(section)
+        section_dict = section_raw if isinstance(section_raw, dict) else {}
+        totals[section] = section_dict.get('total')
+    return totals
+
+
 def gate_budget_source(
     base_budget_path: str | None,
     bootstrap: bool,
@@ -632,16 +651,23 @@ def gate_budget_source(
     #   Adding an exclude hides files from the ratchet.
     base_root = base_budget.get('package_root')
     head_root = head_budget.get('package_root')
-    if base_root != head_root and (
-        not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
-    ):
-        failures.append(
-            f'package_root changed from {base_root!r} (base) to '
-            f'{head_root!r} (head). The scan surface cannot be narrowed '
-            f'by the PR it gates. A root change is only legal when the '
-            f'base root directory no longer exists in the head tree '
-            f'(a true package rename).'
-        )
+    if base_root != head_root:
+        base_root_present = not isinstance(base_root, str) or (REPO_ROOT / base_root).is_dir()
+        if base_root_present:
+            failures.append(
+                f'package_root changed from {base_root!r} (base) to '
+                f'{head_root!r} (head). The scan surface cannot be narrowed '
+                f'by the PR it gates. A root change is only legal when the '
+                f'base root directory no longer exists in the head tree '
+                f'(a true package rename).'
+            )
+        elif _ratchet_totals(base_budget) != _ratchet_totals(head_budget):
+            failures.append(
+                f'package_root changed from {base_root!r} (base) to '
+                f'{head_root!r} (head) together with ratchet-total changes. '
+                f'A root change must be totals-neutral: every total identical '
+                f'to base. Move ratchet totals in a separate PR.'
+            )
 
     base_excludes_raw = base_budget.get('excludes', [])
     head_excludes_raw = head_budget.get('excludes', [])


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Slice #271 (unblocks #269 / PR #270): the typing and fail-loud budget-source ratchets rejected **any** `package_root` change, which also rejected true package renames — pass 2 of the Origo rename failed both gates. A root change is now legal **only when the base root directory no longer exists in the head tree AND every ratchet total is identical to base** (a totals-neutral rename); pointing the gate at a subtree while the old root still exists stays blocked, and no ratchet total can move in the same PR as a root change (review finding by zero-bang — the earlier old-root-absence-only rule left a mv-plus-clean-subtree channel). Residual risk stated plainly: a rename-shaped PR can still relocate files outside the scan surface, exactly as any PR always could by moving files out of the root; operator review is the backstop. Six regression tests cover allow/block/totals-neutrality for both gates, and `pr_checks_ruleset` now runs the new test file. Version 2.0.1 → 2.1.0.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable) — `pytest tests/tools -q`: 34 passed; `ruff check tools tests/tools`: clean
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
