### PR TITLE
ci: sync main ruleset snapshot with GitHub-added dismissal_restriction field

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -25,6 +25,10 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.0.2 on July 6, 2026
+- CI: sync the checked-in main ruleset snapshot with the `dismissal_restriction` field GitHub now returns on the live pull_request rule (disabled/default value; effective branch protection unchanged), unblocking the law-9 ruleset-drift gate.
+
 # v3.0.1 on July 4, 2026
 - Adopt the Origo identity in CI and deploy: repo renamed to Vaquum/Origo, deploy workflow variables `TDW_*` -> `ORIGO_*` (values unchanged; server names intentionally stay tdw), fresh `ORIGO_PRIVATE_KEY` deploy key, GHCR images `origo-dagster`/`origo-clickhouse` (legacy packages retained for rollback), slice-gate help text and ruleset fixtures updated.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "3.0.1"
+version = "3.0.2"
 description = "Origo control plane"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/github/ruleset_live_target.json
+++ b/tests/fixtures/github/ruleset_live_target.json
@@ -28,6 +28,10 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": [

--- a/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
+++ b/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
@@ -27,6 +27,10 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": [

--- a/tests/fixtures/github/ruleset_live_unexpected_field.json
+++ b/tests/fixtures/github/ruleset_live_unexpected_field.json
@@ -28,6 +28,10 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": [

--- a/tests/fixtures/github/ruleset_live_with_bypass_actor.json
+++ b/tests/fixtures/github/ruleset_live_with_bypass_actor.json
@@ -34,6 +34,10 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": [


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Syncs `.github/rulesets/main.json` with the `dismissal_restriction` field GitHub now returns on the live `pull_request` rule of ruleset `5406599`. The field is disabled/default (`{enabled: false, allowed_actors: []}`) — a faithful capture of GitHub's enriched API response, **not** a branch-protection change. The snapshot predated the field, so the law-9 ruleset-drift gate (`pr_checks_ruleset`) was failing on every open PR (it blocked #277). Version 3.0.1 → 3.0.2.

Note surfaced separately (not in this PR): a second long-standing active ruleset `12529363` ("Protect-Main", created 2026-02, no required_status_checks) coexists with `5406599`; additive, pre-existing, flagged for cleanup on tracker #275.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable) — `ruleset_gate.py` against live 5406599: `RULESET GATE -- PASS`
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
