### PR TITLE
refactor(deploy): adopt Origo identity for repo, CI variables, and images

### DIFF
--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -19,12 +19,12 @@ jobs:
     name: Build Images And Deploy
     runs-on: ubuntu-latest
     env:
-      TDW_HOST: ${{ vars.TDW_HOST }}
-      TDW_USER: ${{ vars.TDW_USER }}
+      ORIGO_HOST: ${{ vars.ORIGO_HOST }}
+      ORIGO_USER: ${{ vars.ORIGO_USER }}
       DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
-      PROJECT_NAME: ${{ vars.TDW_PROJECT_NAME }}
+      PROJECT_NAME: ${{ vars.ORIGO_PROJECT_NAME }}
       HUGGINGFACE_DATASET_REPO_ID: ${{ vars.HUGGINGFACE_DATASET_REPO_ID }}
-      TDW_KNOWN_HOSTS: ${{ vars.TDW_KNOWN_HOSTS }}
+      ORIGO_KNOWN_HOSTS: ${{ vars.ORIGO_KNOWN_HOSTS }}
 
     steps:
       - name: Checkout repository
@@ -32,19 +32,19 @@ jobs:
 
       - name: Validate deploy configuration
         run: |
-          test -n "$TDW_HOST"
-          test -n "$TDW_USER"
+          test -n "$ORIGO_HOST"
+          test -n "$ORIGO_USER"
           test -n "$DEPLOY_DIR"
           test -n "$PROJECT_NAME"
           test -n "$HUGGINGFACE_DATASET_REPO_ID"
-          test -n "$TDW_KNOWN_HOSTS"
+          test -n "$ORIGO_KNOWN_HOSTS"
 
       - name: Set image names
         run: |
-          echo "APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:${GITHUB_SHA}" >> "$GITHUB_ENV"
-          echo "APP_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-dagster:latest" >> "$GITHUB_ENV"
-          echo "CLICKHOUSE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:${GITHUB_SHA}" >> "$GITHUB_ENV"
-          echo "CLICKHOUSE_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tdw-control-plane-clickhouse:latest" >> "$GITHUB_ENV"
+          echo "APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/origo-dagster:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "APP_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/origo-dagster:latest" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/origo-clickhouse:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "CLICKHOUSE_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/origo-clickhouse:latest" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -92,19 +92,19 @@ jobs:
       - name: Start SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.TDW_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.ORIGO_PRIVATE_KEY }}
 
       - name: Configure pinned deployment host key
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          printf '%s\n' "$TDW_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          printf '%s\n' "$ORIGO_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
       - name: Upload deploy compose file
         run: |
-          ssh "$TDW_USER@$TDW_HOST" "mkdir -p '$DEPLOY_DIR'"
-          scp docker-compose.deploy.yml "$TDW_USER@$TDW_HOST:$DEPLOY_DIR/docker-compose.deploy.yml"
+          ssh "$ORIGO_USER@$ORIGO_HOST" "mkdir -p '$DEPLOY_DIR'"
+          scp docker-compose.deploy.yml "$ORIGO_USER@$ORIGO_HOST:$DEPLOY_DIR/docker-compose.deploy.yml"
 
       - name: Deploy updated images
         env:
@@ -117,7 +117,7 @@ jobs:
           BINANCE_SPOT_DEPTH200_BASE_URL: ${{ secrets.BINANCE_SPOT_DEPTH200_BASE_URL }}
           BINANCE_SPOT_DEPTH200_AUTH_TOKEN: ${{ secrets.BINANCE_SPOT_DEPTH200_AUTH_TOKEN }}
         run: |
-          DEPLOY_ENV_FILE="/tmp/tdw-deploy.env"
+          DEPLOY_ENV_FILE="/tmp/origo-deploy.env"
           trap 'rm -f "$DEPLOY_ENV_FILE"' EXIT
 
           python3 - <<'PY' > "$DEPLOY_ENV_FILE"
@@ -143,10 +143,10 @@ jobs:
               print(f"{key}={shlex.quote(value)}")
           PY
 
-          scp "$DEPLOY_ENV_FILE" "$TDW_USER@$TDW_HOST:$DEPLOY_DIR/.deploy.env"
+          scp "$DEPLOY_ENV_FILE" "$ORIGO_USER@$ORIGO_HOST:$DEPLOY_DIR/.deploy.env"
 
-          ssh "$TDW_USER@$TDW_HOST" \
-            "DEPLOY_DIR='$DEPLOY_DIR' TDW_HOST='$TDW_HOST' bash -s" <<'REMOTE'
+          ssh "$ORIGO_USER@$ORIGO_HOST" \
+            "DEPLOY_DIR='$DEPLOY_DIR' ORIGO_HOST='$ORIGO_HOST' bash -s" <<'REMOTE'
           set -euo pipefail
 
           export DOCKER_CONFIG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.0.1 on July 4, 2026
+- Adopt the Origo identity in CI and deploy: repo renamed to Vaquum/Origo, deploy workflow variables `TDW_*` -> `ORIGO_*` (values unchanged; server names intentionally stay tdw), fresh `ORIGO_PRIVATE_KEY` deploy key, GHCR images `origo-dagster`/`origo-clickhouse` (legacy packages retained for rollback), slice-gate help text and ruleset fixtures updated.
+
 # v3.0.0 on July 4, 2026
 - BREAKING: rename the Python package `tdw_control_plane` to `origo` — module imports, Dagster workspace/code-location, packaging config, typing/fail-loud gate roots, and the deploy smoke test all move; the Dagster code location becomes `origo.definitions` (instigator state restarts via in-code RUNNING defaults).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "3.0.0"
+version = "3.0.1"
 description = "Origo control plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/github/ruleset_live_target.json
+++ b/tests/fixtures/github/ruleset_live_target.json
@@ -3,7 +3,7 @@
   "name": "Protect-Main",
   "target": "branch",
   "source_type": "Repository",
-  "source": "Vaquum/tdw-control-plane",
+  "source": "Vaquum/Origo",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -96,10 +96,10 @@
   "current_user_can_bypass": "never",
   "_links": {
     "self": {
-      "href": "https://api.github.com/repos/Vaquum/tdw-control-plane/rulesets/5406599"
+      "href": "https://api.github.com/repos/Vaquum/Origo/rulesets/5406599"
     },
     "html": {
-      "href": "https://github.com/Vaquum/tdw-control-plane/rules/5406599"
+      "href": "https://github.com/Vaquum/Origo/rules/5406599"
     }
   }
 }

--- a/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
+++ b/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
@@ -3,7 +3,7 @@
   "name": "Protect-Main",
   "target": "branch",
   "source_type": "Repository",
-  "source": "Vaquum/tdw-control-plane",
+  "source": "Vaquum/Origo",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -95,10 +95,10 @@
   "current_user_can_bypass": "never",
   "_links": {
     "self": {
-      "href": "https://api.github.com/repos/Vaquum/tdw-control-plane/rulesets/5406599"
+      "href": "https://api.github.com/repos/Vaquum/Origo/rulesets/5406599"
     },
     "html": {
-      "href": "https://github.com/Vaquum/tdw-control-plane/rules/5406599"
+      "href": "https://github.com/Vaquum/Origo/rules/5406599"
     }
   }
 }

--- a/tests/fixtures/github/ruleset_live_unexpected_field.json
+++ b/tests/fixtures/github/ruleset_live_unexpected_field.json
@@ -3,7 +3,7 @@
   "name": "Protect-Main",
   "target": "branch",
   "source_type": "Repository",
-  "source": "Vaquum/tdw-control-plane",
+  "source": "Vaquum/Origo",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -96,10 +96,10 @@
   "current_user_can_bypass": "never",
   "_links": {
     "self": {
-      "href": "https://api.github.com/repos/Vaquum/tdw-control-plane/rulesets/5406599"
+      "href": "https://api.github.com/repos/Vaquum/Origo/rulesets/5406599"
     },
     "html": {
-      "href": "https://github.com/Vaquum/tdw-control-plane/rules/5406599"
+      "href": "https://github.com/Vaquum/Origo/rules/5406599"
     }
   },
   "surprise_new_field": true

--- a/tests/fixtures/github/ruleset_live_with_bypass_actor.json
+++ b/tests/fixtures/github/ruleset_live_with_bypass_actor.json
@@ -3,7 +3,7 @@
   "name": "Protect-Main",
   "target": "branch",
   "source_type": "Repository",
-  "source": "Vaquum/tdw-control-plane",
+  "source": "Vaquum/Origo",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -102,10 +102,10 @@
   "current_user_can_bypass": "never",
   "_links": {
     "self": {
-      "href": "https://api.github.com/repos/Vaquum/tdw-control-plane/rulesets/5406599"
+      "href": "https://api.github.com/repos/Vaquum/Origo/rulesets/5406599"
     },
     "html": {
-      "href": "https://github.com/Vaquum/tdw-control-plane/rules/5406599"
+      "href": "https://github.com/Vaquum/Origo/rules/5406599"
     }
   }
 }

--- a/tools/slice_gate.py
+++ b/tools/slice_gate.py
@@ -421,7 +421,7 @@ def main() -> int:
     parser.add_argument(
         '--repo',
         required=True,
-        help='GitHub repository in owner/name form (e.g. Vaquum/tdw-control-plane).',
+        help='GitHub repository in owner/name form (e.g. Vaquum/Origo).',
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Pass 3 — the final pass — of the Origo rename (PRD #266, slice #273). The repo is already renamed to **Vaquum/Origo** (GitHub redirects the old slug). This PR moves the CI/deploy identity to match: the deploy workflow's `TDW_*` variable references become `ORIGO_*` (all four created in repo settings with byte-identical values before this PR — the server identity does not change), the deploy key reference becomes `ORIGO_PRIVATE_KEY` (a fresh ed25519 keypair, public key installed on the host and ssh-verified before the secret was set), GHCR image basenames become `origo-dagster`/`origo-clickhouse` (full refs flow to the server per-deploy via `.deploy.env`; legacy `tdw-control-plane-*` packages retained for rollback), plus the slice-gate help-text example and the four gate-ignored `source`/`_links` strings in the ruleset fixtures. Server-side names (host dir, compose project value, pinned volumes, container names) intentionally stay tdw per operator decision — `ORIGO_PROJECT_NAME`'s value remains `tdw-control-plane`. Version 3.0.0 → 3.0.1.

Legacy `TDW_*` variables and secrets are deleted only at closeout, after the first deploy on this PR's merge succeeds.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable) — `pytest tests/tools -q`: 34 passed; `ruff check tools tests/tools`: clean
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
