### PR TITLE
docs(origo): add MIT license and rewrite README to the Vaquum module spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.3.1 on July 21, 2026
+- Add the MIT license (verbatim from Vaquum/Limen) as a root LICENSE file plus `[project]` license metadata in pyproject.toml, and rewrite README.md to the shared Vaquum module README structure: honest capability inventory backed by code on `main`, a docker-compose quickstart (table creation, one-day spot backfill, query-module read-back), and the standard boilerplate tail.
+
 # v3.3.0 on July 10, 2026
 - Make the daily spot/futures partition write atomic: the full-day row insert (millions of rows over minutes — the window a killed run left a partial day in) now builds and count-verifies a per-day staging table before the live table is touched, then promotes it with a synchronous day DELETE followed by an atomic `MOVE PARTITION` (metadata part-move, not a splittable INSERT..SELECT that can commit a partial day on cancellation). MOVE appends the day into the live month partition, preserving the month's other days. The only residual window (between DELETE and MOVE) leaves the day MISSING, never partial or duplicated, which the daily gap-repair schedule then heals (tracker #275 item 4). Unblocks run-level retries (item 21).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Vaquum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,143 @@
-<h1 align="center">
-  <br>
-  <a href="https://github.com/Vaquum"><img src="https://github.com/Vaquum/Home/raw/main/assets/Logo.png" alt="Vaquum" width="150"></a>
-  <br>
-</h1>
+<div align="center">
+  <br />
+  <a href="https://github.com/Vaquum"><img src="https://github.com/Vaquum/Home/raw/main/assets/Logo.png" alt="Vaquum" width="150" /></a>
+  <br />
+</div>
+<br />
+<div align="center"><b>Vaquum Origo turns raw Binance market archives into checksum-verified trade tables, rebuildable bar projections, and replayable research datasets.</b></div>
 
-<h3 align="center">Origo</h3>
+<div align="center">
+  <a href="#origo">Origo</a> •
+  <a href="#what-origo-is-not">What Origo Is Not</a> •
+  <a href="#capabilities">Capabilities</a> •
+  <a href="#first-backfill">First Backfill</a> •
+  <a href="#learn-more">Learn More</a>
+</div>
+<br />
+<div align="center">
+  <a href="https://docs.vaquum.fi/origo/"><img src="https://img.shields.io/badge/docs-origo-blue" alt="Origo docs" /></a>
+  <a href="https://github.com/Vaquum/Origo/actions/workflows/pr_checks_tests.yml"><img src="https://github.com/Vaquum/Origo/actions/workflows/pr_checks_tests.yml/badge.svg" alt="PR tests" /></a>
+  <a href="https://github.com/Vaquum/Origo/actions/workflows/deploy_on_merge.yml"><img src="https://github.com/Vaquum/Origo/actions/workflows/deploy_on_merge.yml/badge.svg" alt="Deploy on merge" /></a>
+  <a href="https://github.com/Vaquum/Origo/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license" /></a>
+</div>
 
-<p align="center">
-  <a href="#description">Description</a> •
-  <a href="#owner">Owner</a> •
-  <a href="#integrations">Integrations</a> •
-  <a href="#docs">Docs</a>
-</p>
-<hr>
+<hr />
 
-## Description
+<a id="origo"></a>
 
-Control plane for the Origo data platform.
+# Origo — Data layer
 
-## Owner
+*Event-sourced Bitcoin market data platform that turns raw Binance archives into checksum-verified trade tables, rebuildable bar projections, and replayable research datasets.*
 
-- [@mikkokotila](https://github.com/mikkokotila)
+Origo ingests Binance BTCUSDT market data into ClickHouse under Dagster orchestration, records every ingested source file in a checksum ledger, and rebuilds every derived table deterministically from that raw record. The Dagster deployment in this repository is Origo's control plane — the term names that orchestration component, not the project. The project evolves from tdw-control-plane, this repository's original identity.
 
-## Integrations
+## What Origo Is Not
 
-- https://github.com/Vaquum/tdw-docker
+Origo is not:
 
-## Docs
+- a trade execution system
+- a signal research or backtesting engine
+- a multi-exchange market data vendor
 
-`main` deploys the repo-defined production services automatically through GitHub Actions.
-The workflow builds the Dagster and ClickHouse images, pushes them to GitHub Container
-Registry, and deploys `clickhouse`, `dagster`, and `dagit` to the remote host over SSH
-with runtime secrets injected from GitHub repo secrets.
+In the wider Vaquum architecture, Origo sits upstream as the data layer. Limen consumes its outputs downstream as the research engine, and Nexus, Praxis, and Veritas sit further downstream for decisioning, execution, and oversight.
+
+## Capabilities
+
+- Checksum-verified ingestion of Binance BTCUSDT daily trade archives, spot (from 2017-08-17) and USDT-M futures (from 2019-09-08)
+- Ingestion ledgers recording source file, SHA-256 checksums, row counts, Dagster run id, and status for every loaded day
+- Atomic daily partition writes through a count-verified staging table promoted with `MOVE PARTITION`
+- Rebuildable projections from the raw trade record: 1-minute klines plus dollar, volume, tick, and dollar-imbalance bars
+- Aligned 1-minute table refreshed from both the spot and futures markets
+- Rolling `_latest` tables refreshed every minute to cover the span between the last daily load and the latest closed minute
+- Binance spot order-book depth snapshots (20- and 200-level) with 1-minute projections and per-minute reconciliation
+- Hourly ledger-driven gap repair for the spot and futures daily pipelines
+- Hugging Face publishing of twelve kline datasets: six time intervals and six dollar-bar sizes
+- Local monthly Parquet mirror of the twelve kline series, refreshed every minute, with a versioned mmap-ready Arrow bar store rebuilt from it
+- Ratcheted CI gates on every PR: strict pyright typing, fail-loud (no silent fallbacks), Conventional Commits, and version plus CHANGELOG trails
+- Automatic production deploy of merged `main` through GitHub Actions
+
+## First Backfill
+
+The first runnable path is the local Docker Compose stack: create the ClickHouse tables, backfill one day of the spot pipeline, and read it back through the query module.
+
+1. Clone the repository and set the one required secret:
+
+```bash
+git clone https://github.com/Vaquum/Origo.git
+cd Origo
+export CLICKHOUSE_PASSWORD=<choose-a-password>
+```
+
+Supported runtime: the containers run Python 3.11 (`python:3.11.12`) and the package requires Python `>=3.11`; the host needs Docker with Compose. `CLICKHOUSE_PASSWORD` is the only variable without a default — `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, and `CLICKHOUSE_DATABASE` default to the in-network values (`clickhouse`, `9000` native / `8123` HTTP, `default`, `origo`). `HF_TOKEN` and `HUGGINGFACE_DATASET_REPO_ID` are needed only for Hugging Face publishing, and the `BINANCE_SPOT_DEPTH20_*` / `BINANCE_SPOT_DEPTH200_*` pairs only for the live depth collectors; `docker-compose.deploy.yml` requires them all, the local `docker-compose.yml` does not. The local compose file passes `CLICKHOUSE_PASSWORD` only to the ClickHouse server, so the commands below inject it into the Dagster container with `-e`.
+
+1. Start the stack:
+
+```bash
+docker compose up -d --build
+```
+
+1. Create the database and tables:
+
+```bash
+docker compose exec -e CLICKHOUSE_PASSWORD dagster \
+  dagster asset materialize -m origo.definitions \
+  --select "create_origo_database,create_binance_daily_spot_trades_table_origo,create_binance_spot_klines_table_origo,create_binance_spot_dollar_klines_table_origo,create_binance_spot_volume_klines_table_origo,create_binance_spot_tick_klines_table_origo,create_binance_spot_dollar_imbalance_klines_table_origo,create_aligned_1m_exchange_table_origo,create_binance_spot_latest_tables_origo"
+```
+
+1. Backfill one day of the spot pipeline — raw trades, every bar projection, and the aligned table:
+
+```bash
+docker compose exec -e CLICKHOUSE_PASSWORD dagster \
+  dagster job backfill -j refresh_binance_spot_data_source_job \
+  --partitions 2024-01-02 --noprompt
+```
+
+1. Read the day back through the query module:
+
+```bash
+docker compose exec -e CLICKHOUSE_PASSWORD dagster python -c "
+from origo.query.binance_spot_kline_rollups import dollar_month, time_month
+print(time_month(interval_minutes=60, year=2024, month=1))
+print(dollar_month(ratio=15, year=2024, month=1))
+"
+```
+
+`time_month` rolls the 1-minute projection up to any minute interval, and `dollar_month` rolls the 1M-dollar bar base up by an integer ratio. Beyond the quickstart, every job, schedule, and sensor is defined in `origo/definitions.py` and can be launched from the Dagster UI at `http://localhost:4000`.
+
+## Risk Boundary
+
+Origo is research software. Data outputs are not investment advice, trading advice, execution simulation, regulatory approval, or a promise of future performance. Past performance is not predictive, and trading digital assets can result in total loss of capital.
+
+## Learn more
+
+- Start with the full [documentation hub](https://docs.vaquum.fi/origo/overview/docs-hub)
+- See [What is Origo](https://docs.vaquum.fi/origo/overview/what-is-origo), [Product Boundaries](https://docs.vaquum.fi/origo/overview/product-boundaries), and [System Architecture](https://docs.vaquum.fi/origo/overview/system-architecture) for scope and shape
+- Use [Get Started Locally](https://docs.vaquum.fi/origo/guides/get-started-locally) for the local stack
+- Run [your first native query](https://docs.vaquum.fi/origo/guides/run-your-first-native-query) and [your first aligned query](https://docs.vaquum.fi/origo/guides/run-your-first-aligned-query) against the warehouse
+- Rebuild derived tables with [Rebuild Projections](https://docs.vaquum.fi/origo/guides/rebuild-projections) and check coverage with [Understand Historical Coverage](https://docs.vaquum.fi/origo/guides/understand-historical-coverage)
+- Export datasets with [Export Data](https://docs.vaquum.fi/origo/guides/export-data)
+- See the mechanical PR gates in [AGENTS.md](https://github.com/Vaquum/Origo/blob/main/AGENTS.md) and their implementations under [tools](https://github.com/Vaquum/Origo/tree/main/tools)
+- Follow the change record in [CHANGELOG.md](https://github.com/Vaquum/Origo/blob/main/CHANGELOG.md)
+- Contribute through [Contributing](https://docs.vaquum.fi/origo/developer/contributing) and the [Developer docs](https://docs.vaquum.fi/origo/developer)
+
+## Contributing
+
+Contribution starts through [AGENTS.md](https://github.com/Vaquum/Origo/blob/main/AGENTS.md), the [Contributing guide](https://docs.vaquum.fi/origo/developer/contributing), or [open issues](https://github.com/Vaquum/Origo/issues). Before contributing, start with the [Developer docs](https://docs.vaquum.fi/origo/developer).
+
+## Support
+
+Use [open issues](https://github.com/Vaquum/Origo/issues) for support requests and scope questions.
+
+## Vulnerabilities
+
+Report vulnerabilities privately to the repository owner, [@mikkokotila](https://github.com/mikkokotila). Do not report vulnerabilities through public issues.
+
+## Citations
+
+Published work should cite:
+
+Vaquum Origo [Computer software]. (2026). Retrieved from [GitHub](https://github.com/Vaquum/Origo).
+
+## License
+
+[MIT License](https://github.com/Vaquum/Origo/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 *Event-sourced Bitcoin market data platform that turns raw Binance archives into checksum-verified trade tables, rebuildable bar projections, and replayable research datasets.*
 
-Origo ingests Binance BTCUSDT market data into ClickHouse under Dagster orchestration, records every ingested source file in a checksum ledger, and rebuilds every derived table deterministically from that raw record. The Dagster deployment in this repository is Origo's control plane — the term names that orchestration component, not the project. The project evolves from tdw-control-plane, this repository's original identity.
+Origo ingests Binance BTCUSDT market data into ClickHouse under Dagster orchestration, records every ingested source file in a checksum ledger, and rebuilds every daily-partitioned projection deterministically from that raw record; the rolling `_latest` tables and live depth snapshots capture the span after the last daily load and sit outside that rebuild guarantee. The Dagster deployment in this repository is Origo's control plane — the term names that orchestration component, not the project. The project evolves from tdw-control-plane, this repository's original identity.
 
 ## What Origo Is Not
 
@@ -88,7 +88,8 @@ docker compose exec -e CLICKHOUSE_PASSWORD dagster \
 
 ```bash
 docker compose exec -e CLICKHOUSE_PASSWORD dagster \
-  dagster job backfill -j refresh_binance_spot_data_source_job \
+  dagster job backfill -m origo.definitions \
+  -j refresh_binance_spot_data_source_job \
   --partitions 2024-01-02 --noprompt
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "3.3.0"
+version = "3.3.1"
 description = "Origo control plane"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
   "dagster",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "origo"
 version = "3.3.1"
-description = "Origo control plane"
+description = "Event-sourced market data platform for deterministic, replayable financial data access"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Slice #293, from the site-repo honesty alignment audit of 2026-07-20. Two changes, no code touched:

**1. LICENSE.** Adds the MIT license verbatim from [Vaquum/Limen's LICENSE](https://github.com/Vaquum/Limen/blob/main/LICENSE) (`MIT License`, `Copyright (c) 2024 Vaquum`) at the repo root — the repository previously had no license at all. `[project]` gains `license = "MIT"` and `license-files = ["LICENSE"]` (PEP 639, the syntax Limen uses); an sdist build was verified locally to emit `License-Expression: MIT` / `License-File: LICENSE`.

**2. README rewrite.** Replaces the 34-line stub with the shared Vaquum module README structure (logo header, tagline, anchor nav, badges, Is-Not / Capabilities / quickstart / Risk Boundary / boilerplate tail), so Origo's README reads as one set with Limen's. Framing per the owner's decision: event-sourced market data platform for deterministic, replayable financial data access — "control plane" names only the Dagster orchestration component in this repo, not the project. Every claim is backed by code on `main`:

- Scope stated explicitly: Binance BTCUSDT, spot + USDT-M futures, ClickHouse + Dagster (`daily_trades_to_origo.py`, `daily_futures_trades_to_origo.py`).
- Capabilities limited to what exists: checksum-verified ingestion with ledgers (`_process_day`, `binance_daily_spot_trades_ingestion`), atomic staging-table day writes (v3.3.0), rebuildable 1m/dollar/volume/tick/imbalance projections, aligned 1-minute table, rolling `_latest` tables, depth20/200 snapshots with per-minute reconciliation, hourly gap repair, 12 Hugging Face datasets, Parquet mirror + Arrow bar store, CI gates, auto-deploy on merge (kept from the old README's Docs section).
- Quickstart commands verified against the code and CLI: `docker compose up`, table creation via `dagster asset materialize` (the create assets are `deps`-only, nothing auto-creates them), one-day backfill of `refresh_binance_spot_data_source_job`, then `time_month` / `dollar_month` exactly as defined in `origo/query/binance_spot_kline_rollups.py` (including the `-e CLICKHOUSE_PASSWORD` injection the local compose file makes necessary — the dev compose passes the password only to the `clickhouse` service).

Honesty deviations from the Limen skeleton, deliberate: no PyPI/OpenSSF badges (not on PyPI, no bestpractices.dev registration, no Scorecard data for this repo), no SECURITY.md/SUPPORT.md/CONTRIBUTING.md/CITATION.cff links (those files do not exist in this repo — Support routes to issues, Contributing to AGENTS.md + the docs site), and Vulnerabilities routes to the owner because GitHub private vulnerability reporting is currently disabled on this repository (flipping it on would let the section match Limen's wording). Docs links point at the live https://docs.vaquum.fi/origo/ pages.

Version 3.3.0 → 3.3.1 (docs → patch), CHANGELOG entry at head. Local checks: `tools/version_gate.py` PASS, slice-gate rules 6-8 simulated PASS against #293, sdist metadata build PASS.

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran the project's test suite locally without errors (where applicable) — docs-only diff, no code touched; `tools/version_gate.py` PASS and sdist metadata build PASS locally, `tests/origo_source_native` left to CI
- [x] I updated any relevant documentation (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes) — n/a, no code changed
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added) — n/a, no code changed
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge when applicable

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
