### PR TITLE
chore(ci): record the pull_request ruleset field GitHub added to Protect-Main

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -25,6 +25,7 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "require_extra_approval_for_unattributed_changes": true,
         "dismissal_restriction": {
           "enabled": false,
           "allowed_actors": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.5.1 on August 20, 2026
+- Record `require_extra_approval_for_unattributed_changes` in the `Protect-Main` ruleset snapshot. GitHub added the field to the rulesets API, so the live ruleset began reporting it while `.github/rulesets/main.json` did not carry it, and `pr_checks_ruleset` failed every open PR on drift it had not caused. The snapshot now matches the live ruleset field for field, which is the only state in which that gate can tell a real out-of-band change from an API addition.
+
 # v3.5.0 on August 18, 2026
 - Publish the daily BTC briefing feed to HuggingFace on the daily cadence: `publish_btc_briefing_feed` becomes daily-partitioned and uploads each partition day's `btc_briefing/1` feed to the `vaquum/btc_briefing_feed` dataset as one JSON file per day plus a `latest.json` pointer and dataset card (reusing the existing `HF_TOKEN` credential; no new secret). A new `publish_btc_briefing_feed_sensor` fires after each daily spot klines materialization, so the first tick after deploy publishes the most recent complete UTC day and any past covered day is a manual partition launch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "origo"
-version = "3.5.0"
+version = "3.5.1"
 description = "Event-sourced market data platform for deterministic, replayable financial data access"
 readme = "README.md"
 license = "MIT"

--- a/tests/fixtures/github/ruleset_live_target.json
+++ b/tests/fixtures/github/ruleset_live_target.json
@@ -28,6 +28,7 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "require_extra_approval_for_unattributed_changes": true,
         "dismissal_restriction": {
           "enabled": false,
           "allowed_actors": []

--- a/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
+++ b/tests/fixtures/github/ruleset_live_target_without_bypass_actors.json
@@ -27,6 +27,7 @@
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
+        "require_extra_approval_for_unattributed_changes": true,
         "dismissal_restriction": {
           "enabled": false,
           "allowed_actors": []


### PR DESCRIPTION
Closes #302

Unblocks #301, and every other open PR.

### What happened

GitHub added `require_extra_approval_for_unattributed_changes` to the rulesets API. The live `Protect-Main` ruleset started reporting it; `.github/rulesets/main.json` predates it. `pr_checks_ruleset` compares the two field for field, so it began failing PRs on drift none of them caused.

This is not an out-of-band UI edit. Nothing about the protection changes — the value recorded is the one GitHub already enforces.

### Why the fixtures move too

`tests/tools/test_ruleset_gate.py` runs the gate against two fixtures that stand in for the live ruleset. Update the snapshot alone and those tests fail: they would model a live shape that no longer exists, and the gate would stop testing the thing it exists to test. Snapshot and fixtures have to move together.

### Verification

```
python3 tools/ruleset_gate.py --ruleset-file .github/rulesets/main.json \
  --repo Vaquum/Origo --ruleset-id 5406599
RULESET GATE -- PASS
```

The snapshot diff is a single inserted line — no reordering, no reformatting.

`tests/tools/test_ruleset_gate.py` passes. Two failures in `test_lint_ci_contract.py` reproduce identically on clean `main` and are a local ruff version skew (0.15.12 here vs the 0.15.11 CI pins), not this change.