### PR TITLE
fix(deploy): bind dagit to loopback so it is not publicly exposed

### DIFF
--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -29,7 +29,7 @@ jobs:
         run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
-        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py tests/tools/test_budget_source_ratchet.py -q
+        run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py tests/tools/test_budget_source_ratchet.py tests/tools/test_deploy_compose_bind.py -q
 
       - name: Compare live ruleset to checked-in snapshot
         env:

--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -26,7 +26,7 @@ jobs:
         run: python -m venv .venv-ruleset
 
       - name: Install contract dependencies
-        run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest pyyaml 'ruff==0.15.11'
+        run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
 
       - name: Run CI contract tests
         run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py tests/tools/test_budget_source_ratchet.py tests/tools/test_deploy_compose_bind.py -q

--- a/.github/workflows/pr_checks_ruleset.yml
+++ b/.github/workflows/pr_checks_ruleset.yml
@@ -26,7 +26,7 @@ jobs:
         run: python -m venv .venv-ruleset
 
       - name: Install contract dependencies
-        run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest 'ruff==0.15.11'
+        run: .venv-ruleset/bin/python -m pip install --upgrade pip pytest pyyaml 'ruff==0.15.11'
 
       - name: Run CI contract tests
         run: .venv-ruleset/bin/python -m pytest tests/tools/test_cc_gate.py tests/tools/test_ruleset_gate.py tests/tools/test_ci_contract.py tests/tools/test_lint_ci_contract.py tests/tools/test_tests_ci_contract.py tests/tools/test_agents_contract.py tests/tools/test_privileged_ruleset_audit.py tests/tools/test_budget_source_ratchet.py tests/tools/test_deploy_compose_bind.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.0.2 on July 6, 2026
+- SECURITY: bind the deploy dagit webserver to 127.0.0.1 instead of all interfaces (it had no auth and was publicly reachable on :4000 since 2026-04-21); operator access is now via SSH tunnel. Add a tests/tools guard that fails any deploy-compose port not bound to loopback.
+
 # v3.0.1 on July 4, 2026
 - Adopt the Origo identity in CI and deploy: repo renamed to Vaquum/Origo, deploy workflow variables `TDW_*` -> `ORIGO_*` (values unchanged; server names intentionally stay tdw), fresh `ORIGO_PRIVATE_KEY` deploy key, GHCR images `origo-dagster`/`origo-clickhouse` (legacy packages retained for rollback), slice-gate help text and ruleset fixtures updated.
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -20,7 +20,7 @@ services:
   dagit:
     image: ${APP_IMAGE:?APP_IMAGE is required}
     ports:
-      - "4000:3000"
+      - "127.0.0.1:4000:3000"
     environment:
       - DAGSTER_HOME=/opt/app
       - PYTHONPATH=/opt/app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "3.0.1"
+version = "3.0.2"
 description = "Origo control plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/tools/test_deploy_compose_bind.py
+++ b/tests/tools/test_deploy_compose_bind.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+DEPLOY_COMPOSE: Final[Path] = REPO_ROOT / 'docker-compose.deploy.yml'
+
+LOOPBACK: Final[str] = '127.0.0.1'
+
+
+def _published_ports() -> list[tuple[str, str]]:
+    """(service, port-mapping) for every published port in the deploy compose."""
+    compose = yaml.safe_load(DEPLOY_COMPOSE.read_text(encoding='utf-8'))
+    pairs: list[tuple[str, str]] = []
+    for service, spec in compose['services'].items():
+        for mapping in spec.get('ports', []):
+            pairs.append((service, str(mapping)))
+    return pairs
+
+
+def test_all_published_ports_bind_loopback() -> None:
+    # A published port with fewer than three colon-separated parts
+    # (i.e. "HOST:CONTAINER" or bare "CONTAINER") binds every interface.
+    # Loopback binding requires the explicit "127.0.0.1:HOST:CONTAINER" form.
+    exposed = [
+        f'{service}: {mapping}'
+        for service, mapping in _published_ports()
+        if not mapping.startswith(f'{LOOPBACK}:')
+    ]
+    assert exposed == []
+
+
+def test_dagit_bound_to_loopback() -> None:
+    dagit_ports = [mapping for service, mapping in _published_ports() if service == 'dagit']
+    assert dagit_ports == [f'{LOOPBACK}:4000:3000']

--- a/tests/tools/test_deploy_compose_bind.py
+++ b/tests/tools/test_deploy_compose_bind.py
@@ -1,38 +1,146 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Final
-
-import yaml
+from typing import Final, NamedTuple
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 DEPLOY_COMPOSE: Final[Path] = REPO_ROOT / 'docker-compose.deploy.yml'
 
 LOOPBACK: Final[str] = '127.0.0.1'
+LONG_FORM_KEYS: Final[frozenset[str]] = frozenset(
+    {'target', 'published', 'host_ip', 'protocol', 'mode', 'name', 'app_protocol'}
+)
 
 
-def _published_ports() -> list[tuple[str, str]]:
-    """(service, port-mapping) for every published port in the deploy compose."""
-    compose = yaml.safe_load(DEPLOY_COMPOSE.read_text(encoding='utf-8'))
-    pairs: list[tuple[str, str]] = []
-    for service, spec in compose['services'].items():
-        for mapping in spec.get('ports', []):
-            pairs.append((service, str(mapping)))
-    return pairs
+class PublishedPort(NamedTuple):
+    service: str
+    host_ip: str  # '' means every interface (no explicit bind)
+    published: str
+    target: str
+    raw: str
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(' '))
+
+
+def _clean(value: str) -> str:
+    return value.strip().strip('"').strip("'")
+
+
+def _from_short_form(service: str, raw: str) -> PublishedPort:
+    """'[ip:]published[:target]' (protocol suffix stripped) -> PublishedPort."""
+    value = _clean(raw).split('/', 1)[0]
+    parts = value.split(':')
+    if len(parts) == 3:
+        host_ip, published, target = parts
+    elif len(parts) == 2:
+        host_ip, published, target = '', parts[0], parts[1]
+    else:
+        host_ip, published, target = '', '', parts[0]
+    return PublishedPort(service, host_ip, published, target, raw.strip())
+
+
+def _from_long_form(service: str, fields: dict[str, str]) -> PublishedPort:
+    return PublishedPort(
+        service,
+        fields.get('host_ip', ''),
+        fields.get('published', ''),
+        fields.get('target', ''),
+        str(fields),
+    )
+
+
+def _parse_inline_mapping(item: str) -> dict[str, str]:
+    body = item.strip().lstrip('{').rstrip('}')
+    fields: dict[str, str] = {}
+    for pair in body.split(','):
+        if ':' in pair:
+            key, _, val = pair.partition(':')
+            fields[key.strip()] = _clean(val)
+    return fields
+
+
+def _published_ports() -> list[PublishedPort]:
+    """Every published port in the deploy compose (short-form or long-form).
+
+    Hand-parsed with the stdlib only, matching the other pure-stdlib contract
+    gates: walk the indentation services: -> <service>: -> ports: and collect
+    each list item, normalising the "ip:host:container" short form, the inline
+    ``{host_ip, published, target}`` flow map, and the block long form.
+    """
+    lines = DEPLOY_COMPOSE.read_text(encoding='utf-8').splitlines()
+    ports: list[PublishedPort] = []
+
+    in_services = False
+    service = ''
+    service_indent = -1
+    in_ports = False
+    ports_indent = -1
+    block: dict[str, str] | None = None
+
+    def flush() -> None:
+        nonlocal block
+        if block is not None:
+            ports.append(_from_long_form(service, block))
+            block = None
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        indent = _indent(line)
+
+        if indent == 0:
+            flush()
+            in_services = stripped == 'services:'
+            service, in_ports = '', False
+            continue
+        if not in_services:
+            continue
+
+        # Inside a ports: list?
+        if in_ports and indent > ports_indent:
+            if stripped.startswith('- '):
+                flush()
+                item = stripped[2:].strip()
+                if item.startswith('{'):
+                    ports.append(_from_long_form(service, _parse_inline_mapping(item)))
+                elif item.split(':', 1)[0].strip() in LONG_FORM_KEYS and ':' in item:
+                    block = {}
+                    key, _, val = item.partition(':')
+                    if _clean(val):
+                        block[key.strip()] = _clean(val)
+                else:
+                    ports.append(_from_short_form(service, item))
+            elif block is not None:  # continuation of a block long-form entry
+                key, _, val = stripped.partition(':')
+                block[key.strip()] = _clean(val)
+            continue
+
+        # Not (or no longer) inside a ports list.
+        flush()
+        in_ports = False
+
+        if service == '' or indent <= service_indent:
+            if stripped.endswith(':'):
+                service = stripped[:-1]
+                service_indent = indent
+            continue
+        if stripped == 'ports:':
+            in_ports = True
+            ports_indent = indent
+
+    flush()
+    return ports
 
 
 def test_all_published_ports_bind_loopback() -> None:
-    # A published port with fewer than three colon-separated parts
-    # (i.e. "HOST:CONTAINER" or bare "CONTAINER") binds every interface.
-    # Loopback binding requires the explicit "127.0.0.1:HOST:CONTAINER" form.
-    exposed = [
-        f'{service}: {mapping}'
-        for service, mapping in _published_ports()
-        if not mapping.startswith(f'{LOOPBACK}:')
-    ]
+    exposed = [f'{p.service}: {p.raw}' for p in _published_ports() if p.host_ip != LOOPBACK]
     assert exposed == []
 
 
 def test_dagit_bound_to_loopback() -> None:
-    dagit_ports = [mapping for service, mapping in _published_ports() if service == 'dagit']
-    assert dagit_ports == [f'{LOOPBACK}:4000:3000']
+    dagit = [p for p in _published_ports() if p.service == 'dagit']
+    assert len(dagit) == 1
+    assert (dagit[0].host_ip, dagit[0].published, dagit[0].target) == (LOOPBACK, '4000', '3000')


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

E1 of tracker #275 (security P0). The deploy dagit webserver was published on `0.0.0.0:4000` since 2026-04-21 — no auth, externally verified reachable with full GraphQL mutation access (launch/terminate/delete runs, wipe assets, stop schedules). This binds it to `127.0.0.1:4000:3000`, matching how ClickHouse is already bound in the same file; operator access moves to an SSH tunnel (`ssh -L 4000:localhost:4000 root@37.27.112.167`, or `LocalForward 4000 localhost:4000` in `~/.ssh/config`). A new `tests/tools/test_deploy_compose_bind.py` (added to `pr_checks_ruleset`) fails any deploy-compose published port not bound to `127.0.0.1`, so nothing can silently re-expose a service. Version 3.0.1 → 3.0.2.

The live exposure was already closed out-of-band ahead of this PR (dagit container stopped — pipeline unaffected, daemon independent); this PR makes the fix durable, and the deploy restarts dagit loopback-bound.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable) — `pytest tests/tools -q`: 36 passed; `ruff check tools tests/tools`: clean
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
